### PR TITLE
Bugfix: Error 400 and cache management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,7 @@ import CustomHttpCacheInterceptor from './cache/custom-http-cache.interceptor';
       useFactory: async (configService: ConfigService) => ({
         ttl: configService.get('cacheTTL'),
         max: configService.get('cacheMax'),
+        isGlobal: true,
       }),
       inject: [ConfigService],
     }),

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -20,10 +20,13 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const version = this.config.get('version');
     const basePath = this.config.get('web.basePath');
 
-    if (status === 404) {
-      response
-        .status(404)
-        .render('404', { basePath: basePath, version: version });
+    if (status === 404 || status === 400) {
+      response.status(status).render('404', {
+        basePath: basePath,
+        version: version,
+        error: status,
+        message: message,
+      });
     } else if (status === 403) {
       response
         .status(403)

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -29,9 +29,9 @@ export default (): Config => ({
   },
   cache: {
     cacheTTL:
-      (process.env.CACHE_TTL && parseInt(process.env.CACHE_TTL, 10)) || 86400,
+      (process.env.CACHE_TTL && parseInt(process.env.CACHE_TTL, 10)) || 60,
     cacheMax:
-      (process.env.CACHE_MAX && parseInt(process.env.CACHE_MAX, 10)) || 10,
+      (process.env.CACHE_MAX && parseInt(process.env.CACHE_MAX, 10)) || 100,
   },
   logging: {
     enableLoggerMiddleware: process.env.ENABLE_LOGGER_MIDDLEWARE === 'true',

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -44,7 +44,7 @@ export class ConfluenceService {
       this.logger.log(`Retrieving page ${pageId}`);
     } catch (err) {
       this.logger.log(err, 'error:getPage');
-      throw new HttpException(`error:getPage for page ${pageId} > ${err}`, 404);
+      throw new HttpException(`${err}\nPage ${pageId} Not Found`, 404);
     }
     // Check if the label defined in configuration for private pages is present in the metadata labels
     if (

--- a/src/views/404.hbs
+++ b/src/views/404.hbs
@@ -11,10 +11,11 @@
 
       <div class="center">
         <div class="page_404_bg" style="background-image: url({{ basePath }}/images/404.gif)">
-          <h1>404</h1>
+          <h1>{{ error }}</h1>
         </div>
         <div class="page_404_content">
-          <h2 class="message_error">Looks like you are lost</h3>
+          <h2 class="message_error">{{ message }}</h3>
+          {{!-- <h2 class="message_error">Looks like you are lost</h3> --}}
           <p>I'm afraid you've found a page that doesn't exist. Sorry about that.</p>
           <p>That can happen when you follow a link to something that has since been deleted.<br>Or the link was
             incorrect to begin with.</p>


### PR DESCRIPTION
* Handle 400 error properly, similar to 404
* Reduce the default cache parameters to TTL=60s and MAX=100