### PR TITLE
fix(floating-toc): css problems + remove env variable

### DIFF
--- a/src/assets/scss/_floating-toc.scss
+++ b/src/assets/scss/_floating-toc.scss
@@ -50,7 +50,8 @@ button#floating-toc-btn {
 }
 
 /* The floating TOC */
-div.toc-macro.client-side-toc-macro.floating {
+/* The class konviw-float-TOC is provided by a macro in Confluence */
+div.toc-macro.client-side-toc-macro.konviw-float-TOC {
   position: fixed;
   top: calc(3rem);
   right: calc(
@@ -127,13 +128,13 @@ div.toc-macro.client-side-toc-macro.floating {
   button#floating-toc-btn {
     right: calc(var(--fab-btn-right) + 10px);
   }
-  div.toc-macro.client-side-toc-macro {
+  div.toc-macro.client-side-toc-macro.konviw-float-TOC {
     right: calc(var(--fab-btn-right) + 10px);
   }
 }
 /* Small laptot and tablets */
 @media screen and (max-width: 1024px) {
-  div.toc-macro.client-side-toc-macro {
+  div.toc-macro.client-side-toc-macro.konviw-float-TOC {
     &.active {
       width: 40vw;
       height: 60vh;
@@ -142,7 +143,7 @@ div.toc-macro.client-side-toc-macro.floating {
 }
 /* Mobiles */
 @media screen and (max-width: 425px) {
-  div.toc-macro.client-side-toc-macro {
+  div.toc-macro.client-side-toc-macro.konviw-float-TOC {
     &.active {
       width: 80vw;
       height: 80vh;

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -81,7 +81,7 @@ export class ProxyPageService {
     fixHtmlHead(this.config)(this.context);
     fixContentWidth()(this.context);
     fixLinks(this.config)(this.context);
-    fixToc(this.config)(this.context);
+    fixToc()(this.context);
     fixEmojis()(this.context);
     fixDrawio(this.config)(this.context);
     fixExpander()(this.context);

--- a/src/proxy-page/steps/fixToc.ts
+++ b/src/proxy-page/steps/fixToc.ts
@@ -1,62 +1,19 @@
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import TocBuilder from './toc/TocBuilder';
-import Config from '../../config/config';
-import { ConfigService } from '@nestjs/config';
+import { selectOne } from 'css-select';
 
-export default (config: ConfigService): Step => {
+export default (): Step => {
   return (context: ContextService): void => {
     const $ = context.getCheerioBody();
 
-    if (config.get<Config>('appearance.showFloatingToc')) {
-      // Add the button to open the floating TOC
-      $('#Content').append(
-        `<button id='floating-toc-btn'>
-        <svg style='width:24px;height:24px' viewBox='0 0 24 24'>
-          <path fill='currentColor' d='M3,9H17V7H3V9M3,13H17V11H3V13M3,17H17V15H3V17M19,17H21V15H19V17M19,7V9H21V7H19M19,13H21V11H19V13Z' />
-        </svg>
-      </button>`,
-      );
-      $('div.toc-macro.client-side-toc-macro').addClass('floating');
-      // Script used to manipulate the floating TOC with the user's intercations
-      $('body').append(`
-      <script lang='js'>
-        const floatingTocBtn = document.getElementById('floating-toc-btn');
-        const floatingToc = document.querySelector('div.toc-macro.client-side-toc-macro');
-        const floatingTocLinks = floatingToc.querySelectorAll('a.toc-link');
-        
-        const activeFloatingToc = () => {
-          floatingTocBtn.classList.add('active');
-          floatingToc.classList.add('active');
-        }
-        const desactiveFloatingToc = () => {
-          floatingTocBtn.classList.remove('active');
-          floatingToc.classList.remove('active');
-        }
-        const toggleFloatingToc = () => {
-          if (floatingTocBtn.classList.contains('active')) {
-            desactiveFloatingToc();
-          } else {
-            activeFloatingToc();
-          }
-        }
-        /* Open and close the floating TOC when click the button */
-        floatingTocBtn.addEventListener('click', () => {
-          toggleFloatingToc();
-        });
-        /* Close the floating TOC when click outside */
-        document.addEventListener('mouseup', (e) => {
-          if (!floatingTocBtn.contains(e.target) &&!floatingToc.contains(e.target)) {
-            desactiveFloatingToc();
-          }
-        });
-        /* Close the floating TOC when click on a TOC link */
-        floatingTocLinks.forEach(tocLink => {
-          tocLink.addEventListener('click', () => {
-            desactiveFloatingToc();
-          })
-        });
-      </script>`);
+    // If the class konviw-float-menu is present, add the floating TOC btn
+    const floatTocExists = !!selectOne(
+      '.konviw-float-TOC',
+      $('#Content').get(),
+    );
+    if (floatTocExists) {
+      addFloatingTocBtn($);
     }
 
     $('div.client-side-toc-macro').each(
@@ -91,4 +48,56 @@ export default (config: ConfigService): Step => {
       },
     );
   };
+};
+
+/**
+ *  Add the button to open the floating TOC.
+ *  Also add some javascript to manipulate the floating TOC.
+ */
+const addFloatingTocBtn = ($: CheerioStatic) => {
+  $('#Content').append(
+    `<button id='floating-toc-btn'>
+        <svg style='width:24px;height:24px' viewBox='0 0 24 24'>
+          <path fill='currentColor' d='M3,9H17V7H3V9M3,13H17V11H3V13M3,17H17V15H3V17M19,17H21V15H19V17M19,7V9H21V7H19M19,13H21V11H19V13Z' />
+        </svg>
+      </button>`,
+  );
+  // Script used to manipulate the floating TOC with the user's intercations
+  $('body').append(`
+      <script lang='js'>
+        const floatingTocBtn = document.getElementById('floating-toc-btn');
+        const floatingToc = document.querySelector('div.toc-macro.client-side-toc-macro');
+        const floatingTocLinks = floatingToc.querySelectorAll('a.toc-link');
+        const activeFloatingToc = () => {
+          floatingTocBtn.classList.add('active');
+          floatingToc.classList.add('active');
+        }
+        const desactiveFloatingToc = () => {
+          floatingTocBtn.classList.remove('active');
+          floatingToc.classList.remove('active');
+        }
+        const toggleFloatingToc = () => {
+          if (floatingTocBtn.classList.contains('active')) {
+            desactiveFloatingToc();
+          } else {
+            activeFloatingToc();
+          }
+        }
+        /* Open and close the floating TOC when click the button */
+        floatingTocBtn.addEventListener('click', () => {
+          toggleFloatingToc();
+        });
+        /* Close the floating TOC when click outside */
+        document.addEventListener('mouseup', (e) => {
+          if (!floatingTocBtn.contains(e.target) &&!floatingToc.contains(e.target)) {
+            desactiveFloatingToc();
+          }
+        });
+        /* Close the floating TOC when click on a TOC link */
+        floatingTocLinks.forEach(tocLink => {
+          tocLink.addEventListener('click', () => {
+            desactiveFloatingToc();
+          })
+        });
+      </script>`);
 };

--- a/tests/unit/steps/fixToc.spec.ts
+++ b/tests/unit/steps/fixToc.spec.ts
@@ -1,7 +1,6 @@
 import fixToc from '../../../src/proxy-page/steps/fixToc';
 import { ContextService } from '../../../src/context/context.service';
 import { createModuleRefForStep } from './utils';
-import { ConfigService } from '@nestjs/config';
 import { Step } from '../../../src/proxy-page/proxy-page.step';
 
 const example =
@@ -22,14 +21,12 @@ const example =
 
 describe('ConfluenceProxy / fix TOC', () => {
   let context: ContextService;
-  let config: ConfigService;
   let step: Step;
 
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    config = moduleRef.get<ConfigService>(ConfigService);
-    step = fixToc(config);
+    step = fixToc();
 
     context.Init('XXX', '123456', 'dark');
     context.setHtmlBody(example);


### PR DESCRIPTION
- [x] floating TOC now displayed properly on all devices
- [x] remove env variable, use css class macro from confluence instead

@PiiXiieeS Can you give it a try on local before merging ?

NOTE: I used the class name `konviw-float-TOC` (I found it's more explicit), so maybe you need to change the macro on confluence