### PR TITLE
feat(proxy-api): add labels filter to search api

### DIFF
--- a/src/proxy-api/proxy-api.controller.ts
+++ b/src/proxy-api/proxy-api.controller.ts
@@ -27,9 +27,6 @@ export class ProxyApiController {
       params.spaceKey,
       undefined,
       'blogpost',
-      undefined,
-      999,
-      undefined,
     );
   }
 

--- a/src/proxy-api/proxy-api.controller.ts
+++ b/src/proxy-api/proxy-api.controller.ts
@@ -16,8 +16,8 @@ export class ProxyApiController {
   constructor(private readonly proxyApi: ProxyApiService) {}
 
   /**
-   * @GET (controller) api/getAllPosts/:spaceKey
-   * @description Route to retrieve the list of blog posts in the defined spaceKey
+   * @GET (controller) api/BlogPosts/:spaceKey
+   * @description Route to retrieve the list of blog posts in a given spaceKey
    * @return {string} 'JSON' - JSON with Blog Posts content and metadata
    */
   @ApiOkResponse({ description: 'All blog posts from a given space key' })
@@ -25,20 +25,21 @@ export class ProxyApiController {
   async getBlogPosts(@Param() params: PostsParamsDTO): Promise<KonviwResults> {
     return this.proxyApi.getSearchResults(
       params.spaceKey,
-      '',
+      undefined,
       'blogpost',
+      undefined,
       999,
-      '',
+      undefined,
     );
   }
 
   /**
    * @GET (controller) api/search
-   * @description Route to retrieve the list of Confluence pages matching the passed criteria
+   * @description Route to retrieve the list of Confluence pages matching a given criteria
    * @return {string} 'JSON' - JSON with searched pages and metadata
    */
   @ApiOkResponse({
-    description: 'All pages that matches the given search string',
+    description: 'All pages that matches the given search string and filters',
   })
   @Get('search')
   async getSearchResults(
@@ -48,6 +49,7 @@ export class ProxyApiController {
       queries.spaceKey,
       queries.query,
       queries.type,
+      queries.labels,
       queries.maxResults,
       queries.cursorResults,
     );

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -31,25 +31,28 @@ export class ProxyApiService {
    * @function getSearchResults Service
    * @description Search content in Confluence
    * @return Promise {string}
-   * @param spaceKey {string} 'iadc' - space key where the page belongs
+   * @param spaceKeys {string} 'iadc|dgbi' - space key where the page belongs
    * @param query {string} 'vision factory' - words to be searched
    * @param type {string} 'blogpost' - type of Confluence page, either 'page' or 'blogpost'
+   * @param labels {string} 'label1,label2' - labels to include as filters in the search
    * @param maxResults {number} '15' - limit of records to be retrieved
    * @param cursorResults {string} 'URI' - one of the two URIs provided by Confluence to navigate to the next or previous set of records
    */
   async getSearchResults(
-    spaceKey: string,
+    spaceKeys: string,
     query = undefined,
     type = undefined,
+    labels = undefined,
     maxResults = 999,
     cursorResults = '',
   ): Promise<KonviwResults> {
     // destructuring data gets implicity typed from the response
     // while we explicitly type it for better control
     const { data }: { data: SearchResults } = await this.confluence.Search(
-      spaceKey,
+      spaceKeys,
       query,
       type,
+      labels,
       maxResults,
       cursorResults,
     );
@@ -59,7 +62,7 @@ export class ProxyApiService {
 
     const parseResults: KonviwContent[] = data.results.map(
       (doc: ResultsContent) => {
-        this.context.Init(spaceKey, doc.content.id);
+        this.context.Init(spaceKeys, doc.content.id);
         this.context.setHtmlBody(doc.content.body.view.value);
         const atlassianIadcRegEx = new RegExp(`${baseURL}/wiki/`);
         parseHeaderBlog()(this.context);

--- a/src/proxy-api/proxy-api.validation.dto.ts
+++ b/src/proxy-api/proxy-api.validation.dto.ts
@@ -42,6 +42,15 @@ export class SearchQueryDTO {
 
   @ApiPropertyOptional({
     required: false,
+    description: `The Confluence labels separated by ',' which will be filtered as AND.`,
+    example: 'label1,label2',
+  })
+  @IsOptional()
+  @IsString()
+  labels: string;
+
+  @ApiPropertyOptional({
+    required: false,
     description: `The maximum number of results to retrieve`,
     example: '20',
   })
@@ -51,7 +60,7 @@ export class SearchQueryDTO {
   maxResults: number;
 
   // This query param must encode all special characters, including: , / ? : @ & = + $ #
-  // For instance using encodeURIComponent()
+  // For instance using encodeURIComponent(meta.next)
   @ApiPropertyOptional({
     required: false,
     description: `The URL path received by the API after a previous search to perform moves to the next or previous page of results.`,


### PR DESCRIPTION
- multiple labels can be provided if separated by comma ','
- multiple labels will be treated as 'AND' filter

Resolves FND-1156