### PR TITLE
fix: FND-1101 preload only metadata and fix thumbnail

### DIFF
--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -53,7 +53,6 @@ p.media-group {
 }
 
 .confluence-embedded-image {
-  /* override other styles to make responsive */
-  width: 70% !important;
-  height: auto !important;
+  width: 70%;
+  height: auto;
 }

--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -1,7 +1,7 @@
 // Video iframe ===================================
 video {
   padding: 10px;
-  width: 100%;
+  width: 70%;
   height: auto;
 }
 
@@ -50,4 +50,10 @@ img {
 p.media-group {
   padding: 0px;
   margin: 0px;
+}
+
+.confluence-embedded-image {
+  /* override other styles to make responsive */
+  width: 70% !important;
+  height: auto !important;
 }

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -174,3 +174,15 @@ ul.childpages-macro li {
     }
   }
 }
+
+video {
+  /* override other styles to make responsive */
+  width: 70%    !important;
+  height: auto   !important;
+}
+
+.confluence-embedded-image {
+  /* override other styles to make responsive */
+  width: 70%    !important;
+  height: auto   !important;
+}

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -173,15 +173,3 @@ ul.childpages-macro li {
     }
   }
 }
-
-video {
-  /* override other styles to make responsive */
-  width: 70% !important;
-  height: auto !important;
-}
-
-.confluence-embedded-image {
-  /* override other styles to make responsive */
-  width: 70% !important;
-  height: auto !important;
-}

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -30,7 +30,6 @@ html {
   font-weight: var(--main-font-weight);
 }
 
-
 h1.titlePage {
   color: var(--heading-color);
   font-size: var(--title-font-size);
@@ -177,12 +176,12 @@ ul.childpages-macro li {
 
 video {
   /* override other styles to make responsive */
-  width: 70%    !important;
-  height: auto   !important;
+  width: 70% !important;
+  height: auto !important;
 }
 
 .confluence-embedded-image {
   /* override other styles to make responsive */
-  width: 70%    !important;
-  height: auto   !important;
+  width: 70% !important;
+  height: auto !important;
 }

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -53,7 +53,6 @@ p.media-group {
 }
 
 .confluence-embedded-image {
-  /* override other styles to make responsive */
-  width: 70% !important;
-  height: auto !important;
+  width: 70%;
+  height: auto;
 }

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -1,7 +1,7 @@
 // Video iframe ===================================
 video {
   padding: 10px;
-  width: 100%;
+  width: 70%;
   height: auto;
 }
 
@@ -50,4 +50,10 @@ img {
 p.media-group {
   padding: 0px;
   margin: 0px;
+}
+
+.confluence-embedded-image {
+  /* override other styles to make responsive */
+  width: 70% !important;
+  height: auto !important;
 }

--- a/src/proxy-page/steps/fixVideo.ts
+++ b/src/proxy-page/steps/fixVideo.ts
@@ -40,7 +40,7 @@ export default (): Step => {
               ).attr('href')}#t=0.1"></video>`,
             )
             .append('<br />')
-            .append($(fileWrapper));
+            .append($(fileWrapper).addClass('smalltext'));
         }
       },
     );

--- a/src/proxy-page/steps/fixVideo.ts
+++ b/src/proxy-page/steps/fixVideo.ts
@@ -35,9 +35,9 @@ export default (): Step => {
           $(fileWrapper)
             .parent()
             .append(
-              `<video poster="${pathMedia}/${titleMedia}.jpg" controls><source src="${$(
+              `<video controls preload="metadata"><source src="${$(
                 fileWrapper,
-              ).attr('href')}" type="video/mp4"></video>`,
+              ).attr('href')}#t=0.1" type="video/mp4"></video>`,
             );
 
           // TODO: this section with decodeURI is buggy in some cases. Replace by RegEx

