### PR TITLE
fix: WEB-98 Paragraphs and h3 in tables have the same font-weight as in Confluence

### DIFF
--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -20,6 +20,11 @@ table.confluenceTable th.confluenceTh {
   z-index: 2;
   box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.4);
   font-size: var(--main-font-size);
+  font-weight: bold;
+
+  p {
+    font-weight: initial;
+  }
 }
 
 .confluenceTh,
@@ -343,14 +348,6 @@ table.confluenceTable td.confluenceTd[data-highlight-colour='\#000000'] {
   background-color: #000000;
 }
 /* ADG3 colors end */
-
-table.confluenceTable th.confluenceTh {
-  font-weight: bold;
-
-  p {
-    font-weight: initial;
-  }
-}
 
 table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */
 table.confluenceTable th.confluenceTh.nohighlight > p {

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -29,6 +29,10 @@ table.confluenceTable th.confluenceTh {
   vertical-align: top;
   min-width: 8px; /* CONF-39943: set table cell min-width to which cursor can be focused */
   word-wrap: break-word;
+
+  h1, h2, h3 {
+    font-weight: 600;
+  }
 }
 
 /* Lists in tables */
@@ -340,9 +344,12 @@ table.confluenceTable td.confluenceTd[data-highlight-colour='\#000000'] {
 }
 /* ADG3 colors end */
 
-table.confluenceTable th.confluenceTh,
-table.confluenceTable th.confluenceTh > p {
+table.confluenceTable th.confluenceTh {
   font-weight: bold;
+
+  p {
+    font-weight: initial;
+  }
 }
 
 table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -20,6 +20,11 @@ table.confluenceTable th.confluenceTh {
   z-index: 2;
   box-shadow: 0 3px 2px -1px rgba(0, 0, 0, 0.4);
   font-size: var(--main-font-size);
+  font-weight: bold;
+
+  p {
+    font-weight: initial;
+  }
 }
 
 .confluenceTh,
@@ -343,14 +348,6 @@ table.confluenceTable td.confluenceTd[data-highlight-colour='\#000000'] {
   background-color: #000000;
 }
 /* ADG3 colors end */
-
-table.confluenceTable th.confluenceTh {
-  font-weight: bold;
-
-  p {
-    font-weight: initial;
-  }
-}
 
 table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */
 table.confluenceTable th.confluenceTh.nohighlight > p {

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -29,6 +29,10 @@ table.confluenceTable th.confluenceTh {
   vertical-align: top;
   min-width: 8px; /* CONF-39943: set table cell min-width to which cursor can be focused */
   word-wrap: break-word;
+
+  h1, h2, h3 {
+    font-weight: 600;
+  }
 }
 
 /* Lists in tables */
@@ -43,7 +47,6 @@ table.confluenceTable th.confluenceTh {
 .table-wrap {
   margin: auto;
   margin-top: 20px;
-  // overflow-x: auto;
 }
 
 /* an exception to above rule for tables that are first child */
@@ -341,9 +344,12 @@ table.confluenceTable td.confluenceTd[data-highlight-colour='\#000000'] {
 }
 /* ADG3 colors end */
 
-table.confluenceTable th.confluenceTh,
-table.confluenceTable th.confluenceTh > p {
+table.confluenceTable th.confluenceTh {
   font-weight: bold;
+
+  p {
+    font-weight: initial;
+  }
 }
 
 table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */


### PR DESCRIPTION
Refers https://sanofi.atlassian.net/browse/WEB-98