### PR TITLE
fix(fixLinks): remove links from user mentions

### DIFF
--- a/src/proxy-page/steps/fixLinks.ts
+++ b/src/proxy-page/steps/fixLinks.ts
@@ -59,6 +59,13 @@ export default (config: ConfigService): Step => {
       replaceAttributeLink('src', link);
     });
 
+    // Remove links from user mentions
+    $('a.confluence-userlink.user-mention').each(
+      (_index: number, link: CheerioElement) => {
+        delete link.attribs.href;
+      },
+    );
+
     // We have improved this code by parsing links and images with Cheerio
     // and replace them instead of doing a big regex on the whole HTML page.
     // Because it may break some real texts containing "/wiki" that we don't want to replace.


### PR DESCRIPTION
Quick and simple fix
I don't find a way to replace easily the whole tag within an _em_ or _span_ tag, so I think it's enough for the moment