### PR TITLE
Bugfix: WEB-1961 control content type attachments

### DIFF
--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -228,7 +228,7 @@ export interface Attachment {
   id: string,
   comment: string,
   version: {
-    number: 1,
+    number: number,
     message: string,
     minorEdit: boolean,
     authorId: string,

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -223,3 +223,25 @@ export interface ResultGlobalContainer {
   title: string;
   displayUrl: string;
 }
+
+export interface Attachment {
+  id: string,
+  comment: string,
+  version: {
+    number: 1,
+    message: string,
+    minorEdit: boolean,
+    authorId: string,
+    createdAt: string // date-time
+},
+  downloadLink: string,
+  mediaType: string,
+  title: string,
+  fileSize: number,
+  status: ContentStatusType,
+  pageId: number,
+  fileId: string,
+  mediaTypeDescription: string,
+  webuiLink: string,
+  _links: GenericLinks
+}

--- a/src/proxy-api/steps/getExcerptAndHeaderImage.ts
+++ b/src/proxy-api/steps/getExcerptAndHeaderImage.ts
@@ -15,13 +15,15 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
   let blogImgSrc = context.getHeaderImage();
   if (blogImgSrc && !blogImgSrc.startsWith('http')) {
     // not a URL (image uploaded to Confluence)
-    const attachments = await confluence.getAttachments(context.getType(), context.getPageId());
-    const blogImgAttachment = attachments.find((e) =>
-    // find the attachment matching the UID got from the headerImage attribute
-      e.fileId === blogImgSrc);
-    if (blogImgAttachment) {
-      blogImgSrc = `${webBasePath}/wiki${blogImgAttachment?.downloadLink}`;
-      context.setHeaderImage(blogImgSrc);
+    const attachments = await confluence.getAttachments(context.getPageId());
+    if (attachments) {
+      const blogImgAttachment = attachments.find((e) =>
+      // find the attachment matching the UID got from the headerImage attribute
+        e.fileId === blogImgSrc);
+      if (blogImgAttachment) {
+        blogImgSrc = `${webBasePath}/wiki${blogImgAttachment?.downloadLink}`;
+        context.setHeaderImage(blogImgSrc);
+      }
     }
   }
 


### PR DESCRIPTION
- adding types for api attachments results
- checking content type to call the rigth api for attachments
- better management of exceptions

resolves WEB-1961