### PR TITLE
Bugfix: narrow confluence-jim-macro selector to include jira-table only

### DIFF
--- a/src/proxy-page/steps/addJira.ts
+++ b/src/proxy-page/steps/addJira.ts
@@ -19,9 +19,11 @@ export default (config: ConfigService, jiraService: JiraService): Step => {
     const elementTags = [];
     // this is the outer div used to wrap the Jira issues macro
     // which it is saved to place the tables just before
-    $('.confluence-jim-macro').each((_, elementJira: cheerio.Element) => {
-      elementTags.push(elementJira);
-    });
+    $('div.confluence-jim-macro.jira-table').each(
+      (_, elementJira: cheerio.Element) => {
+        elementTags.push(elementJira);
+      },
+    );
 
     const jiraIssuesPromises = [];
     // this is the div holding the data to scrap the list of issues

--- a/tests/unit/steps/addJira.spec.ts
+++ b/tests/unit/steps/addJira.spec.ts
@@ -67,7 +67,7 @@ describe('Confluence Proxy / addJira', () => {
         </ac:structured-macro>' data-pageid="page-id">`;
 
     context.setHtmlBody(
-      `<html><head><title>test</title></head><body><div id='Content'><div class='confluence-jim-macro'>${cheerioBody}</div></div></body></html>`,
+      `<html><head><title>test</title></head><body><div id='Content'><div class='confluence-jim-macro jira-table'>${cheerioBody}</div></div></body></html>`,
     );
     await step(context);
     const $ = context.getCheerioBody();


### PR DESCRIPTION
- narrow the selector for the jira table to avoid confusion with jira inline links

fixes WEB-267