### PR TITLE
feat: FND-1136 moving large tables from fix column width to the proportional percentage per column

### DIFF
--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -30,6 +30,7 @@ import fixChartMacro from './steps/fixChart';
 import fixRoadmap from './steps/fixRoadmap';
 import fixFrameAllowFullscreen from './steps/fixFrameAllowFullscreen';
 import fixImageSize from './steps/fixImageSize';
+import fixColGroupWidth from './steps/fixColGroupWidth';
 import addLibrariesCSS from './steps/addLibrariesCSS';
 import addLibrariesJS from './steps/addLibrariesJS';
 import addSlidesCSS from './steps/addSlidesCSS';
@@ -117,6 +118,7 @@ export class ProxyPageService {
     fixCode()(this.context);
     fixFrameAllowFullscreen()(this.context);
     fixImageSize()(this.context);
+    fixColGroupWidth()(this.context);
     if (type === 'blog') {
       addHeaderBlog()(this.context);
     } else if (type !== 'notitle') {

--- a/src/proxy-page/steps/fixColGroupWidth.ts
+++ b/src/proxy-page/steps/fixColGroupWidth.ts
@@ -1,0 +1,42 @@
+import { ContextService } from '../../context/context.service';
+import { Step } from '../proxy-page.step';
+import * as cheerio from 'cheerio';
+
+/**
+ * ### Proxy page step to fix colgroup width
+ *
+ * This module gets Cheerio to search all colgroup ('colgroup')
+ * and convert the width to the proportional percentage
+ * when the width sum of colgroup more than 1000
+ *
+ * @param  {ConfigService} config
+ * @returns void
+ */
+export default (): Step => {
+  return (context: ContextService): void => {
+    context.setPerfMark('fixColgroupWidth');
+    const $ = context.getCheerioBody();
+    $('colgroup').each((_index: number, elementColgroup: cheerio.Element) => {
+      let sumColWidth = 0;
+      const maxColWidth = 1000;
+      elementColgroup.childNodes.forEach((elementColumn: cheerio.Element) => {
+        sumColWidth += getElementValue(elementColumn);
+      });
+      if (sumColWidth > maxColWidth) {
+        elementColgroup.childNodes.forEach((elementColumn: cheerio.Element) => {
+          const newWidth = Math.round(
+            (getElementValue(elementColumn) / sumColWidth) * 100,
+          );
+          elementColumn.attribs = { style: 'width: ' + newWidth + '%;' };
+        });
+      }
+    });
+    context.getPerfMeasure('fixColgroupWidth');
+  };
+};
+
+function getElementValue(elementColumn: cheerio.Element): number {
+  return Number(
+    JSON.parse(JSON.stringify(elementColumn.attribs)).style.match(/\d+/)[0],
+  );
+}

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -1,8 +1,8 @@
-import fixColgroupWidth from '../../../src/proxy-page/steps/fixColgroupWidth';
+import fixColgroupWidth from '../../../src/proxy-page/steps/fixColGroupWidth';
 import { ContextService } from '../../../src/context/context.service';
 import { createModuleRefForStep } from './utils';
 
-describe('ConfluenceProxy / fixColgroupWidth', () => {
+describe('ConfluenceProxy / fixColGroupWidth', () => {
   let context: ContextService;
 
   const step = fixColgroupWidth();

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -20,6 +20,7 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
     expect(context.getHtmlBody()).toContain('width: 224.0px;');
     step(context);
     expect(context.getHtmlBody()).toContain('width: 224.0px;');
+    expect(context.getHtmlBody()).not.toContain('width: 25%;');
   });
 
   it('should convert column width from px to proportional percentage % when sum of colgroup column widths is more than 1000px', () => {

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
     context.setHtmlBody('<html><head></head><body></body></html>');
   });
 
-  it('should not convert column width to proportional percentage', () => {
+  it('should not convert column width from px to proportional percentage % when sum of colgroup column widths is less than 1000px', () => {
     const colGroup = '<table><colgroup><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/></colgroup></table>';
     context.setHtmlBody(colGroup);
     expect(context.getHtmlBody()).toContain('width: 224.0px;');
@@ -22,8 +22,7 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
     expect(context.getHtmlBody()).toContain('width: 224.0px;');
   });
 
-
-  it('should convert column width to proportional percentage', () => {
+  it('should convert column width from px to proportional percentage % when sum of colgroup column widths is more than 1000px', () => {
     const colGroup = '<table><colgroup><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/></colgroup></table>';
     context.setHtmlBody(colGroup);
     expect(context.getHtmlBody()).toContain('width: 224.0px');
@@ -32,5 +31,4 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
     expect(context.getHtmlBody()).toContain('width: 20%;');
   });
   
-
 })

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -1,0 +1,36 @@
+import fixColgroupWidth from '../../../src/proxy-page/steps/fixColgroupWidth';
+import { ContextService } from '../../../src/context/context.service';
+import { createModuleRefForStep } from './utils';
+
+describe('ConfluenceProxy / fixColgroupWidth', () => {
+  let context: ContextService;
+
+  const step = fixColgroupWidth();
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.Init('XXX', '123456', 'dark');
+    context.setHtmlBody('<html><head></head><body></body></html>');
+  });
+
+  it('should not convert column width to proportional percentage', () => {
+    const colGroup = '<table><colgroup><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/></colgroup></table>';
+    context.setHtmlBody(colGroup);
+    expect(context.getHtmlBody()).toContain('width: 224.0px;');
+    step(context);
+    expect(context.getHtmlBody()).toContain('width: 224.0px;');
+  });
+
+
+  it('should convert column width to proportional percentage', () => {
+    const colGroup = '<table><colgroup><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/><col style="width: 224.0px;"/></colgroup></table>';
+    context.setHtmlBody(colGroup);
+    expect(context.getHtmlBody()).toContain('width: 224.0px');
+    step(context);
+    expect(context.getHtmlBody()).not.toContain('width: 224.0px');
+    expect(context.getHtmlBody()).toContain('width: 20%;');
+  });
+  
+
+})


### PR DESCRIPTION
- The Confluence API returns a fixed width for each of the columns of a table using the colgroup 
- We calculate the sum of all column widths of a colgroup, once is more than 1000px :
  - We convert the value of the width for its column into the proportional percentage
- We adapt the standard response when the total width of the table is more than 1000px