### PR TITLE
fix: blog posts not correctly rendering images

### DIFF
--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -166,6 +166,9 @@ export class ConfluenceService {
           'content.history',
           'content.metadata.labels',
           'content.body.view',
+          'content.version',
+          // header image if any defined
+          'content.metadata.properties.cover_picture_id_published',
         ].join(','),
         includeArchivedSpaces: false,
       };

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -82,17 +82,13 @@ export class ProxyApiService {
     const parseResults: KonviwContent[] = await Promise.all(
       data.results.map(async (doc: ResultsContent) => {
         const spacekey = doc.resultGlobalContainer.displayUrl.split('/')[2];
-        const content: Content = await this.confluence.getPage(
-          spacekey,
-          doc.content.id,
-        );
         const context = new ContextService(this.config);
         context.initPageContext(
           spacekey,
           doc.content.id,
           undefined,
           undefined,
-          content,
+          doc.content,
         );
         context.setHtmlBody(doc.content.body.view.value);
         const atlassianIadcRegEx = new RegExp(`${baseURL}/wiki/`);

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -86,16 +86,17 @@ export class ProxyApiService {
           spacekey,
           doc.content.id,
         );
-        this.context.initPageContext(
+        const context = new ContextService(this.config);
+        context.initPageContext(
           spacekey,
           doc.content.id,
           undefined,
           undefined,
           content,
         );
-        this.context.setHtmlBody(doc.content.body.view.value);
+        context.setHtmlBody(doc.content.body.view.value);
         const atlassianIadcRegEx = new RegExp(`${baseURL}/wiki/`);
-        await parseHeaderBlog(this.config, this.confluence)(this.context);
+        await parseHeaderBlog(this.config, this.confluence)(context);
         // TODO: review and enable in future release
         // getFirstExcerpt()(this.context);
         const contentResult: KonviwContent = {
@@ -115,15 +116,15 @@ export class ProxyApiService {
           labels: doc.content.metadata.labels.results.map((list: any) => ({
             tag: list.label,
           })),
-          imgblog: this.context
+          imgblog: context
             .getImgBlog()
             .replace(atlassianIadcRegEx, `${baseHost}${basePath}/wiki/`),
           summary: doc.excerpt,
           space: spacekey,
           lastModified: doc.friendlyLastModified,
-          excerptBlog: this.context.getExcerpt(),
-          body: this.context.getTextBody(),
-          readTime: this.context.getReadTime(),
+          excerptBlog: context.getExcerpt(),
+          body: context.getTextBody(),
+          readTime: context.getReadTime(),
         };
         return contentResult;
       }),

--- a/src/proxy-api/steps/parseHeaderBlog.ts
+++ b/src/proxy-api/steps/parseHeaderBlog.ts
@@ -4,8 +4,7 @@ import { ConfluenceService } from '../../confluence/confluence.service';
 import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
 
-// This module search for the first Page Properties macro in the page and collects the image
-// and a blockquote to set them as blog post header image and blog blockquote
+// This module search for the right image and a blockquote to set them as blog post header image and headline
 export default (config: ConfigService, confluence: ConfluenceService): Step => {
   return async (context: ContextService): Promise<void> => {
     const $ = context.getCheerioBody();
@@ -21,6 +20,8 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => {
         blogImgSrc = `${webBasePath}/wiki${blogImgAttachment?._links?.download}`;
       }
     }
+
+    // a macro page-properties with an image and blockquote inside will be used alternatively to define both image and blockquote for the blog post
     $(".plugin-tabmeta-details[data-macro-name='details']")
       .first()
       .each((_index: number, elementProperties: cheerio.Element) => {
@@ -31,6 +32,13 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => {
           blogImgSrc = imgBlog?.attr('src');
         }
         context.setExcerpt(excerptBlog.html());
+      });
+
+    // alternatively a single first blockquote will be used as headline for the blog post
+    $('blockquote')
+      .first()
+      .each((_index: number, elementProperties: cheerio.Element) => {
+        context.setExcerpt($(elementProperties).html());
       });
     context.setImgBlog(blogImgSrc);
   };

--- a/src/proxy-api/steps/parseHeaderBlog.ts
+++ b/src/proxy-api/steps/parseHeaderBlog.ts
@@ -27,10 +27,11 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => {
         const imgBlog = $(elementProperties).find('img');
         const excerptBlog = $(elementProperties).find('blockquote');
         if (!blogImgSrc) {
-          blogImgSrc = imgBlog?.attr('src'); // headerIMage has priority over page-proterties's image
+          // header image has priority over page-proterties's image
+          blogImgSrc = imgBlog?.attr('src');
         }
-        context.setImgBlog(blogImgSrc);
         context.setExcerpt(excerptBlog.html());
       });
+    context.setImgBlog(blogImgSrc);
   };
 };


### PR DESCRIPTION
In this MR, we fix:
- The Singleton Issue for rendering content
- The image not rendering without page properties
- Extended search function in confluence.service to retrieve: **version** and **metadata.properties.cover_picture_id_published**