### PR TITLE
Feature: render tables with colgroup

### DIFF
--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -105,7 +105,6 @@ export class ProxyPageService {
     fixExpander()(this.context);
     fixUserProfile()(this.context);
     fixVideo()(this.context);
-    fixTableColGroup()(this.context);
     fixEmptyLineIncludePage()(this.context);
     fixRoadmap(this.config)(this.context);
     fixCode()(this.context);
@@ -158,7 +157,7 @@ export class ProxyPageService {
     fixExpander()(this.context);
     fixUserProfile()(this.context);
     fixVideo()(this.context);
-    fixTableColGroup()(this.context);
+    // fixTableColGroup()(this.context);
     fixEmptyLineIncludePage()(this.context);
     fixRoadmap(this.config)(this.context);
     fixFrameAllowFullscreen()(this.context);

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -12,7 +12,6 @@ import fixHtmlHead from './steps/fixHtmlHead';
 import fixUserProfile from './steps/fixUserProfile';
 import fixContentWidth from './steps/fixContentWidth';
 import fixVideo from './steps/fixVideo';
-import fixTableColGroup from './steps/fixTableColGroup';
 import fixEmptyLineIncludePage from './steps/fixEmptyLineIncludePage';
 import fixCode from './steps/fixCode';
 import addCustomCss from './steps/addCustomCss';
@@ -157,7 +156,6 @@ export class ProxyPageService {
     fixExpander()(this.context);
     fixUserProfile()(this.context);
     fixVideo()(this.context);
-    // fixTableColGroup()(this.context);
     fixEmptyLineIncludePage()(this.context);
     fixRoadmap(this.config)(this.context);
     fixFrameAllowFullscreen()(this.context);

--- a/src/static/reveal/theme/digital.css
+++ b/src/static/reveal/theme/digital.css
@@ -374,9 +374,10 @@ section.has-light-background h6 {
 .reveal table th,
 .reveal table td {
   text-align: left;
+  font-size: 0.8em;
   padding: 0.1em 0.1em 0.1em 0.1em;
   border-bottom: 1px solid;
-  vertical-align: center;
+  vertical-align: top;
 }
 
 .reveal table th[align='center'],

--- a/src/static/reveal/theme/iadc.css
+++ b/src/static/reveal/theme/iadc.css
@@ -361,10 +361,11 @@ section.has-light-background h6 {
 
 .reveal table th,
 .reveal table td {
+  font-size: 0.8em;
   text-align: left;
   padding: 0.1em 0.1em 0.1em 0.1em;
   border-bottom: 1px solid;
-  vertical-align: center;
+  vertical-align: top;
 }
 
 .reveal table th[align='center'],

--- a/src/static/reveal/theme/konviw.css
+++ b/src/static/reveal/theme/konviw.css
@@ -377,9 +377,10 @@ section.has-light-background h6 {
 .reveal table th,
 .reveal table td {
   text-align: left;
+  font-size: 0.7em;
   padding: 0.1em 0.1em 0.1em 0.1em;
   border-bottom: 1px solid;
-  vertical-align: center;
+  vertical-align: top;
 }
 
 .reveal table th[align='center'],


### PR DESCRIPTION
* renderPage and renderSlides will be rendered without the fixTableColGroup step to size the columns with the width returned by the Confluence API.
* in renderSlides the style of table is slightly improved to align vertically to top and smaller text size

Resolves FND-1135