### PR TITLE
docs: migration to new confluence konviw instance

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,10 +1,13 @@
+const package = require('../../package.json');
+
 module.exports = {
-  // title: 'konviw',
-  description: 'Enterprise public viewer for your Confluence pages.',
+  description: package.description,
+  version: package.version,
   base: '/konviw/', // when published to GitHub Pages
   // base: '/', // when rendered locally
   head: [['link', { rel: 'icon', href: '/konviw.png' }]],
   themeConfig: {
+    version: package.version,
     logo: '/konviw.svg',
     nav: [
       { text: 'Home', link: '/' },

--- a/docs/demoIntroduction.md
+++ b/docs/demoIntroduction.md
@@ -2,4 +2,4 @@
 title: Demo
 ---
 
-<ConfluencePage pageId='98321'/>
+<ConfluencePage pageId='32981'/>

--- a/docs/demoStyles.md
+++ b/docs/demoStyles.md
@@ -2,4 +2,4 @@
 title: Demo Styles
 ---
 
-<ConfluencePage pageId='163955'/>
+<ConfluencePage pageId='98444'/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,10 @@ features:
     details: Simplified REST API providing a read-only access to search pages and retrieve page content.
   - title: Create stunning Presentations on the Web
     details: Web slides deck directly from your Confluence pages. Thanks to the awesome job done by reveal.js
-
-footer: MIT licensed and made with 💚 Sanofi IADC
 ---
+
+---
+
+<p align="center">
+MIT licensed and made with 💚 Sanofi IADC • Version {{ $themeConfig.version }}
+</p>


### PR DESCRIPTION
* new demo docs pointing to new confluence instance konviw
* package.json used in vuepress docs to show release