### PR TITLE
fix(drawio): diagrams not working in include pages

### DIFF
--- a/src/proxy-page/steps/fixDrawio.ts
+++ b/src/proxy-page/steps/fixDrawio.ts
@@ -27,8 +27,7 @@ export default (config: ConfigService): Step => {
             //   )}" alt="${foundBlock[0]}" /></figure>`,
             // );
             $(element).prepend(
-              `<figure>
-                <img class="img-zoomable" 
+              `<figure><img class="img-zoomable" 
                   src="${webBasePath}/wiki/download/attachments/${foundBlock[0].replace(
                 /pageId=s*([^|]*)|diagramDisplayName=s*([^|]*)/g,
                 '$1',
@@ -36,8 +35,7 @@ export default (config: ConfigService): Step => {
                 /pageId=s*([^|]*)|diagramDisplayName=s*([^|]*)/g,
                 '$2.png',
               )}" 
-                  alt="${foundBlock[1]}" />
-              </figure>`,
+                  alt="${foundBlock[1]}" /></figure>`,
             );
           }
         }

--- a/src/proxy-page/steps/fixDrawio.ts
+++ b/src/proxy-page/steps/fixDrawio.ts
@@ -15,13 +15,29 @@ export default (config: ConfigService): Step => {
         const thisBlock = $(element).html();
         if (thisBlock) {
           // Finding a block with the pattern diagramDisplayName=<name-file> is enought the determine the name of the file
-          const foundBlock = thisBlock.match(/diagramDisplayName=s*([^|]*)/g);
+          // const foundBlock = thisBlock.match(/diagramDisplayName=s*([^|]*)/g);
+          const foundBlock = thisBlock.match(
+            /pageId=s*([^|]*)|diagramDisplayName=s*([^|]*)/g,
+          );
           if (foundBlock) {
+            // $(element).prepend(
+            //   `<figure><img class="img-zoomable" src="${webBasePath}/wiki/download/attachments/${context.getPageId()}/${foundBlock[0].replace(
+            //     /diagramDisplayName=s*([^|]*)/g,
+            //     '$1.png',
+            //   )}" alt="${foundBlock[0]}" /></figure>`,
+            // );
             $(element).prepend(
-              `<figure><img class="img-zoomable" src="${webBasePath}/wiki/download/attachments/${context.getPageId()}/${foundBlock[0].replace(
-                /diagramDisplayName=s*([^|]*)/g,
-                '$1.png',
-              )}" alt="${foundBlock[0]}" /></figure>`,
+              `<figure>
+                <img class="img-zoomable" 
+                  src="${webBasePath}/wiki/download/attachments/${foundBlock[0].replace(
+                /pageId=s*([^|]*)|diagramDisplayName=s*([^|]*)/g,
+                '$1',
+              )}/${foundBlock[1].replace(
+                /pageId=s*([^|]*)|diagramDisplayName=s*([^|]*)/g,
+                '$2.png',
+              )}" 
+                  alt="${foundBlock[1]}" />
+              </figure>`,
             );
           }
         }

--- a/tests/unit/steps/fixDrawio.spec.ts
+++ b/tests/unit/steps/fixDrawio.spec.ts
@@ -15,7 +15,7 @@ const example =
   `<script>document.addEventListener('DOMContentLoaded', function () {new Zooming({}).listen('.img-zoomable');new Zooming({}).listen('.confluence-embedded-image')})</script><script>var coll = document.getElementsByClassName("expand-control");        var i;        for (i = 0; i < coll.length; i++) {          coll[i].addEventListener("click", function() {            this.classList.toggle("active");            var content = this.nextElementSibling;            if (content.style.display === "block") {              content.style.display = "none";            } else {              content.style.display = "block";            }          });        }</script></div>` +
   `</body></html>`;
 
-const image0 = `<img class="img-zoomable" src="/cpv/wiki/download/attachments/123456/Test Styles Content Confluence.drawio.png" alt="diagramDisplayName=Test Styles Content Confluence.drawio">`;
+const image0 = `<img class="img-zoomable" src="/cpv/wiki/download/attachments/473006389/Test Styles Content Confluence.drawio.png" alt="diagramDisplayName=Test Styles Content Confluence.drawio">`;
 const image1 = `<img class="img-zoomable" src="/cpv/wiki/download/attachments/123456/MS-Whispr-iObeya-Architecture-079f65948d008454029450fc73f0e032de29ca68.png" alt="diagramDisplayName=MS-Whispr-iObeya-Architecture">`;
 
 describe('ConfluenceProxy / fixDrawio', () => {


### PR DESCRIPTION
For diagrams in include pages we have to parse the drawio macro to get both pageId and attachment.

Draw.io diagrams from include pages are not correctly displayed in konviw because the attachment is not in the parent page but in the embedded page.

The fixDrawio.ts step is parsing the drawio macro to compose the URL of the PNG image that drawio automatically generates for each diagram. But the path of the URL is relative to the current page and not considering the fact that the diagram could come from another page.