### PR TITLE
Feature: Types for the Confluence API calls and content processing

### DIFF
--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -180,16 +180,46 @@ export interface ContentMetadata {
 }
 
 export interface LabelsArray {
-  results: Labels[];
+  results: Label[];
   start: number; // int32
   limit: number; // int32
   size: number; // int32
   _links: GenericLinks;
 }
 
-export interface Labels {
+export interface Label {
   prefix: string;
   name: string;
   id: string;
   label: string;
+}
+
+export interface SearchResults {
+  results: ResultsContent[];
+  start: number;
+  limit: number;
+  size: number;
+  totalSize: number;
+  cqlQuery: string;
+  searchDuration: number;
+  _links: GenericLinks;
+}
+
+export interface ResultsContent {
+  content: Content;
+  title: string;
+  excerpt: string;
+  url: string;
+  resultGlobalContainer: ResultGlobalContainer;
+  breadcrumbs: any[];
+  entityType: string;
+  iconCssClass: string;
+  lastModified: string;
+  friendlyLastModified: string;
+  score: number;
+}
+
+export interface ResultGlobalContainer {
+  title: string;
+  displayUrl: string;
 }

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -7,7 +7,7 @@ import {
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { AxiosResponse } from 'axios';
-import { Content } from './confluence.interface';
+import { Content, SearchResults } from './confluence.interface';
 
 @Injectable()
 export class ConfluenceService {
@@ -32,7 +32,7 @@ export class ConfluenceService {
     try {
       this.logger.log(`Retrieving page ${pageId}`);
       results = await this.http
-        .get(`/wiki/rest/api/content/${pageId}`, {
+        .get<Content>(`/wiki/rest/api/content/${pageId}`, {
           params: {
             type: 'page',
             spaceKey,
@@ -103,7 +103,7 @@ export class ConfluenceService {
     query: string,
     maxResult = 999,
     cursorResults = '',
-  ): Promise<AxiosResponse> {
+  ): Promise<AxiosResponse<SearchResults>> {
     let uriSearch: string;
     let params: any = {};
     let cql: string;
@@ -134,7 +134,7 @@ export class ConfluenceService {
       };
     }
     try {
-      const results: AxiosResponse = await this.http
+      const results: AxiosResponse<SearchResults> = await this.http
         .get(uriSearch, { params })
         .toPromise();
       this.logger.log(
@@ -153,13 +153,13 @@ export class ConfluenceService {
    * @return Promise {any}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    */
-  async getAllPosts(spaceKey: string): Promise<AxiosResponse> {
+  async getAllPosts(spaceKey: string): Promise<AxiosResponse<SearchResults>> {
     let cpl = `(type=blogpost)`;
     cpl = `${cpl} AND (label!=draft) AND (label=published)`;
     cpl = `${cpl} AND (space=${spaceKey})`;
     try {
-      const results: AxiosResponse = await this.http
-        .get('/wiki/rest/api/search', {
+      const results: AxiosResponse<SearchResults> = await this.http
+        .get<SearchResults>('/wiki/rest/api/search', {
           params: {
             limit: 999,
             cql: cpl,

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -7,6 +7,7 @@ import {
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { AxiosResponse } from 'axios';
+import { Content } from './confluence.interface';
 
 @Injectable()
 export class ConfluenceService {
@@ -23,9 +24,13 @@ export class ConfluenceService {
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
    */
-  async getPage(spaceKey: string, pageId: string): Promise<AxiosResponse> {
-    let results: AxiosResponse<any>;
+  async getPage(
+    spaceKey: string,
+    pageId: string,
+  ): Promise<AxiosResponse<Content>> {
+    let results: AxiosResponse<Content>;
     try {
+      this.logger.log(`Retrieving page ${pageId}`);
       results = await this.http
         .get(`/wiki/rest/api/content/${pageId}`, {
           params: {
@@ -34,14 +39,15 @@ export class ConfluenceService {
             expand: [
               // fields to retrieve
               'body.view',
+              // TODO: FND-1104 Investigate why this properties is not retrieved via axios while it works in Postman
               'metadata.properties.content_appearance_published',
               'metadata.labels',
-              'version,history',
+              'version',
+              'history',
             ].join(','),
           },
         })
         .toPromise();
-      this.logger.log(`Retrieving page ${pageId}`);
     } catch (err) {
       this.logger.log(err, 'error:getPage');
       throw new HttpException(`${err}\nPage ${pageId} Not Found`, 404);

--- a/src/health/health-atlassian.service.ts
+++ b/src/health/health-atlassian.service.ts
@@ -21,7 +21,7 @@ export class ApiHealthService extends HealthIndicator {
   async apiCheck(): Promise<HealthIndicatorResult> {
     let isHealthy = true;
     try {
-      await this.confluence.getAllPosts('konviw');
+      await this.confluence.Search('konviw');
     } catch (error) {
       isHealthy = false;
     }

--- a/src/proxy-api/proxy-api.controller.ts
+++ b/src/proxy-api/proxy-api.controller.ts
@@ -9,6 +9,7 @@ import {
   GetSpacesQueryDTO,
 } from './proxy-api.validation.dto';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { KonviwResults } from './proxy-api.interface';
 @ApiTags('proxy-api')
 @Controller('api')
 export class ProxyApiController {
@@ -21,8 +22,14 @@ export class ProxyApiController {
    */
   @ApiOkResponse({ description: 'All blog posts from a given space key' })
   @Get('getAllPosts/:spaceKey')
-  async getAllPosts(@Param() params: PostsParamsDTO): Promise<any> {
-    return this.proxyApi.getAllPosts(params.spaceKey);
+  async getAllPosts(@Param() params: PostsParamsDTO): Promise<KonviwResults> {
+    return await this.proxyApi.getSearchResults(
+      params.spaceKey,
+      '',
+      'blogpost',
+      999,
+      '',
+    );
   }
 
   /**
@@ -34,10 +41,13 @@ export class ProxyApiController {
     description: 'All pages that matches the given search string',
   })
   @Get('search')
-  async getSearchResults(@Query() queries: SearchQueryDTO): Promise<any> {
+  async getSearchResults(
+    @Query() queries: SearchQueryDTO,
+  ): Promise<KonviwResults> {
     return this.proxyApi.getSearchResults(
       queries.spaceKey,
       queries.query,
+      queries.type,
       queries.maxResults,
       queries.cursorResults,
     );

--- a/src/proxy-api/proxy-api.controller.ts
+++ b/src/proxy-api/proxy-api.controller.ts
@@ -23,7 +23,7 @@ export class ProxyApiController {
   @ApiOkResponse({ description: 'All blog posts from a given space key' })
   @Get('getAllPosts/:spaceKey')
   async getAllPosts(@Param() params: PostsParamsDTO): Promise<KonviwResults> {
-    return await this.proxyApi.getSearchResults(
+    return this.proxyApi.getSearchResults(
       params.spaceKey,
       '',
       'blogpost',

--- a/src/proxy-api/proxy-api.interface.ts
+++ b/src/proxy-api/proxy-api.interface.ts
@@ -1,0 +1,38 @@
+type ContentType = 'page' | 'blogpost' | 'comment' | 'attachment';
+
+export interface KonviwContent {
+  docId: string;
+  title: string;
+  type: ContentType;
+  url: string;
+  createdAt: string;
+  createdBy: string;
+  createdByAvatar: string;
+  createdByEmail: string;
+  labels: KonviwLabel[];
+  imgblog: string;
+  summary: string;
+  space: string;
+  lastModified: string;
+  excerptBlog: string;
+  body: string;
+  readTime: number;
+}
+
+export interface KonviwLabel {
+  tag: string;
+}
+
+export interface KonviwResults {
+  meta: MetadataSearch;
+  results: KonviwContent[];
+}
+
+export interface MetadataSearch {
+  limit: number;
+  size: number;
+  totalSize: number;
+  query: string;
+  next: string;
+  prev: string;
+}

--- a/src/proxy-api/proxy-api.validation.dto.ts
+++ b/src/proxy-api/proxy-api.validation.dto.ts
@@ -22,20 +22,32 @@ export class SearchQueryDTO {
   @IsString()
   spaceKey: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
+    required: false,
     description: `The combination of words to search.`,
-    example: 'styles',
+    example: 'manifesto',
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   query: string;
 
   @ApiPropertyOptional({
     required: false,
-    description: `The combination of words to search.`,
-    example: '2',
+    description: `The type of page. Options are 'page' or 'blogpage'`,
+    example: 'blogpost',
   })
   @IsOptional()
+  @IsString()
+  type: string;
+
+  @ApiPropertyOptional({
+    required: false,
+    description: `The maximum number of results to retrieve`,
+    example: '20',
+  })
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
   maxResults: number;
 
   // This query param must encode all special characters, including: , / ? : @ & = + $ #
@@ -46,6 +58,7 @@ export class SearchQueryDTO {
     example: ' ',
   })
   @IsOptional()
+  @IsString()
   cursorResults: string;
 }
 

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -58,7 +58,6 @@ export class ProxyPageService {
     this.context.setEmail(data.history.createdBy.email);
     this.context.setAvatar(data.history.createdBy.profilePicture.path);
     this.context.setWhen(data.history.createdDate);
-    // TODO: FND-1104 Currently not working because this property is not retrieved
     if (
       data.metadata.properties['content-appearance-published']?.value ===
       'full-width'
@@ -70,8 +69,8 @@ export class ProxyPageService {
   }
 
   /**
-   * Function renderPage Service
-   *
+   * @function renderPage Service
+   * @description Render a Confluence page as read-only konviw document
    * @return Promise {string}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
@@ -129,6 +128,7 @@ export class ProxyPageService {
 
   /**
    * @function renderSlides Service
+   * @description Render a Confluence page as konviw slide deck
    * @return Promise {string}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
@@ -164,7 +164,7 @@ export class ProxyPageService {
   }
 
   /**
-   * getMediaCdnUrl Service
+   * @function getMediaCdnUrl Service
    * @return Promise string
    * @param uri {string} 'iadc' - URL of the media file to return
    */

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -32,6 +32,7 @@ import fixDrawioMacro from './steps/fixDrawio';
 import fixChartMacro from './steps/fixChart';
 import fixRoadmap from './steps/fixRoadmap';
 import fixFrameAllowFullscreen from './steps/fixFrameAllowFullscreen';
+import { Content } from '../confluence/confluence.interface';
 
 @Injectable()
 export class ProxyPageService {
@@ -48,19 +49,19 @@ export class ProxyPageService {
     pageId: string,
     theme: string,
     style: string,
-    results: any,
+    data: Content,
   ) {
     this.context.Init(spaceKey, pageId, theme, style);
-    this.context.setTitle(results.title);
-    this.context.setHtmlBody(results.body.view.value);
-    this.context.setAuthor(results.history.createdBy.displayName);
-    this.context.setEmail(results.history.createdBy.email);
-    this.context.setAvatar(results.history.createdBy.profilePicture.path);
-    this.context.setWhen(results.history.createdDate);
+    this.context.setTitle(data.title);
+    this.context.setHtmlBody(data.body.view.value);
+    this.context.setAuthor(data.history.createdBy.displayName);
+    this.context.setEmail(data.history.createdBy.email);
+    this.context.setAvatar(data.history.createdBy.profilePicture.path);
+    this.context.setWhen(data.history.createdDate);
+    // TODO: FND-1104 Currently not working because this property is not retrieved
     if (
-      results.metadata.properties['content-appearance-published'] &&
-      results.metadata.properties['content-appearance-published'].value ===
-        'full-width'
+      data.metadata.properties['content-appearance-published']?.value ===
+      'full-width'
     ) {
       this.context.setFullWidth(true);
     } else {


### PR DESCRIPTION
- getPage response typed with Content
- initContext data typed with Content
- New interfaces for konviw API responses
- getSearchResults typed
- getAllPosts removed as fully harmonised with getSearchResults so the endpoint is kept but using the same search function