### PR TITLE
BugFix: WEB-1959 attachments API v2 for blogposts

### DIFF
--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -276,13 +276,24 @@ export class ConfluenceService {
     }
   }
 
-  async getAttachments(pageId: string): Promise<any> {
-    const results: AxiosResponse = await firstValueFrom(
-      this.http.get<Content>(
-        `/wiki/api/v2/pages/${pageId}/attachments`,
-      ),
-    );
-    return results.data?.results;
+  async getAttachments(type:string, pageId: string): Promise<any> {
+    // adjust the API endpoint in plural
+    // while type comes from the search in singular
+    const apiEndPoint = type === 'page' ? 'pages' : 'blogposts';
+    try {
+      const results: AxiosResponse = await firstValueFrom(
+        this.http.get<Content>(
+          `/wiki/api/v2/${apiEndPoint}/${pageId}/attachments`,
+        ),
+      );
+      this.logger.log(
+        `Retrieving attachments from ${type} ${pageId} via REST API v2`,
+      );
+      return results.data?.results;
+    } catch (err: any) {
+      this.logger.log(err, `error:getAttachments from page ${pageId}`);
+      throw new HttpException(`error:getAttachments > ${err}`, err.response.status);
+    }
   }
 
   async getSpecialAtlassianIcons(image?: string): Promise<any> {

--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -9,10 +9,16 @@ import { Version } from './context.interface';
 export class ContextService {
   private readonly logger = new Logger(ContextService.name);
 
+  // The Confluence space key
   private spaceKey = '';
 
+  // The unique page ID
   private pageId = '';
 
+  // Document type could be 'page' or 'blogpost'
+  private type = '';
+
+  // Theme between 'light' (default) and 'dark'
   private theme = '';
 
   private style = '';
@@ -60,7 +66,8 @@ export class ContextService {
   initPageContext(
     spaceKey: string,
     pageId: string,
-    theme?: string,
+    theme: string,
+    type?: string,
     style?: string,
     data?: Content,
     loadAsDocument = true, // eslint-disable-line default-param-last
@@ -69,6 +76,7 @@ export class ContextService {
     this.spaceKey = spaceKey;
     this.pageId = pageId;
     this.theme = theme;
+    this.type = type;
     this.style = style;
     const logger = new Logger(ContextService.name);
 
@@ -195,6 +203,14 @@ export class ContextService {
 
   getSpaceKey(): string {
     return this.spaceKey;
+  }
+
+  getType(): string {
+    return this.type;
+  }
+
+  setType(type: string): void {
+    this.type = type;
   }
 
   getTitle(): string {

--- a/src/proxy-api/dto/SearchQuery.ts
+++ b/src/proxy-api/dto/SearchQuery.ts
@@ -24,7 +24,7 @@ export default class SearchQueryDTO {
 
   @ApiPropertyOptional({
     required: false,
-    description: 'The type of page. Options are \'page\' or \'blogpage\'',
+    description: 'The type of page. Options are \'page\' or \'blogpost\'',
     example: 'blogpost',
   })
   @IsOptional()

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -70,7 +70,7 @@ export class ProxyApiService {
     const { data }: { data: SearchResults } = await this.confluence.Search(
       spaceKeys,
       query,
-      type,
+      type, // 'page' or 'blogpost'
       labels,
       maxResults,
       cursorResults,
@@ -86,8 +86,9 @@ export class ProxyApiService {
         context.initPageContext(
           spacekey,
           doc.content.id,
-          undefined,
-          undefined,
+          undefined, // theme
+          type, // 'page' or 'blogpost'
+          undefined, // data
           doc.content,
         );
         context.setHtmlBody(doc.content.body.view.value);
@@ -398,7 +399,7 @@ export class ProxyApiService {
     type: string,
   ): Promise<Partial<KonviwContent>> {
     const content: Content = await this.confluence.getPage(spaceKey, pageId);
-    this.context.initPageContext(spaceKey, pageId, null, type, content, false);
+    this.context.initPageContext(spaceKey, pageId, undefined, type, undefined, content, false);
     // TODO: check whether we could add the excerpt and image header image also to the API metadata
     // await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);
     const addJiraPromise = addJira(this.config, this.jira)(this.context);

--- a/src/proxy-api/steps/getExcerptAndHeaderImage.ts
+++ b/src/proxy-api/steps/getExcerptAndHeaderImage.ts
@@ -15,7 +15,7 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
   let blogImgSrc = context.getHeaderImage();
   if (blogImgSrc && !blogImgSrc.startsWith('http')) {
     // not a URL (image uploaded to Confluence)
-    const attachments = await confluence.getAttachments(context.getPageId());
+    const attachments = await confluence.getAttachments(context.getType(), context.getPageId());
     const blogImgAttachment = attachments.find((e) =>
     // find the attachment matching the UID got from the headerImage attribute
       e.fileId === blogImgSrc);
@@ -39,20 +39,20 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
   // defined in a page-properties section in a blog post
   // a macro page-properties with an image and blockquote inside will be used alternatively to define
   // both image and blockquote for the blog post
-  $(".plugin-tabmeta-details[data-macro-name='details']")
-    .first()
-    .each((_index: number, elementProperties: cheerio.Element) => {
-      const imgBlog = $(elementProperties).find('img');
-      const excerptBlog = $(elementProperties).find('blockquote');
-      if (!blogImgSrc) {
-        // header image has priority over page-proterties's image
-        blogImgSrc = imgBlog?.attr('src');
-        context.setHeaderImage(blogImgSrc);
-      }
-      if (context.getExcerpt() === '') {
-        context.setExcerpt(excerptBlog.text());
-      }
-    });
+  // $(".plugin-tabmeta-details[data-macro-name='details']")
+  //   .first()
+  //   .each((_index: number, elementProperties: cheerio.Element) => {
+  //     const imgBlog = $(elementProperties).find('img');
+  //     const excerptBlog = $(elementProperties).find('blockquote');
+  //     if (!blogImgSrc) {
+  //       // header image has priority over page-proterties's image
+  //       blogImgSrc = imgBlog?.attr('src');
+  //       context.setHeaderImage(blogImgSrc);
+  //     }
+  //     if (context.getExcerpt() === '') {
+  //       context.setExcerpt(excerptBlog.text());
+  //     }
+  //   });
 
   // if not excerpt at all then alternatively we take a summary of the body of the document
   if (context.getExcerpt() === '') {

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -92,9 +92,10 @@ export class ProxyPageService {
       spaceKey,
       pageId,
       theme,
+      type,
       style,
       content,
-      true,
+      true, // loadAsDocument
       view,
     );
     const addJiraPromise = addJira(this.config, this.jira)(this.context);

--- a/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
@@ -20,6 +20,7 @@ export default (context: ContextService, spaceKey: string, pageId: string, style
     spaceKey,
     pageId,
     'light',
+    'page', // default 'page' assuming slides not used for blogposts
     existSlideStyle ? valueSlideStyle : style,
     content,
     true,


### PR DESCRIPTION
- getAttachments function fixed to get attachments for pages and for blogposts because API v2 comes with different endpoints
- extend context.service.ts to store already the type of the document as the API v2 distinguish between pages and blogposts
- as per WEB-344 removed the old code used to load images and blockquote from page-properties macro

Resolves WEB-1959