--- a/src/proxy-page/steps/fixVideo.ts
+++ b/src/proxy-page/steps/fixVideo.ts
@@ -28,7 +28,7 @@ export default (): Step => {
         );
         // Search for the path $1, title $2 and extension $3 (not used)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [, pathMedia, titleMedia, extMedia] =
+        const [, pathMedia] =
           searchMedia.exec($(fileWrapper).attr('href')) ?? [];
         if (pathMedia) {
           // Append the video tag with src to the attachment and an image as poster
@@ -37,19 +37,10 @@ export default (): Step => {
             .append(
               `<video controls preload="metadata"><source src="${$(
                 fileWrapper,
-              ).attr('href')}#t=0.1" type="video/mp4"></video>`,
-            );
-
-          // Append the name of the file as caption for the video
-          $(fileWrapper)
-            .parent()
-            .append(
-              `<br /><span class="smalltext">${decodeURI(
-                titleMedia,
-              )}.${extMedia}</span>`,
-            );
-
-          $(fileWrapper).remove();
+              ).attr('href')}#t=0.1"></video>`,
+            )
+            .append('<br />')
+            .append($(fileWrapper));
         }
       },
     );

--- a/src/proxy-page/steps/fixVideo.ts
+++ b/src/proxy-page/steps/fixVideo.ts
@@ -40,15 +40,14 @@ export default (): Step => {
               ).attr('href')}#t=0.1" type="video/mp4"></video>`,
             );
 
-          // TODO: this section with decodeURI is buggy in some cases. Replace by RegEx
           // Append the name of the file as caption for the video
-          // $(fileWrapper)
-          //   .parent()
-          //   .append(
-          //     `<span class="smalltext">${decodeURI(
-          //       titleMedia,
-          //     )}.${extMedia}</span>`,
-          //   );
+          $(fileWrapper)
+            .parent()
+            .append(
+              `<br /><span class="smalltext">${decodeURI(
+                titleMedia,
+              )}.${extMedia}</span>`,
+            );
 
           $(fileWrapper).remove();
         }

--- a/tests/unit/steps/fixVideo.spec.ts
+++ b/tests/unit/steps/fixVideo.spec.ts
@@ -4,9 +4,9 @@ import { createModuleRefForStep } from './utils';
 
 const expected =
   `<html><head></head><body><div id="Content"><span class="confluence-embedded-file-wrapper image-center-wrapper">` +
-  `<video poster="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.jpg" controls="">` +
-  `<source src="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1" type="video/mp4"></video>` +
-  // `<span class="smalltext">DMDG SAP metadata.mp4</span>` +
+  `<video controls="" preload="metadata">` +
+  `<source src="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1#t=0.1"></video>` +
+  `<br><a href="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1">DMDG SAP metadata.mp4</a>` +
   `</span></div></body></html>`;
 
 describe('ConfluenceProxy / add html5 video tag to visualize video attachment', () => {

--- a/tests/unit/steps/fixVideo.spec.ts
+++ b/tests/unit/steps/fixVideo.spec.ts
@@ -6,7 +6,7 @@ const expected =
   `<html><head></head><body><div id="Content"><span class="confluence-embedded-file-wrapper image-center-wrapper">` +
   `<video controls="" preload="metadata">` +
   `<source src="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1#t=0.1"></video>` +
-  `<br><a href="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1">DMDG SAP metadata.mp4</a>` +
+  `<br><a href="/cpv/wiki/download/attachments/473006389/DMDG%20SAP%20metadata.mp4?version=1" class="smalltext">DMDG SAP metadata.mp4</a>` +
   `</span></div></body></html>`;
 
 describe('ConfluenceProxy / add html5 video tag to visualize video attachment', () => {


### PR DESCRIPTION
- After testing `preload="none"`, `preload="metadata"` seems to be a better option to only preload meta datas, it also helps to generate the video preview (thumbnail).
- `poster="${pathMedia}/${titleMedia}.jpg"` is not working at all so has been removed
-  Added css to make confluence images and videos responsive
- Re-enabled caption for videos from file name, seems there is no bug

