### PR TITLE
Feature: WEB-1515 display konviw pages and konviw slides in status draft

### DIFF
--- a/src/assets/scss/slides.scss
+++ b/src/assets/scss/slides.scss
@@ -69,6 +69,7 @@
 @import 'macro-content-by-label';
 @import 'macro-roadmap';
 @import 'macro-jira';
+@import 'macro-toc';
 
 // Hidden section ===========================================
 .hidden {

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -25,22 +25,28 @@ export class ConfluenceService {
    * @return Promise {any}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
+   * @param version {string} '9' - id of the page to retrieve
+   * @param status {string} 'current' - use 'current' or nothing for published pages and 'draft' for pages in DRAFT not yet published
    */
   async getPage(
     spaceKey: string,
     pageId: string,
     version?: string,
+    status?: string,
   ): Promise<Content> {
     let results: AxiosResponse<Content>;
     try {
       const uri = version ? `${pageId}/version/${version}` : `${pageId}`;
       const prefix = version ? 'content.' : '';
+      // default to 'current'
+      const statusPage = status ?? 'current';
       this.logger.log(`Retrieving page ${pageId}`);
       this.logger.log(`Retrieving version ${version}`);
       results = await firstValueFrom(
         this.http.get<Content>(`/wiki/rest/api/content/${uri}`, {
           params: {
             type: 'page',
+            status: statusPage,
             spaceKey,
             // select special fields to retrieve
             expand: [

--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -89,10 +89,10 @@ export class ContextService {
       this.setTitle(data.title);
       [,,,, this.spaceKey] = data._expandable.space.split('/');
       this.setHtmlBody(data.body.view.value, loadAsDocument);
-      this.setAuthor(data.history.createdBy.displayName);
-      this.setEmail(data.history.createdBy.email);
+      this.setAuthor(data.history.createdBy?.displayName);
+      this.setEmail(data.history.createdBy?.email);
       this.setAvatar(
-        `${baseHost}${basePath}/${data.history.createdBy.profilePicture.path.replace(
+        `${baseHost}${basePath}/${data.history.createdBy?.profilePicture.path.replace(
           /^\/wiki/,
           'wiki',
         )}`,
@@ -105,8 +105,8 @@ export class ContextService {
         when: data.history.createdDate,
         friendlyWhen: timeFromNow(data.history.createdDate),
         modificationBy: {
-          displayName: data.history.createdBy.displayName,
-          email: data.history.createdBy.email,
+          displayName: data.history.createdBy?.displayName,
+          email: data.history.createdBy?.email,
           profilePicture: this.getAvatar(),
         },
       };

--- a/src/proxy-page/dto/PageQuery.ts
+++ b/src/proxy-page/dto/PageQuery.ts
@@ -61,4 +61,15 @@ export default class PageQueryDTO {
   @IsString()
   @IsIn(['no-cache', 'clear-cache'])
     cache: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    required: false,
+    description: 'Use \'current\' or nothing for published pages and \'draft\' for pages in DRAFT not yet published',
+    example: 'current',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['current', 'draft'])
+    status: string;
 }

--- a/src/proxy-page/dto/SlidesQuery.ts
+++ b/src/proxy-page/dto/SlidesQuery.ts
@@ -49,4 +49,15 @@ export default class SlidesQueryDTO {
   @IsString()
   @IsIn(['no-cache', 'clear-cache'])
     cache: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    required: false,
+    description: 'Use \'current\' or nothing for published pages and \'draft\' for pages in DRAFT not yet published',
+    example: 'current',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['current', 'draft'])
+    status: string;
 }

--- a/src/proxy-page/proxy-page.controller.ts
+++ b/src/proxy-page/proxy-page.controller.ts
@@ -34,11 +34,12 @@ export class ProxyPageController {
    * @param month {string} [optional] '04' - month of publication of the blog post
    * @param day {string} [optional] '12' - day of publication of the blog post
    * @param pageId {string} '639243960' - id of the page to retrieve
+   * @param pageVersion {string} '9' - The version of the page to render
    * @query theme {string} 'dark' - switch between light and dark themes
    * @query type {string} 'blog' - 'blog' to display a post header or 'notitle' to remove the title of the page
    * @query style {string} 'konviw' - style to render the page
-   * @query nozoom {string} '' - disable zoom effect in images
-   * @query view {string} '' - disable scroll to top, zoom effect in images, reading progress bar and floating toc menu
+   * @query view {string} 'fullpage' - disable scroll to top, zoom effect in images, reading progress bar and floating toc menu
+   * @query status {string} 'current' - use 'current' or nothing for published pages and 'draft' for pages in DRAFT not yet published
    */
 
   @ApiOperation({
@@ -57,7 +58,8 @@ export class ProxyPageController {
     @Query() queries: PageQueryDTO,
   ) {
     this.logger.log(
-      `Rendering page.. /${params.spaceKey}/${params.pageId}/${params.pageVersion}`,
+      `Rendering page.. /${params.spaceKey}/${params.pageId}/${params.pageVersion} `
+      + `with style ${queries.style} and status ${queries.status}`,
     );
     return this.proxyPage.renderPage(
       params.spaceKey,
@@ -67,6 +69,7 @@ export class ProxyPageController {
       queries.type,
       queries.style,
       queries.view,
+      queries.status,
     );
   }
 
@@ -79,6 +82,7 @@ export class ProxyPageController {
    * @param pageId {string} '639243960' - id of the page to retrieve
    * @query style {string} 'konviw' - select the theme to use for your slide deck
    * @query transition {string} 'slide' - transition animation for the slide deck
+   * @query status {string} 'current' - use 'current' or nothing for published pages and 'draft' for pages in DRAFT not yet published
    */
   @ApiOperation({
     summary: 'Render a Slides',
@@ -88,19 +92,25 @@ export class ProxyPageController {
   @ApiOkResponse({
     description: 'Full html of the rendered page as reveal.js slides',
   })
-  @Get('/slides/:spaceKey/:pageId/:pageSlug?')
+  @Get([
+    '/slides/:spaceKey/:pageId/:pageSlug?',
+    '/slides/:spaceKey/:pageId/versions/:pageVersion/:pageSlug?',
+  ])
   async getSlides(
     @Param() params: PageParamsDTO,
     @Query() queries: SlidesQueryDTO,
   ) {
     this.logger.log(
-      `Rendering Slides for ... /${params.spaceKey}/${params.pageId} with style ${queries.style}`,
+      `Rendering Slides for ... /${params.spaceKey}/${params.pageId}/${params.pageVersion} `
+      + `with style ${queries.style} and status ${queries.status}`,
     );
     return this.proxyPage.renderSlides(
       params.spaceKey,
       params.pageId,
+      params.pageVersion,
       queries.style,
       queries.transition,
+      queries.status,
     );
   }
 

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -60,9 +60,12 @@ export class ProxyPageService {
    * @return Promise {string}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
+   * @param version {string} '9' - the version of the page to render
    * @param theme {string} 'dark' - light or dark theme used by the page
    * @param type {string} 'blog' - type of the page
-   * @param style {string} 'iadc' - theme to style the page
+   * @param style {string} 'konviw' - style to render the page
+   * @param view {string} 'fullpage' - disable scroll to top, zoom effect in images, reading progress bar and floating toc menu
+   * @param status {string} 'current' - use 'current' or nothing for published pages and 'draft' for pages in DRAFT not yet published
    */
   async renderPage(
     spaceKey: string,
@@ -72,11 +75,13 @@ export class ProxyPageService {
     type: string,
     style: string,
     view: string,
+    status: string,
   ): Promise<string> {
     const content: Content = await this.confluence.getPage(
       spaceKey,
       pageId,
       version,
+      status,
     );
     this.context.initPageContext(
       spaceKey,
@@ -138,15 +143,20 @@ export class ProxyPageService {
    * @return Promise {string}
    * @param spaceKey {string} 'iadc' - space key where the page belongs
    * @param pageId {string} '639243960' - id of the page to retrieve
-   * @param theme {string} '#FFFFFF' - the theme used of the page
+   * @param version {string} '9' - the version of the page to render
+   * @param style {string} 'konviw' - style to render the page
+   * @param theme {string} 'light' - the theme used of the page
+   * @param status {string} 'current' - use 'current' or nothing for published pages and 'draft' for pages in DRAFT not yet published
    */
   async renderSlides(
     spaceKey: string,
     pageId: string,
+    version: string,
     style: string,
     transition: string,
+    status: string,
   ): Promise<string> {
-    const content: Content = await this.confluence.getPage(spaceKey, pageId);
+    const content: Content = await this.confluence.getPage(spaceKey, pageId, version, status);
     this.context.initPageContext(
       spaceKey,
       pageId,
@@ -161,6 +171,7 @@ export class ProxyPageService {
     fixHtmlHead(this.config)(this.context);
     fixToc()(this.context);
     await fixLinks(this.config, this.http)(this.context);
+    fixToc()(this.context);
     fixEmojis(this.config)(this.context);
     fixDrawioMacro(this.config)(this.context);
     fixChartMacro(this.config)(this.context);

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -159,6 +159,7 @@ export class ProxyPageService {
     const addJiraPromise = addJira(this.config, this.jira)(this.context);
     addSlidesCSS(this.config)(this.context);
     fixHtmlHead(this.config)(this.context);
+    fixToc()(this.context);
     await fixLinks(this.config, this.http)(this.context);
     fixEmojis(this.config)(this.context);
     fixDrawioMacro(this.config)(this.context);

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -169,7 +169,6 @@ export class ProxyPageService {
     const addJiraPromise = addJira(this.config, this.jira)(this.context);
     addSlidesCSS(this.config)(this.context);
     fixHtmlHead(this.config)(this.context);
-    fixToc()(this.context);
     await fixLinks(this.config, this.http)(this.context);
     fixToc()(this.context);
     fixEmojis(this.config)(this.context);

--- a/src/static/reveal/theme/digital.css
+++ b/src/static/reveal/theme/digital.css
@@ -194,7 +194,8 @@ section.has-light-background h6 {
 }
 
 .cover .reveal p,
-.cover .reveal p a {
+.cover .reveal p a ,
+.cover .reveal a {
   color: white;
 }
 

--- a/tests/unit/speed/speedSteps.spec.ts
+++ b/tests/unit/speed/speedSteps.spec.ts
@@ -42,7 +42,7 @@ describe('Speed / Steps', () => {
   let config: ConfigService;
 
   // Time expected for each step to be execute within, in ms.
-  const timeExpected = 150;
+  const timeExpected = 200;
 
   // Number of time we check the step execution time.
   const iteration = 100;


### PR DESCRIPTION
- add status to getPage so we can render konviw pages and slides while we work on a draft document
- konviw pages will be also rendered for documents not yet published
- for not published pages displayName, email, profile are not set
- add new route /slides/:spaceKey/:pageId:/versions/:pageVersion to render slides for any given version
- add fixTOC (table of contents) to slides

completes WEB-1515