### PR TITLE
fix: docker image repository for instana layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY package*.json ./
 RUN npm ci --quiet --only=production
 
 # Add the Instana APM layer
-COPY --from=instana/aws-fargate-nodejs /instana /instana
+COPY --from=icr.io/instana/aws-fargate-nodejs:latest /instana /instana
 RUN /instana/setup.sh
 ENV NODE_OPTIONS="--require /instana/node_modules/@instana/aws-fargate"
 


### PR DESCRIPTION
`invalid from flag value instana/aws-fargate-nodejs: pull access denied for instana/aws-fargate-nodejs`

Fargate layer image provided by Instana is no longer hosted on [DockerHub](https://hub.docker.com/) but on [icr.io](https://www.ibm.com/cloud/container-registry). 

As a consequence, the Dockerfile used in this project need to be updated.