### PR TITLE
feat: add http exception filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "confluence-cms-api",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,25 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const { statusCode, message, error } = JSON.parse(
+      JSON.stringify(exception.getResponse()),
+    );
+
+    response.status(statusCode).json({
+      statusCode,
+      message,
+      error,
+      docs: 'https://sanofi-iadc.github.io/konviw/',
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import path from 'path';
 import { AppModule } from './app.module';
 import sassMiddleware from 'node-sass-middleware';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
   const logger = new Logger('bootstrap');
@@ -24,6 +25,8 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   app.setGlobalPrefix('cpv');
   app.disable('x-powered-by');


### PR DESCRIPTION
[Link to the NestJs doc of exception filters](https://docs.nestjs.com/exception-filters#exception-filters-1)
The filter is applied globally and catch every http error. It adds a link to the Konviw documentation in the json response.