### PR TITLE
fix: import compliant with esModuleInterop true

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,4 +1,4 @@
-import * as packageJson from '../../package.json';
+import packageJson from '../../package.json';
 import Config from '../config/config.d';
 
 export default (): Config => ({

--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import * as cheerio from 'cheerio';
+import cheerio from 'cheerio';
 import { performance, PerformanceObserver } from 'perf_hooks';
 
 @Injectable()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import * as path from 'path';
+import path from 'path';
 import { AppModule } from './app.module';
-import * as sassMiddleware from 'node-sass-middleware';
+import sassMiddleware from 'node-sass-middleware';
 
 async function bootstrap() {
   const logger = new Logger('bootstrap');

--- a/src/proxy-page/steps/toc/TocListRenderingStrategy.ts
+++ b/src/proxy-page/steps/toc/TocListRenderingStrategy.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio';
+import cheerio from 'cheerio';
 import TocRenderingStrategy from './TocRenderingStrategy';
 import Toc from './Toc';
 import TocSection from './TocSection';


### PR DESCRIPTION
Fix side effect introduced by the configuration change in tsconfig.json [test: add basic e2e setup](https://github.com/Sanofi-IADC/konviw/commit/4d98ac1aaa6508e6469364db56967b769d868666) so moving the imports from `import * as sassMiddleware from 'node-sass-middleware'` to `import sassMiddleware from 'node-sass-middleware'`.