### PR TITLE
fix(ExceptionFilter): use the right error properties from the exception

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -11,12 +11,12 @@ export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
-    const { statusCode, message, error } = JSON.parse(
-      JSON.stringify(exception.getResponse()),
-    );
+    const message = exception.message;
+    const status = exception.getStatus();
+    const error = exception.name;
 
-    response.status(statusCode).json({
-      statusCode,
+    response.status(status).json({
+      status,
       message,
       error,
       docs: 'https://sanofi-iadc.github.io/konviw/',


### PR DESCRIPTION
using the error properties from the parse response may throw unexpected errors with Axios