### PR TITLE
 fix: WEB-203 better manage slideSettings defaults

### DIFF
--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -17,6 +17,8 @@ export class ContextService {
 
   private style = '';
 
+  private slideTransition = '';
+
   private view = '';
 
   private cheerioBody = cheerio.load('html');
@@ -284,6 +286,14 @@ export class ContextService {
 
   getStyle(): string {
     return this.style;
+  }
+
+  getSlideTransition(): string {
+    return this.slideTransition;
+  }
+
+  setSlideTransition(transition: string): void {
+    this.slideTransition = transition;
   }
 
   getAuthor(): string {

--- a/src/proxy-page/steps/addNewSlides.ts
+++ b/src/proxy-page/steps/addNewSlides.ts
@@ -3,9 +3,7 @@ import * as cheerio from 'cheerio';
 import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
-import {
-  getAttributesFromChildren, getMacroSlideSettingsPropertyValueByKey, getObjectFromStorageXMLForPageProperties, loadStorageContentToXML,
-} from '../utils/macroSlide';
+import { getAttributesFromChildren, getObjectFromStorageXMLForPageProperties } from '../utils/macroSlide';
 
 export default (config: ConfigService, content: Content): Step => (context: ContextService): void => {
   context.setPerfMark('addNewSlides');
@@ -35,11 +33,6 @@ export default (config: ConfigService, content: Content): Step => (context: Cont
   const attachmentResource = `${webBasePath}/wiki/download/attachments/${context.getPageId()}/`;
 
   const $ = context.getCheerioBody();
-
-  const storageContentXML = loadStorageContentToXML(content);
-
-  const macroSettingsSlideTransition = getMacroSlideSettingsPropertyValueByKey(storageContentXML, 'slide_settings_transition', 'slide');
-  context.setSlideTransition(macroSettingsSlideTransition?.value as string);
 
   const convertSlideFragmentValueToBoolean = (value: string) => value === 'yes';
 
@@ -95,9 +88,7 @@ export default (config: ConfigService, content: Content): Step => (context: Cont
   $(".conf-macro[data-macro-name='slide']").each(
     (_index: number, slideProperties: cheerio.Element) => {
       const storageXML = getObjectFromStorageXMLForPageProperties(slideProperties, content);
-      const { options } = getAttributesFromChildren(storageXML, {
-        defaultValueForSlideTransition: macroSettingsSlideTransition.value,
-      });
+      const { options } = getAttributesFromChildren(storageXML);
       const {
         slideBackgroundAttachment, slideType, slideTransition, slideParagraphAnimation,
       } = options;

--- a/src/proxy-page/steps/addSlidesJS.ts
+++ b/src/proxy-page/steps/addSlidesJS.ts
@@ -56,7 +56,6 @@ export default (config: ConfigService): Step => (context: ContextService): void 
             loadIcons: true,
           },
           transition: "${context.getSlideTransition()}",
-          backgroundTransition: 'fade',
           slideNumber: 'c/t',
           disableLayout: false,
           margin: 0.1,

--- a/src/proxy-page/steps/addSlidesJS.ts
+++ b/src/proxy-page/steps/addSlidesJS.ts
@@ -55,7 +55,7 @@ export default (config: ConfigService): Step => (context: ContextService): void 
             hideMissingTitles: false,
             loadIcons: true,
           },
-          transition: 'fade',
+          transition: "${context.getSlideTransition()}",
           backgroundTransition: 'fade',
           slideNumber: 'c/t',
           disableLayout: false,

--- a/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
@@ -1,21 +1,29 @@
 import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { getMacroSlideSettingsPropertyValueByKey, loadStorageContentToXML } from '../utils/macroSlide';
+import { MacroSlideSettingsProperty } from '../utils/macroSlide.interface';
 
 export default (context: ContextService, spaceKey: string, pageId: string, style?: string, content?: Content): void => {
   const storageXML = loadStorageContentToXML(content);
 
-  const { exist, value } = getMacroSlideSettingsPropertyValueByKey(storageXML, 'slide_settings_theme', 'digital');
+  const {
+    exist: existSlideStyle,
+    value: valueSlideStyle,
+  }: MacroSlideSettingsProperty = getMacroSlideSettingsPropertyValueByKey(storageXML, 'slide_settings_theme', 'digital');
 
-  const slideStyle = exist ? value : style;
+  const {
+    exist: existSlideTransition,
+    value: valueSlideTransition,
+  }: MacroSlideSettingsProperty = getMacroSlideSettingsPropertyValueByKey(storageXML, 'slide_settings_transition', 'slide');
 
   context.initPageContext(
     spaceKey,
     pageId,
     'light',
-    slideStyle,
+    existSlideStyle ? valueSlideStyle : style,
     content,
     true,
     '',
   );
+  context.setSlideTransition(existSlideTransition ? valueSlideTransition : 'slide');
 };

--- a/src/proxy-page/utils/macroSlide.interface.ts
+++ b/src/proxy-page/utils/macroSlide.interface.ts
@@ -1,0 +1,4 @@
+export interface MacroSlideSettingsProperty {
+  exist: boolean;
+  value: string;
+}

--- a/src/proxy-page/utils/macroSlide.ts
+++ b/src/proxy-page/utils/macroSlide.ts
@@ -1,9 +1,11 @@
 import * as cheerio from 'cheerio';
 import { Content } from '../../confluence/confluence.interface';
+import { MacroSlideSettingsProperty } from './macroSlide.interface';
 
 export const loadStorageContentToXML = (content: Content) => cheerio.load(content?.body?.storage?.value ?? '', { xmlMode: true });
 
-export const getMacroSlideSettingsPropertyValueByKey = ($storageContent: cheerio.CheerioAPI, key: string, defaultValue: string) => {
+export const getMacroSlideSettingsPropertyValueByKey = ($storageContent: cheerio.CheerioAPI, key: string, defaultValue: string):
+MacroSlideSettingsProperty => {
   const findElement = $storageContent(`ac\\:parameter[ac\\:name="${key}"]`);
   const getObjectFromElement = findElement && findElement['0'];
   const defineObject = getObjectFromElement && getObjectFromElement.children[0] as any;
@@ -22,11 +24,6 @@ export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio
 
 export const getAttributesFromChildren = (
   storageXML: cheerio.Cheerio<cheerio.Element>,
-  {
-    defaultValueForSlideTransition,
-  }: {
-    defaultValueForSlideTransition: string
-  },
 ): { options: { [key: string]: string } } => {
   const getValueByKeyOrAssignDefault = (array: any[], compareKey: string, defaultValue: string) =>
     Object.values(array).find(({ key }) => key === compareKey)?.value ?? defaultValue;

--- a/src/proxy-page/utils/macroSlide.ts
+++ b/src/proxy-page/utils/macroSlide.ts
@@ -20,7 +20,7 @@ export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio
   return storageXML;
 };
 
-export const getAttribiutesFromChildren = (
+export const getAttributesFromChildren = (
   storageXML: cheerio.Cheerio<cheerio.Element>,
   {
     defaultValueForSlideTransition,
@@ -31,22 +31,20 @@ export const getAttribiutesFromChildren = (
   const getValueByKeyOrAssignDefault = (array: any[], compareKey: string, defaultValue: string) =>
     Object.values(array).find(({ key }) => key === compareKey)?.value ?? defaultValue;
 
-  const options = getAttribiutesFromChildrenByType(storageXML) as any;
-
-  const slideTransitionDefinedValue = getValueByKeyOrAssignDefault(options, 'slide_transition', defaultValueForSlideTransition);
+  const options = getAttributesFromChildrenByType(storageXML) as any;
 
   return {
     options: {
       slideId: getValueByKeyOrAssignDefault(options, 'slide_id', ''),
       slideType: getValueByKeyOrAssignDefault(options, 'slide_type', 'default'),
-      slideTransition: slideTransitionDefinedValue === 'none' ? defaultValueForSlideTransition : slideTransitionDefinedValue,
+      slideTransition: getValueByKeyOrAssignDefault(options, 'slide_transition', ''),
       slideParagraphAnimation: getValueByKeyOrAssignDefault(options, 'slide_paragraph_animation', 'no'),
       slideBackgroundAttachment: getValueByKeyOrAssignDefault(options, 'slide_background_attachment', ''),
     },
   };
 };
 
-const getAttribiutesFromChildrenByType = (
+const getAttributesFromChildrenByType = (
   storageXML: cheerio.Cheerio<cheerio.Element>,
 ) => storageXML.children().map((_, element: any) => {
   const dataInput = element.children && element.children[0];


### PR DESCRIPTION
 - a new context property for slideTransition to default this value at reveal library initialization
 - `data-transition=` at section level only defined if provided for the slide

 fixes WEB-203