### PR TITLE
fix: WEB-163 : metadata exchange

### DIFF
--- a/src/proxy-page/steps/addLibrariesJS.ts
+++ b/src/proxy-page/steps/addLibrariesJS.ts
@@ -41,8 +41,8 @@ export default (): Step => {
           konviwFrameUrl: window.location.href,
           konviwSpaceKey: '${context.getSpaceKey()}',
           konviwPageId: '${context.getPageId()}',
-          konviwTitle: '${context.getTitle()}',
-          konviwExcerpt: '${context.getExcerpt()}',
+          konviwTitle: '${context.getTitle().replace(/'/g, "\\'")}',
+          konviwExcerpt: '${context.getExcerpt().replace(/'/g, "\\'")}',
           konviwCreatedVersion: '${JSON.stringify(
             context.getCreatedVersion(),
           )}',


### PR DESCRIPTION
fixed a bug where the 'excerpt' and 'title' metadata fields could cause a bug in the 'page information' if they contained a quote character