### PR TITLE
chore(nodejs): dropping support for 12.x, adding support for 16.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 15.x, 16.x, 17.x]
     env:
       CPV_CONFLUENCE_API_TOKEN: ${{ secrets.CPV_CONFLUENCE_API_TOKEN }}
       CPV_CONFLUENCE_API_USERNAME: ${{ secrets.CPV_CONFLUENCE_API_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
     env:
       CPV_CONFLUENCE_API_TOKEN: ${{ secrets.CPV_CONFLUENCE_API_TOKEN }}
       CPV_CONFLUENCE_API_USERNAME: ${{ secrets.CPV_CONFLUENCE_API_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
     env:
       CPV_CONFLUENCE_API_TOKEN: ${{ secrets.CPV_CONFLUENCE_API_TOKEN }}
       CPV_CONFLUENCE_API_USERNAME: ${{ secrets.CPV_CONFLUENCE_API_USERNAME }}
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 15.x, 16.x, 17.x]
     env:
       CYPRESS_BASE_URL: https://konviw.vercel.app/cpv
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
     env:
       CYPRESS_BASE_URL: https://konviw.vercel.app/cpv
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
     env:
       CYPRESS_BASE_URL: https://konviw.vercel.app/cpv
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   Vuepress:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '16.x'
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=12.18.1
+ARG NODE_VERSION=16.14.0
 
 ########################
 # Builder stage


### PR DESCRIPTION
In this MR:

- We drop support for 12.x
- We add support for 16.x
- Make defaults to LTS 16.14.0 for release and Dockerfile
- We add support for 17.x in tests and pipeline