### PR TITLE
Bugfix: WEB-1905 avoid rewriting URL of pages

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -237,7 +237,8 @@ ul.childpages-macro li {
 // Confluence space
 .confluence-space {
   img {
-    height: 48px;
-    width: 48px;
+    height: 20px;
+    width: 20px;
+    padding-bottom: 0;
   }
 }

--- a/src/cache/custom-http-cache.interceptor.ts
+++ b/src/cache/custom-http-cache.interceptor.ts
@@ -7,7 +7,7 @@ export default class CustomHttpCacheInterceptor extends CacheInterceptor {
     const isGetRequest = request.method === 'GET';
     const key = request.url;
 
-    if (!isGetRequest || request.query.cache === 'no-cache') {
+    if (!isGetRequest || request.query.cache === 'no-cache' || request.query.status === 'draft') {
       return undefined;
     }
     if (request.query.cache === 'clear-cache') {

--- a/src/proxy-page/steps/fixConfluenceSpace.ts
+++ b/src/proxy-page/steps/fixConfluenceSpace.ts
@@ -27,9 +27,16 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
   $('a').each((_, anchor) => {
     const confluenceSpaceRegex = new RegExp('^(.*?)(/wiki/spaces/)(.*)$');
     const href = anchor?.attribs?.href ?? '';
-    const isConfluenceSpace = confluenceSpaceRegex.test(href);
+    // retrieves the text value displayed by the link
+    const textLink = $(anchor).text() ?? '';
+    // this test that the value text looks also as a Confluence space URL
+    const isUrlLink = confluenceSpaceRegex.test(textLink);
+    // links to pages are tagged with special attribute data-linked-resource-type='page'
+    const isPage = anchor?.attribs['data-linked-resource-type'] === 'page';
+    // only if it is not a Confluence page and the URL looks like an space will add the special className
+    const isConfluenceSpace = confluenceSpaceRegex.test(href) && isUrlLink && !isPage;
     if (isConfluenceSpace) {
-      $(anchor).replaceWith(`<a className="${confluenceSpaceClassList}" target="_blank" href="${href}">${href}</a>`);
+      $(anchor).replaceWith(`<a className="${confluenceSpaceClassList}" target="_blank" href="${href}">${textLink}</a>`);
     }
   });
 


### PR DESCRIPTION
- exclude pages from the fixConfluenceSpace step
- also avoid the step if the value of the link was set manually
- icons for the confluence spaces too big and resized to 20px
- disable cache for query status=draft so changes are displayed realtime

resolves WEB-1905