### PR TITLE
feat: WEB-1894 Migrated getPage functionality into Confluence REST API v2

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,7 +100,7 @@ describe('addHeaderTitle', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should add the h1 title', () => {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,8 +99,7 @@ describe('addHeaderTitle', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should add the h1 title', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "konviw",
-  "version": "3.8.1",
+  "version": "3.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3990,6 +3990,29 @@
             "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
+        }
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.22.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+          "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.13.2",
     "css-select": "5.1.0",
+    "date-fns": "^2.30.0",
     "hbs": "4.2.0",
     "https-proxy-agent": "^5.0.1",
     "reflect-metadata": "0.1.13",

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -150,7 +150,7 @@ export interface ContentHistory {
   _links?: GenericLinks;
 }
 
-export interface Content {
+export interface Content extends ContentRestAPIv2 {
   [key: string]: any;
 
   id: string;
@@ -290,7 +290,7 @@ export type SpaceContent = {
 
 export type LabelsContent = LabelsArray;
 
-export type PropertiesContent = Properties[];
+export type PropertiesContent = Properties;
 
 export type AuthorContent = {
   type: string;
@@ -318,7 +318,7 @@ export type VersionAuthorContent = {
   _links: GenericLinks;
 };
 
-export type ConfluenceRestAPIv2PageContent = {
+export type ContentRestAPIv2 = {
   [key: string]: any;
   pageContent: PageContent;
   spaceContent: SpaceContent;

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -288,10 +288,6 @@ export type SpaceContent = {
   createdAt: string;
 };
 
-export type LabelsContent = LabelsArray;
-
-export type PropertiesContent = Properties;
-
 export type AuthorContent = {
   type: string;
   accountId: string;
@@ -322,8 +318,8 @@ export type ContentRestAPIv2 = {
   [key: string]: any;
   pageContent: PageContent;
   spaceContent: SpaceContent;
-  labelsContent: LabelsContent;
-  propertiesContent: PropertiesContent;
+  labelsContent: LabelsArray;
+  propertiesContent: Properties;
   authorContent: AuthorContent;
   versionAuthorContent: VersionAuthorContent;
 };

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -245,3 +245,85 @@ export interface Attachment {
   webuiLink: string,
   _links: GenericLinks
 }
+
+export type Properties = {
+  [key: string]: {
+    value: string;
+    key: string;
+    id: string;
+    version: any;
+  }
+}
+
+export type PageContent = {
+  id: string;
+  version: {
+    number: number;
+    message: string;
+    minorEdit: boolean;
+    authorId: string;
+    createdAt: string;
+  },
+  parentType: string;
+  authorId: string;
+  title: string;
+  status: ContentStatusType;
+  body: { view: { value: string }, storage: { value: string } },
+  parentId: string;
+  spaceId: string;
+  createdAt: string;
+  position: number;
+  _links: GenericLinks;
+};
+
+export type SpaceContent = {
+  name: string;
+  key: string;
+  id: string;
+  type: string;
+  homepageId: string;
+  icon: string | null;
+  description: string | null;
+  status: string;
+  createdAt: string;
+};
+
+export type LabelsContent = LabelsArray;
+
+export type PropertiesContent = Properties[];
+
+export type AuthorContent = {
+  type: string;
+  accountId: string;
+  accountType: string;
+  email: string;
+  publicName: string;
+  profilePicture: Icon,
+  displayName: string;
+  isExternalCollaborator: boolean,
+  _expandable: GenericLinks;
+  _links: GenericLinks;
+};
+
+export type VersionAuthorContent = {
+  type: string;
+  accountId: string;
+  accountType: string;
+  email: string;
+  publicName: string;
+  profilePicture: Icon,
+  displayName: string;
+  isExternalCollaborator: boolean;
+  _expandable: GenericLinks;
+  _links: GenericLinks;
+};
+
+export type ConfluenceRestAPIv2PageContent = {
+  [key: string]: any;
+  pageContent: PageContent;
+  spaceContent: SpaceContent;
+  labelsContent: LabelsContent;
+  propertiesContent: PropertiesContent;
+  authorContent: AuthorContent;
+  versionAuthorContent: VersionAuthorContent;
+};

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -316,20 +316,19 @@ export class ConfluenceService {
 
   async getAttachments(pageId: string): Promise<Attachment[]> {
     // from API v2 we have to use first this API to identify the proper content from the pageID
-    const typeContent: AxiosResponse = await firstValueFrom(
+    const typeContentResponse: AxiosResponse = await firstValueFrom(
       this.http.post('/wiki/api/v2/content/convert-ids-to-types', { contentIds: [pageId] }),
     );
-    if (typeContent?.data.results[pageId]) {
-      // set the proper API endpoint based on the appropiate content
-      const apiEndPoint = typeContent?.data.results[pageId] === 'page' ? 'pages' : 'blogposts';
+    const contentType = this.getApiEndPoint(typeContentResponse, pageId);
+    if (contentType) {
       try {
         const results: AxiosResponse = await firstValueFrom(
-          this.http.get(`/wiki/api/v2/${apiEndPoint}/${pageId}/attachments`),
+          this.http.get(`/wiki/api/v2/${contentType}/${pageId}/attachments`),
         );
-        this.logger.log(`Retrieving attachments from ${typeContent?.data.results[pageId]} ${pageId} via REST API v2`);
+        this.logger.log(`Retrieving attachments from ${contentType} ${pageId} via REST API v2`);
         return results.data?.results;
       } catch (err: any) {
-        this.logger.log(err, `error:getAttachments from ${typeContent?.data.results[pageId]} ${pageId}`);
+        this.logger.log(err, `error:getAttachments from ${contentType} ${pageId}`);
         return undefined;
       }
     }

--- a/src/context/context.helpers.ts
+++ b/src/context/context.helpers.ts
@@ -1,45 +1,16 @@
+import { formatDistance } from 'date-fns';
 import { Content } from '../confluence/confluence.interface';
 import { ApiVersion } from './context.interface';
 
-/*
- * Get the amount of time from now for a date
- * (c) 2019 Chris Ferdinandi, MIT License
- * https://gomakethings.com/a-vanilla-js-alternative-to-the-moment.js-timefromnow-method/
- * @param  {String} The date to get the time from now for
- * @return {String} The time from now data
- */
-export const timeFromNow = (TimeToConvert: string): string => {
-  // Get timestamps
-  const unixTime = new Date(TimeToConvert).getTime();
-  if (!unixTime) return '';
-  const now = new Date().getTime();
-  // Calculate difference
-  let difference = unixTime / 1000 - now / 1000;
-  // Convert difference to absolute
-  difference = Math.abs(difference);
-  let unitOfTime = '';
-  let time = 0;
-  // Calculate time unit
-  if (difference / (60 * 60 * 24 * 365) > 1) {
-    unitOfTime = 'years';
-    time = Math.floor(difference / (60 * 60 * 24 * 365));
-  } else if (difference / (60 * 60 * 24 * 45) > 1) {
-    unitOfTime = 'months';
-    time = Math.floor(difference / (60 * 60 * 24 * 45));
-  } else if (difference / (60 * 60 * 24) > 1) {
-    unitOfTime = 'days';
-    time = Math.floor(difference / (60 * 60 * 24));
-  } else if (difference / (60 * 60) > 1) {
-    unitOfTime = 'hours';
-    time = Math.floor(difference / (60 * 60));
-  } else {
-    unitOfTime = 'seconds';
-    time = Math.floor(difference);
-  }
-  // Return time from now data
-  return `${time} ${unitOfTime} ago`;
-};
+export const timeFromNow = (TimeToConvert: string): string =>
+  formatDistance(new Date(TimeToConvert), new Date(), { addSuffix: true });
 
+/**
+ * ### Content Migration Helper
+ * The following list of features is used in the migration process.
+ * After its completion, please remove the function and apply the code ultimately at the website level.
+ * Anonymous functions are helpful in the fact that we collect data and get from it only within the api version, which avoids errors.
+ */
 export const setTitleHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.title,

--- a/src/context/context.helpers.ts
+++ b/src/context/context.helpers.ts
@@ -1,4 +1,5 @@
 import { Content } from '../confluence/confluence.interface';
+import { ApiVersion } from './context.interface';
 
 /*
  * Get the amount of time from now for a date
@@ -39,7 +40,7 @@ export const timeFromNow = (TimeToConvert: string): string => {
   return `${time} ${unitOfTime} ago`;
 };
 
-export const setTitleHelper = (data: Content, apiVersion: string) => {
+export const setTitleHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.title,
     v2: () => data.pageContent.title,
@@ -47,7 +48,7 @@ export const setTitleHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setSpaceKeyHelper = (data: Content, apiVersion: string) => {
+export const setSpaceKeyHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => {
       const [,,,, key] = data._expandable.space.split('/');
@@ -58,7 +59,7 @@ export const setSpaceKeyHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setHtmlBodyHelper = (data: Content, apiVersion: string) => {
+export const setHtmlBodyHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.body.view.value,
     v2: () => data.pageContent.body.view.value,
@@ -66,15 +67,15 @@ export const setHtmlBodyHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setBodyStorageHelper = (data: Content, apiVersion: string) => {
+export const setBodyStorageHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
-    v1: () => data.body?.storage.value,
+    v1: () => data.body?.storage?.value,
     v2: () => data.pageContent?.body?.storage?.value,
   };
   return config[apiVersion]();
 };
 
-export const setAuthorHelper = (data: Content, apiVersion: string) => {
+export const setAuthorHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.history.createdBy?.displayName,
     v2: () => data.authorContent.publicName,
@@ -82,7 +83,7 @@ export const setAuthorHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setEmailHelper = (data: Content, apiVersion: string) => {
+export const setEmailHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.history.createdBy?.email,
     v2: () => data.authorContent.email,
@@ -90,7 +91,7 @@ export const setEmailHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setAvatarHelper = (baseHost: string, basePath: string, data: Content, apiVersion: string) => {
+export const setAvatarHelper = (baseHost: string, basePath: string, data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => `${baseHost}${basePath}/${data.history.createdBy?.profilePicture.path.replace(
       /^\/wiki/,
@@ -104,7 +105,7 @@ export const setAvatarHelper = (baseHost: string, basePath: string, data: Conten
   return config[apiVersion]();
 };
 
-export const setWhenHelper = (data: Content, apiVersion: string) => {
+export const setWhenHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.history.createdDate,
     v2: () => data.pageContent.createdAt,
@@ -112,7 +113,7 @@ export const setWhenHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setLabelsHelper = (data: Content, apiVersion: string) => {
+export const setLabelsHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.metadata.labels.results,
     v2: () => data.labelsContent.results,
@@ -120,7 +121,7 @@ export const setLabelsHelper = (data: Content, apiVersion: string) => {
   return config[apiVersion]();
 };
 
-export const setCreatedVersionHelper = (data: Content, apiVersion: string, getAvatar: () => string) => {
+export const setCreatedVersionHelper = (data: Content, apiVersion: ApiVersion, getAvatar: () => string) => {
   const config = {
     v1: () => ({
       when: data.history.createdDate,
@@ -147,7 +148,7 @@ export const setCreatedVersionHelper = (data: Content, apiVersion: string, getAv
   };
 };
 
-export const setLastVersionHelper = (baseHost: string, basePath: string, data: Content, apiVersion: string) => {
+export const setLastVersionHelper = (baseHost: string, basePath: string, data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => ({
       versionNumber: data.version.number,
@@ -179,7 +180,7 @@ export const setLastVersionHelper = (baseHost: string, basePath: string, data: C
   return config[apiVersion]();
 };
 
-export const contentAppearancePublishedHelper = (data: Content, apiVersion: string) => {
+export const contentAppearancePublishedHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.metadata?.properties['content-appearance-published']?.value,
     v2: () => data.propertiesContent['content-appearance-published']?.value,
@@ -187,7 +188,7 @@ export const contentAppearancePublishedHelper = (data: Content, apiVersion: stri
   return config[apiVersion]();
 };
 
-export const coverPictureIdPublishedHelper = (data: Content, apiVersion: string) => {
+export const coverPictureIdPublishedHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.metadata?.properties['cover-picture-id-published']?.value,
     v2: () => data.propertiesContent['cover-picture-id-published']?.value,
@@ -195,7 +196,7 @@ export const coverPictureIdPublishedHelper = (data: Content, apiVersion: string)
   return config[apiVersion]();
 };
 
-export const emojiTitlePublishedHelper = (data: Content, apiVersion: string) => {
+export const emojiTitlePublishedHelper = (data: Content, apiVersion: ApiVersion) => {
   const config = {
     v1: () => data.metadata?.properties['emoji-title-published']?.value,
     v2: () => data.propertiesContent['emoji-title-published']?.value,

--- a/src/context/context.helpers.ts
+++ b/src/context/context.helpers.ts
@@ -1,0 +1,204 @@
+import { Content } from '../confluence/confluence.interface';
+
+/*
+ * Get the amount of time from now for a date
+ * (c) 2019 Chris Ferdinandi, MIT License
+ * https://gomakethings.com/a-vanilla-js-alternative-to-the-moment.js-timefromnow-method/
+ * @param  {String} The date to get the time from now for
+ * @return {String} The time from now data
+ */
+export const timeFromNow = (TimeToConvert: string): string => {
+  // Get timestamps
+  const unixTime = new Date(TimeToConvert).getTime();
+  if (!unixTime) return '';
+  const now = new Date().getTime();
+  // Calculate difference
+  let difference = unixTime / 1000 - now / 1000;
+  // Convert difference to absolute
+  difference = Math.abs(difference);
+  let unitOfTime = '';
+  let time = 0;
+  // Calculate time unit
+  if (difference / (60 * 60 * 24 * 365) > 1) {
+    unitOfTime = 'years';
+    time = Math.floor(difference / (60 * 60 * 24 * 365));
+  } else if (difference / (60 * 60 * 24 * 45) > 1) {
+    unitOfTime = 'months';
+    time = Math.floor(difference / (60 * 60 * 24 * 45));
+  } else if (difference / (60 * 60 * 24) > 1) {
+    unitOfTime = 'days';
+    time = Math.floor(difference / (60 * 60 * 24));
+  } else if (difference / (60 * 60) > 1) {
+    unitOfTime = 'hours';
+    time = Math.floor(difference / (60 * 60));
+  } else {
+    unitOfTime = 'seconds';
+    time = Math.floor(difference);
+  }
+  // Return time from now data
+  return `${time} ${unitOfTime} ago`;
+};
+
+export const setTitleHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.title,
+    v2: () => data.pageContent.title,
+  };
+  return config[apiVersion]();
+};
+
+export const setSpaceKeyHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => {
+      const [,,,, key] = data._expandable.space.split('/');
+      return key;
+    },
+    v2: () => data.spaceContent.key,
+  };
+  return config[apiVersion]();
+};
+
+export const setHtmlBodyHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.body.view.value,
+    v2: () => data.pageContent.body.view.value,
+  };
+  return config[apiVersion]();
+};
+
+export const setBodyStorageHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.body?.storage.value,
+    v2: () => data.pageContent?.body?.storage?.value,
+  };
+  return config[apiVersion]();
+};
+
+export const setAuthorHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.history.createdBy?.displayName,
+    v2: () => data.authorContent.publicName,
+  };
+  return config[apiVersion]();
+};
+
+export const setEmailHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.history.createdBy?.email,
+    v2: () => data.authorContent.email,
+  };
+  return config[apiVersion]();
+};
+
+export const setAvatarHelper = (baseHost: string, basePath: string, data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => `${baseHost}${basePath}/${data.history.createdBy?.profilePicture.path.replace(
+      /^\/wiki/,
+      'wiki',
+    )}`,
+    v2: () => `${baseHost}${basePath}/${data.authorContent.profilePicture.path.replace(
+      /^\/wiki/,
+      'wiki',
+    )}`,
+  };
+  return config[apiVersion]();
+};
+
+export const setWhenHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.history.createdDate,
+    v2: () => data.pageContent.createdAt,
+  };
+  return config[apiVersion]();
+};
+
+export const setLabelsHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.metadata.labels.results,
+    v2: () => data.labelsContent.results,
+  };
+  return config[apiVersion]();
+};
+
+export const setCreatedVersionHelper = (data: Content, apiVersion: string, getAvatar: () => string) => {
+  const config = {
+    v1: () => ({
+      when: data.history.createdDate,
+      friendlyWhen: timeFromNow(data.history.createdDate),
+      modificationBy: {
+        displayName: data.history.createdBy?.displayName,
+        email: data.history.createdBy?.email,
+        profilePicture: getAvatar(),
+      },
+    }),
+    v2: () => ({
+      when: data.pageContent.createdAt,
+      friendlyWhen: timeFromNow(data.pageContent.createdAt),
+      modificationBy: {
+        displayName: data.authorContent.publicName,
+        email: data.authorContent.email,
+        profilePicture: getAvatar(),
+      },
+    }),
+  };
+  return {
+    versionNumber: 1,
+    ...config[apiVersion](),
+  };
+};
+
+export const setLastVersionHelper = (baseHost: string, basePath: string, data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => ({
+      versionNumber: data.version.number,
+      when: data.version.when,
+      friendlyWhen: timeFromNow(data.version.when),
+      modificationBy: {
+        displayName: data.version.by.publicName,
+        email: data.version.by.email,
+        profilePicture: `${baseHost}${basePath}/${data.version.by.profilePicture?.path.replace(
+          /^\/wiki/,
+          'wiki',
+        )}`,
+      },
+    }),
+    v2: () => ({
+      versionNumber: data.pageContent.version.number,
+      when: data.pageContent.version.createdAt,
+      friendlyWhen: timeFromNow(data.pageContent.version.createdAt),
+      modificationBy: {
+        displayName: data.versionAuthorContent.publicName,
+        email: data.versionAuthorContent.email,
+        profilePicture: `${baseHost}${basePath}/${data.versionAuthorContent.profilePicture?.path.replace(
+          /^\/wiki/,
+          'wiki',
+        )}`,
+      },
+    }),
+  };
+  return config[apiVersion]();
+};
+
+export const contentAppearancePublishedHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.metadata?.properties['content-appearance-published']?.value,
+    v2: () => data.propertiesContent['content-appearance-published']?.value,
+  };
+  return config[apiVersion]();
+};
+
+export const coverPictureIdPublishedHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.metadata?.properties['cover-picture-id-published']?.value,
+    v2: () => data.propertiesContent['cover-picture-id-published']?.value,
+  };
+  return config[apiVersion]();
+};
+
+export const emojiTitlePublishedHelper = (data: Content, apiVersion: string) => {
+  const config = {
+    v1: () => data.metadata?.properties['emoji-title-published']?.value,
+    v2: () => data.propertiesContent['emoji-title-published']?.value,
+  };
+  return config[apiVersion]();
+};

--- a/src/context/context.interface.ts
+++ b/src/context/context.interface.ts
@@ -10,3 +10,5 @@ export interface User {
   email: string;
   profilePicture: string;
 }
+
+export type ApiVersion = 'v1' | 'v2';

--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -3,7 +3,7 @@ import * as cheerio from 'cheerio';
 import { performance, PerformanceObserver } from 'perf_hooks';
 import { ConfigService } from '@nestjs/config';
 import { Content, Label } from '../confluence/confluence.interface';
-import { Version } from './context.interface';
+import { ApiVersion, Version } from './context.interface';
 import {
   contentAppearancePublishedHelper,
   coverPictureIdPublishedHelper,
@@ -44,7 +44,7 @@ export class ContextService {
 
   private view = '';
 
-  private apiVersion: 'v1' | 'v2';
+  private apiVersion: ApiVersion;
 
   private cheerioBody = cheerio.load('html');
 
@@ -85,7 +85,7 @@ export class ContextService {
   constructor(private config: ConfigService) {}
 
   initPageContext(
-    apiVersion: 'v1' | 'v2',
+    apiVersion: ApiVersion,
     spaceKey: string,
     pageId: string,
     theme: string,
@@ -391,11 +391,11 @@ export class ContextService {
     return this.headerEmoji;
   }
 
-  setApiVersion(version: 'v1' | 'v2'): void {
+  setApiVersion(version: ApiVersion): void {
     this.apiVersion = version;
   }
 
-  getApiVersion(): 'v1' | 'v2' {
+  getApiVersion(): ApiVersion {
     return this.apiVersion;
   }
 }

--- a/src/context/context.service.ts
+++ b/src/context/context.service.ts
@@ -4,6 +4,23 @@ import { performance, PerformanceObserver } from 'perf_hooks';
 import { ConfigService } from '@nestjs/config';
 import { Content, Label } from '../confluence/confluence.interface';
 import { Version } from './context.interface';
+import {
+  contentAppearancePublishedHelper,
+  coverPictureIdPublishedHelper,
+  emojiTitlePublishedHelper,
+  setAuthorHelper,
+  setAvatarHelper,
+  setCreatedVersionHelper,
+  setEmailHelper,
+  setBodyStorageHelper,
+  setLabelsHelper,
+  setLastVersionHelper,
+  setSpaceKeyHelper,
+  setTitleHelper,
+  setWhenHelper,
+  timeFromNow,
+  setHtmlBodyHelper,
+} from './context.helpers';
 
 @Injectable()
 export class ContextService {
@@ -27,7 +44,11 @@ export class ContextService {
 
   private view = '';
 
+  private apiVersion: 'v1' | 'v2';
+
   private cheerioBody = cheerio.load('html');
+
+  private bodyStorage = '';
 
   private title = '';
 
@@ -63,115 +84,8 @@ export class ContextService {
 
   constructor(private config: ConfigService) {}
 
-  initPageContextRestAPIv2(
-    spaceKey: string,
-    pageId: string,
-    theme: string,
-    type?: string,
-    style?: string,
-    data?: Content,
-    loadAsDocument = true, // eslint-disable-line default-param-last
-    view?: string,
-  ) {
-    this.spaceKey = spaceKey;
-    this.pageId = pageId;
-    this.theme = theme;
-    this.type = type;
-    this.style = style;
-    const logger = new Logger(ContextService.name);
-
-    // Activate the observer in development
-    if (this.config.get('env').toString() === 'development') {
-      this.observer = new PerformanceObserver((list) => {
-        const entry = list.getEntries()[0];
-        logger.log(`Time for [${entry.name}] = ${entry.duration}ms`);
-      });
-      this.observer.observe({ entryTypes: ['measure'], buffered: false });
-    }
-
-    if (view) {
-      this.setView(view);
-    }
-    if (data) {
-      const baseHost = this.config.get('web.baseHost');
-      const basePath = this.config.get('web.basePath');
-
-      this.setTitle(data.pageContent.title);
-      this.spaceKey = data.spaceContent.key;
-      this.setHtmlBody(data.pageContent.body.view.value, loadAsDocument);
-      this.setAuthor(data.authorContent.publicName);
-      this.setEmail(data.authorContent.email);
-      this.setAvatar(
-        `${baseHost}${basePath}/${data.authorContent.profilePicture.path.replace(
-          /^\/wiki/,
-          'wiki',
-        )}`,
-      );
-      this.setWhen(data.pageContent.createdAt);
-      this.setLabels(data.labelsContent.results);
-
-      const createdBy: Version = {
-        versionNumber: 1,
-        when: data.pageContent.createdAt,
-        friendlyWhen: timeFromNow(data.pageContent.createdAt),
-        modificationBy: {
-          displayName: data.authorContent.publicName,
-          email: data.authorContent.email,
-          profilePicture: this.getAvatar(),
-        },
-      };
-      this.setCreatedVersion(createdBy);
-
-      const modifiedBy: Version = {
-        versionNumber: data.pageContent.version.number,
-        when: data.pageContent.version.createdAt,
-        friendlyWhen: timeFromNow(data.pageContent.version.createdAt),
-        modificationBy: {
-          displayName: data.versionAuthorContent.publicName,
-          email: data.versionAuthorContent.email,
-          profilePicture: `${baseHost}${basePath}/${data.versionAuthorContent.profilePicture?.path.replace(
-            /^\/wiki/,
-            'wiki',
-          )}`,
-        },
-      };
-      this.setLastVersion(modifiedBy);
-
-      if (data.propertiesContent['content-appearance-published']?.value === 'full-width') {
-        this.setFullWidth(true);
-      } else {
-        this.setFullWidth(false);
-      }
-
-      // retrieve the header image published and set in context
-      if (data.propertiesContent['cover-picture-id-published']) {
-        this.setHeaderImage(
-          JSON.parse(
-            data.propertiesContent['cover-picture-id-published'].value,
-          ).id,
-        );
-        logger.log(
-          `GET cover-picture-id-published to set context 'headerImage' to ${this.getHeaderImage()}`,
-        );
-      } else {
-        this.setHeaderImage('');
-      }
-
-      // retrieve the header emoji published and set in context
-      if (data.propertiesContent['emoji-title-published']) {
-        this.setHeaderEmoji(
-          data.propertiesContent['emoji-title-published'].value,
-        );
-        logger.log(
-          `GET emoji-title-published to set context 'headerEmoji' to ${this.getHeaderEmoji()}`,
-        );
-      } else {
-        this.setHeaderEmoji('');
-      }
-    }
-  }
-
   initPageContext(
+    apiVersion: 'v1' | 'v2',
     spaceKey: string,
     pageId: string,
     theme: string,
@@ -197,6 +111,8 @@ export class ContextService {
       this.observer.observe({ entryTypes: ['measure'], buffered: false });
     }
 
+    this.setApiVersion(apiVersion);
+
     if (view) {
       this.setView(view);
     }
@@ -204,64 +120,29 @@ export class ContextService {
       const baseHost = this.config.get('web.baseHost');
       const basePath = this.config.get('web.basePath');
 
-      this.setTitle(data.title);
-      [,,,, this.spaceKey] = data._expandable.space.split('/');
-      this.setHtmlBody(data.body.view.value, loadAsDocument);
-      this.setAuthor(data.history.createdBy?.displayName);
-      this.setEmail(data.history.createdBy?.email);
-      this.setAvatar(
-        `${baseHost}${basePath}/${data.history.createdBy?.profilePicture.path.replace(
-          /^\/wiki/,
-          'wiki',
-        )}`,
-      );
-      this.setWhen(data.history.createdDate);
-      this.setLabels(data.metadata.labels.results);
+      this.setTitle(setTitleHelper(data, apiVersion));
+      this.spaceKey = setSpaceKeyHelper(data, apiVersion);
+      this.setHtmlBody(setHtmlBodyHelper(data, apiVersion), loadAsDocument);
+      this.setBodyStorage(setBodyStorageHelper(data, apiVersion));
+      this.setAuthor(setAuthorHelper(data, apiVersion));
+      this.setEmail(setEmailHelper(data, apiVersion));
+      this.setAvatar(setAvatarHelper(baseHost, basePath, data, apiVersion));
+      this.setWhen(setWhenHelper(data, apiVersion));
+      this.setLabels(setLabelsHelper(data, apiVersion));
+      this.setCreatedVersion(setCreatedVersionHelper(data, apiVersion, () => this.getAvatar()));
+      this.setLastVersion(setLastVersionHelper(baseHost, basePath, data, apiVersion));
 
-      const createdBy: Version = {
-        versionNumber: 1,
-        when: data.history.createdDate,
-        friendlyWhen: timeFromNow(data.history.createdDate),
-        modificationBy: {
-          displayName: data.history.createdBy?.displayName,
-          email: data.history.createdBy?.email,
-          profilePicture: this.getAvatar(),
-        },
-      };
-      this.setCreatedVersion(createdBy);
-
-      const modifiedBy: Version = {
-        versionNumber: data.version.number,
-        when: data.version.when,
-        friendlyWhen: timeFromNow(data.version.when),
-        modificationBy: {
-          displayName: data.version.by.publicName,
-          email: data.version.by.email,
-          profilePicture: `${baseHost}${basePath}/${data.version.by.profilePicture?.path.replace(
-            /^\/wiki/,
-            'wiki',
-          )}`,
-        },
-      };
-      this.setLastVersion(modifiedBy);
-
-      if (
-        data.metadata?.properties['content-appearance-published']
-        && data.metadata?.properties['content-appearance-published'].value
-          === 'full-width'
-      ) {
+      const contentAppearancePublished = contentAppearancePublishedHelper(data, apiVersion);
+      if (contentAppearancePublished === 'full-width') {
         this.setFullWidth(true);
       } else {
         this.setFullWidth(false);
       }
 
       // retrieve the header image published and set in context
-      if (data.metadata?.properties['cover-picture-id-published']) {
-        this.setHeaderImage(
-          JSON.parse(
-            data.metadata?.properties['cover-picture-id-published'].value,
-          ).id,
-        );
+      const coverPictureIdPublished = coverPictureIdPublishedHelper(data, apiVersion);
+      if (coverPictureIdPublished) {
+        this.setHeaderImage(JSON.parse(coverPictureIdPublished).id);
         logger.log(
           `GET cover-picture-id-published to set context 'headerImage' to ${this.getHeaderImage()}`,
         );
@@ -270,10 +151,9 @@ export class ContextService {
       }
 
       // retrieve the header emoji published and set in context
-      if (data.metadata?.properties['emoji-title-published']) {
-        this.setHeaderEmoji(
-          data.metadata?.properties['emoji-title-published'].value,
-        );
+      const emojiTitlePublished = emojiTitlePublishedHelper(data, apiVersion);
+      if (emojiTitlePublished) {
+        this.setHeaderEmoji(emojiTitlePublished);
         logger.log(
           `GET emoji-title-published to set context 'headerEmoji' to ${this.getHeaderEmoji()}`,
         );
@@ -351,6 +231,14 @@ export class ContextService {
 
   getHtmlBody(): string {
     return this.getCheerioBody().html();
+  }
+
+  setBodyStorage(body: string) {
+    this.bodyStorage = body;
+  }
+
+  getBodyStorage(): string {
+    return this.bodyStorage;
   }
 
   getHtmlInnerBody(): string {
@@ -502,47 +390,12 @@ export class ContextService {
   getHeaderEmoji(): string {
     return this.headerEmoji;
   }
-}
 
-/*
- * Get the amount of time from now for a date
- * (c) 2019 Chris Ferdinandi, MIT License
- * https://gomakethings.com/a-vanilla-js-alternative-to-the-moment.js-timefromnow-method/
- * @param  {String} The date to get the time from now for
- * @return {String} The time from now data
- */
-function timeFromNow(TimeToConvert: string): string {
-  // Get timestamps
-  const unixTime = new Date(TimeToConvert).getTime();
-  if (!unixTime) return '';
-  const now = new Date().getTime();
-
-  // Calculate difference
-  let difference = unixTime / 1000 - now / 1000;
-
-  // Convert difference to absolute
-  difference = Math.abs(difference);
-  let unitOfTime = '';
-  let time = 0;
-
-  // Calculate time unit
-  if (difference / (60 * 60 * 24 * 365) > 1) {
-    unitOfTime = 'years';
-    time = Math.floor(difference / (60 * 60 * 24 * 365));
-  } else if (difference / (60 * 60 * 24 * 45) > 1) {
-    unitOfTime = 'months';
-    time = Math.floor(difference / (60 * 60 * 24 * 45));
-  } else if (difference / (60 * 60 * 24) > 1) {
-    unitOfTime = 'days';
-    time = Math.floor(difference / (60 * 60 * 24));
-  } else if (difference / (60 * 60) > 1) {
-    unitOfTime = 'hours';
-    time = Math.floor(difference / (60 * 60));
-  } else {
-    unitOfTime = 'seconds';
-    time = Math.floor(difference);
+  setApiVersion(version: 'v1' | 'v2'): void {
+    this.apiVersion = version;
   }
 
-  // Return time from now data
-  return `${time} ${unitOfTime} ago`;
+  getApiVersion(): 'v1' | 'v2' {
+    return this.apiVersion;
+  }
 }

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -5,7 +5,7 @@ import { ContextService } from '../context/context.service';
 import {
   SearchResults,
   ResultsContent,
-  ConfluenceRestAPIv2PageContent,
+  Content,
 } from '../confluence/confluence.interface';
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
@@ -478,8 +478,8 @@ export class ProxyApiService {
     pageId: string,
     type: string,
   ): Promise<Partial<KonviwContent>> {
-    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(spaceKey, pageId);
-    this.context.initPageContext(spaceKey, pageId, undefined, type, undefined, content, false);
+    const content: Content = await this.confluence.getPage(spaceKey, pageId);
+    this.context.initPageContextRestAPIv2(spaceKey, pageId, undefined, type, undefined, content, false);
     // TODO: check whether we could add the excerpt and image header image also to the API metadata
     // await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);
     const addJiraPromise = addJira(this.config, this.jira)(this.context);

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -83,6 +83,7 @@ export class ProxyApiService {
         const spacekey = doc.resultGlobalContainer.displayUrl.split('/')[2];
         const context = new ContextService(this.config);
         context.initPageContext(
+          'v1',
           spacekey,
           doc.content.id,
           undefined, // theme
@@ -479,7 +480,7 @@ export class ProxyApiService {
     type: string,
   ): Promise<Partial<KonviwContent>> {
     const content: Content = await this.confluence.getPage(spaceKey, pageId);
-    this.context.initPageContextRestAPIv2(spaceKey, pageId, undefined, type, undefined, content, false);
+    this.context.initPageContext('v2', spaceKey, pageId, undefined, type, undefined, content, false);
     // TODO: check whether we could add the excerpt and image header image also to the API metadata
     // await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);
     const addJiraPromise = addJira(this.config, this.jira)(this.context);

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -3,9 +3,9 @@ import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import { ContextService } from '../context/context.service';
 import {
-  Content,
   SearchResults,
   ResultsContent,
+  ConfluenceRestAPIv2PageContent,
 } from '../confluence/confluence.interface';
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
@@ -478,7 +478,7 @@ export class ProxyApiService {
     pageId: string,
     type: string,
   ): Promise<Partial<KonviwContent>> {
-    const content: Content = await this.confluence.getPage(spaceKey, pageId);
+    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(spaceKey, pageId);
     this.context.initPageContext(spaceKey, pageId, undefined, type, undefined, content, false);
     // TODO: check whether we could add the excerpt and image header image also to the API metadata
     // await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -5,7 +5,7 @@ import getExcerptAndHeaderImage from '../proxy-api/steps/getExcerptAndHeaderImag
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
 import { ContextService } from '../context/context.service';
-import { Content } from '../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../confluence/confluence.interface';
 import delUnnecessaryCode from './steps/delUnnecessaryCode';
 import fixLinks from './steps/fixLinks';
 import fixEmojis from './steps/fixEmojis';
@@ -83,7 +83,7 @@ export class ProxyPageService {
     view: string,
     status: string,
   ): Promise<string> {
-    const content: Content = await this.confluence.getPage(
+    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(
       spaceKey,
       pageId,
       version,
@@ -167,7 +167,7 @@ export class ProxyPageService {
     style: string,
     status: string,
   ): Promise<string> {
-    const content: Content = await this.confluence.getPage(spaceKey, pageId, version, status);
+    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(spaceKey, pageId, version, status);
     addSlideContextByStrategy(
       this.context,
       spaceKey,

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -5,7 +5,7 @@ import getExcerptAndHeaderImage from '../proxy-api/steps/getExcerptAndHeaderImag
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
 import { ContextService } from '../context/context.service';
-import { ConfluenceRestAPIv2PageContent } from '../confluence/confluence.interface';
+import { Content } from '../confluence/confluence.interface';
 import delUnnecessaryCode from './steps/delUnnecessaryCode';
 import fixLinks from './steps/fixLinks';
 import fixEmojis from './steps/fixEmojis';
@@ -83,13 +83,13 @@ export class ProxyPageService {
     view: string,
     status: string,
   ): Promise<string> {
-    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(
+    const content: Content = await this.confluence.getPage(
       spaceKey,
       pageId,
       version,
       status,
     );
-    this.context.initPageContext(
+    this.context.initPageContextRestAPIv2(
       spaceKey,
       pageId,
       theme,
@@ -167,7 +167,7 @@ export class ProxyPageService {
     style: string,
     status: string,
   ): Promise<string> {
-    const content: ConfluenceRestAPIv2PageContent = await this.confluence.getPage(spaceKey, pageId, version, status);
+    const content: Content = await this.confluence.getPage(spaceKey, pageId, version, status);
     addSlideContextByStrategy(
       this.context,
       spaceKey,

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -89,7 +89,8 @@ export class ProxyPageService {
       version,
       status,
     );
-    this.context.initPageContextRestAPIv2(
+    this.context.initPageContext(
+      'v2',
       spaceKey,
       pageId,
       theme,
@@ -120,7 +121,7 @@ export class ProxyPageService {
     fixCode()(this.context);
     fixFrameAllowFullscreen()(this.context);
     fixImageSize()(this.context);
-    fixCaptionImage(content)(this.context);
+    fixCaptionImage()(this.context);
     fixColGroupWidth()(this.context);
     if (contextType.includes('blog')) {
       await addHeaderBlog()(this.context);
@@ -190,14 +191,14 @@ export class ProxyPageService {
     fixEmptyLineIncludePage()(this.context);
     fixRoadmap(this.config)(this.context);
     fixImageSize()(this.context);
-    fixCaptionImage(content)(this.context);
+    fixCaptionImage()(this.context);
     fixFrameAllowFullscreen()(this.context);
     fixSVG(this.config)(this.context);
     fixTableBackground()(this.context);
     addTableResponsive()(this.context);
     delUnnecessaryCode()(this.context);
     await addJiraPromise;
-    addSlideTypeByStrategy(content, this.config)(this.context);
+    addSlideTypeByStrategy(this.config)(this.context);
     addSlidesJS(this.config)(this.context);
     addMessageLastSlide()(this.context);
     addWebStatsTracker(this.config)(this.context);

--- a/src/proxy-page/steps/addMessageLastSlide.ts
+++ b/src/proxy-page/steps/addMessageLastSlide.ts
@@ -13,12 +13,9 @@ export default (): Step => (context: ContextService): void => {
       function updateMessageVisibility() {
         const lastSlideIndex = Reveal.getHorizontalSlides().length - 1;
         const isLastSlide = Reveal.getIndices().h === lastSlideIndex;
-        console.log(lastSlideIndex,isLastSlide);
-        console.log(Reveal.getIndices().h);
         if (isLastSlide){
           document.querySelector('.message').style.display = 'block';
-        }
-        else{
+        } else{
           document.querySelector('.message').style.display = 'none';
         }
       }

--- a/src/proxy-page/steps/addNewSlides.ts
+++ b/src/proxy-page/steps/addNewSlides.ts
@@ -1,11 +1,10 @@
 import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import { getAttributesFromChildren, getObjectFromStorageXMLForPageProperties } from '../utils/macroSlide';
 
-export default (config: ConfigService, content: Content): Step => (context: ContextService): void => {
+export default (config: ConfigService): Step => (context: ContextService): void => {
   context.setPerfMark('addNewSlides');
 
   const commonUnexpectedExpression = [
@@ -87,7 +86,7 @@ export default (config: ConfigService, content: Content): Step => (context: Cont
   // Div with class conf-macro and property slide (Confluence macro "slide") is framing the sections for each slide
   $(".conf-macro[data-macro-name='slide']").each(
     (_index: number, slideProperties: cheerio.Element) => {
-      const storageXML = getObjectFromStorageXMLForPageProperties(slideProperties, content);
+      const storageXML = getObjectFromStorageXMLForPageProperties(slideProperties, context);
       const { options } = getAttributesFromChildren(storageXML);
       const {
         slideBackgroundAttachment, slideType, slideTransition, slideParagraphAnimation,

--- a/src/proxy-page/steps/addNewSlides.ts
+++ b/src/proxy-page/steps/addNewSlides.ts
@@ -1,11 +1,11 @@
 import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
-import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
+import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import { getAttributesFromChildren, getObjectFromStorageXMLForPageProperties } from '../utils/macroSlide';
 
-export default (config: ConfigService, content: ConfluenceRestAPIv2PageContent): Step => (context: ContextService): void => {
+export default (config: ConfigService, content: Content): Step => (context: ContextService): void => {
   context.setPerfMark('addNewSlides');
 
   const commonUnexpectedExpression = [

--- a/src/proxy-page/steps/addNewSlides.ts
+++ b/src/proxy-page/steps/addNewSlides.ts
@@ -1,11 +1,11 @@
 import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import { getAttributesFromChildren, getObjectFromStorageXMLForPageProperties } from '../utils/macroSlide';
 
-export default (config: ConfigService, content: Content): Step => (context: ContextService): void => {
+export default (config: ConfigService, content: ConfluenceRestAPIv2PageContent): Step => (context: ContextService): void => {
   context.setPerfMark('addNewSlides');
 
   const commonUnexpectedExpression = [

--- a/src/proxy-page/steps/fixCaptionImage.ts
+++ b/src/proxy-page/steps/fixCaptionImage.ts
@@ -1,5 +1,4 @@
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 
@@ -12,10 +11,10 @@ import { Step } from '../proxy-page.step';
  * @param  {ConfigService} config
  * @returns void
  */
-export default (content: Content): Step => (context: ContextService): void => {
+export default (): Step => (context: ContextService): void => {
   context.setPerfMark('fixCaptionImage');
   const $ = context.getCheerioBody();
-  const xmlStorageFormat = cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });
+  const xmlStorageFormat = cheerio.load(context.getBodyStorage(), { xmlMode: true });
   const getImageCaption = (elementImg: cheerio.Element) => {
     const filename = elementImg.attribs['data-linked-resource-default-alias'];
     const attachmentContent = xmlStorageFormat(`ri\\:attachment[ri\\:filename="${filename}"]`);

--- a/src/proxy-page/steps/fixCaptionImage.ts
+++ b/src/proxy-page/steps/fixCaptionImage.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
+import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 
@@ -12,7 +12,7 @@ import { Step } from '../proxy-page.step';
  * @param  {ConfigService} config
  * @returns void
  */
-export default (content: ConfluenceRestAPIv2PageContent): Step => (context: ContextService): void => {
+export default (content: Content): Step => (context: ContextService): void => {
   context.setPerfMark('fixCaptionImage');
   const $ = context.getCheerioBody();
   const xmlStorageFormat = cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });

--- a/src/proxy-page/steps/fixCaptionImage.ts
+++ b/src/proxy-page/steps/fixCaptionImage.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 
@@ -12,10 +12,10 @@ import { Step } from '../proxy-page.step';
  * @param  {ConfigService} config
  * @returns void
  */
-export default (content: Content): Step => (context: ContextService): void => {
+export default (content: ConfluenceRestAPIv2PageContent): Step => (context: ContextService): void => {
   context.setPerfMark('fixCaptionImage');
   const $ = context.getCheerioBody();
-  const xmlStorageFormat = cheerio.load(content?.body?.storage?.value ?? '', { xmlMode: true });
+  const xmlStorageFormat = cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });
   const getImageCaption = (elementImg: cheerio.Element) => {
     const filename = elementImg.attribs['data-linked-resource-default-alias'];
     const attachmentContent = xmlStorageFormat(`ri\\:attachment[ri\\:filename="${filename}"]`);

--- a/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
@@ -1,4 +1,4 @@
-import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
+import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { getMacroSlideSettingsPropertyValueByKey, loadStorageContentToXML } from '../utils/macroSlide';
 import { MacroSlideSettingsProperty } from '../utils/macroSlide.interface';
@@ -8,7 +8,7 @@ export default (
   spaceKey: string,
   pageId: string,
   style?: string,
-  content?: ConfluenceRestAPIv2PageContent,
+  content?: Content,
 ): void => {
   const storageXML = loadStorageContentToXML(content);
 
@@ -22,7 +22,7 @@ export default (
     value: valueSlideTransition,
   }: MacroSlideSettingsProperty = getMacroSlideSettingsPropertyValueByKey(storageXML, 'slide_settings_transition', 'slide');
 
-  context.initPageContext(
+  context.initPageContextRestAPIv2(
     spaceKey,
     pageId,
     'light',

--- a/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
@@ -1,9 +1,15 @@
-import { Content } from '../../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { getMacroSlideSettingsPropertyValueByKey, loadStorageContentToXML } from '../utils/macroSlide';
 import { MacroSlideSettingsProperty } from '../utils/macroSlide.interface';
 
-export default (context: ContextService, spaceKey: string, pageId: string, style?: string, content?: Content): void => {
+export default (
+  context: ContextService,
+  spaceKey: string,
+  pageId: string,
+  style?: string,
+  content?: ConfluenceRestAPIv2PageContent,
+): void => {
   const storageXML = loadStorageContentToXML(content);
 
   const {

--- a/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideContextByStrategy.ts
@@ -10,7 +10,7 @@ export default (
   style?: string,
   content?: Content,
 ): void => {
-  const storageXML = loadStorageContentToXML(content);
+  const storageXML = loadStorageContentToXML(context);
 
   const {
     exist: existSlideStyle,
@@ -22,7 +22,8 @@ export default (
     value: valueSlideTransition,
   }: MacroSlideSettingsProperty = getMacroSlideSettingsPropertyValueByKey(storageXML, 'slide_settings_transition', 'slide');
 
-  context.initPageContextRestAPIv2(
+  context.initPageContext(
+    context.getApiVersion(),
     spaceKey,
     pageId,
     'light',

--- a/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
@@ -1,11 +1,11 @@
 import { ConfigService } from '@nestjs/config';
-import { Content } from '../../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import addNewSlides from '../steps/addNewSlides';
 import addSlides from '../steps/addSlides';
 
-export default (content: Content, config: ConfigService): Step => (context: ContextService): void => {
+export default (content: ConfluenceRestAPIv2PageContent, config: ConfigService): Step => (context: ContextService): void => {
   const $ = context.getCheerioBody();
 
   const isGeneratedNewMacroSlide = $(".conf-macro[data-macro-name='slideSettings']").length > 0

--- a/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
@@ -1,11 +1,11 @@
 import { ConfigService } from '@nestjs/config';
-import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
+import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import addNewSlides from '../steps/addNewSlides';
 import addSlides from '../steps/addSlides';
 
-export default (content: ConfluenceRestAPIv2PageContent, config: ConfigService): Step => (context: ContextService): void => {
+export default (content: Content, config: ConfigService): Step => (context: ContextService): void => {
   const $ = context.getCheerioBody();
 
   const isGeneratedNewMacroSlide = $(".conf-macro[data-macro-name='slideSettings']").length > 0

--- a/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
+++ b/src/proxy-page/strategySteps/addSlideTypeByStrategy.ts
@@ -1,18 +1,17 @@
 import { ConfigService } from '@nestjs/config';
-import { Content } from '../../confluence/confluence.interface';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 import addNewSlides from '../steps/addNewSlides';
 import addSlides from '../steps/addSlides';
 
-export default (content: Content, config: ConfigService): Step => (context: ContextService): void => {
+export default (config: ConfigService): Step => (context: ContextService): void => {
   const $ = context.getCheerioBody();
 
   const isGeneratedNewMacroSlide = $(".conf-macro[data-macro-name='slideSettings']").length > 0
         || $(".conf-macro[data-macro-name='slide']").length > 0;
 
   if (isGeneratedNewMacroSlide) {
-    addNewSlides(config, content)(context);
+    addNewSlides(config)(context);
   } else {
     addSlides()(context);
   }

--- a/src/proxy-page/utils/macroSlide.ts
+++ b/src/proxy-page/utils/macroSlide.ts
@@ -1,8 +1,9 @@
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
 import { MacroSlideSettingsProperty } from './macroSlide.interface';
 
-export const loadStorageContentToXML = (content: Content) => cheerio.load(content?.body?.storage?.value ?? '', { xmlMode: true });
+export const loadStorageContentToXML = (content: ConfluenceRestAPIv2PageContent) =>
+  cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });
 
 export const getMacroSlideSettingsPropertyValueByKey = ($storageContent: cheerio.CheerioAPI, key: string, defaultValue: string):
 MacroSlideSettingsProperty => {
@@ -15,7 +16,7 @@ MacroSlideSettingsProperty => {
   };
 };
 
-export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, content: Content): any => {
+export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, content: ConfluenceRestAPIv2PageContent): any => {
   const $storageContent = loadStorageContentToXML(content);
   const dataLocalId = pageProperties.attribs['data-local-id'];
   const storageXML = $storageContent(`ac\\:structured-macro[ac\\:local-id="${dataLocalId}"]`);

--- a/src/proxy-page/utils/macroSlide.ts
+++ b/src/proxy-page/utils/macroSlide.ts
@@ -1,8 +1,8 @@
 import * as cheerio from 'cheerio';
-import { ConfluenceRestAPIv2PageContent } from '../../confluence/confluence.interface';
+import { Content } from '../../confluence/confluence.interface';
 import { MacroSlideSettingsProperty } from './macroSlide.interface';
 
-export const loadStorageContentToXML = (content: ConfluenceRestAPIv2PageContent) =>
+export const loadStorageContentToXML = (content: Content) =>
   cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });
 
 export const getMacroSlideSettingsPropertyValueByKey = ($storageContent: cheerio.CheerioAPI, key: string, defaultValue: string):
@@ -16,7 +16,7 @@ MacroSlideSettingsProperty => {
   };
 };
 
-export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, content: ConfluenceRestAPIv2PageContent): any => {
+export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, content: Content): any => {
   const $storageContent = loadStorageContentToXML(content);
   const dataLocalId = pageProperties.attribs['data-local-id'];
   const storageXML = $storageContent(`ac\\:structured-macro[ac\\:local-id="${dataLocalId}"]`);

--- a/src/proxy-page/utils/macroSlide.ts
+++ b/src/proxy-page/utils/macroSlide.ts
@@ -1,9 +1,9 @@
 import * as cheerio from 'cheerio';
-import { Content } from '../../confluence/confluence.interface';
 import { MacroSlideSettingsProperty } from './macroSlide.interface';
+import { ContextService } from '../../context/context.service';
 
-export const loadStorageContentToXML = (content: Content) =>
-  cheerio.load(content?.pageContent?.body?.storage?.value ?? '', { xmlMode: true });
+export const loadStorageContentToXML = (context: ContextService) =>
+  cheerio.load(context.getBodyStorage(), { xmlMode: true });
 
 export const getMacroSlideSettingsPropertyValueByKey = ($storageContent: cheerio.CheerioAPI, key: string, defaultValue: string):
 MacroSlideSettingsProperty => {
@@ -16,8 +16,8 @@ MacroSlideSettingsProperty => {
   };
 };
 
-export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, content: Content): any => {
-  const $storageContent = loadStorageContentToXML(content);
+export const getObjectFromStorageXMLForPageProperties = (pageProperties: cheerio.Element, context: ContextService): any => {
+  const $storageContent = loadStorageContentToXML(context);
   const dataLocalId = pageProperties.attribs['data-local-id'];
   const storageXML = $storageContent(`ac\\:structured-macro[ac\\:local-id="${dataLocalId}"]`);
   return storageXML;

--- a/tests/e2e/proxy-api/proxy-api.e2e-spec.ts
+++ b/tests/e2e/proxy-api/proxy-api.e2e-spec.ts
@@ -30,7 +30,6 @@ describe('proxy-api', () => {
     const res = await request(app.getHttpServer()).get(
       `/api/spaces/konviw/pages/${INTRO_TO_KONVIW_ID}`,
     );
-
     expect(res.statusCode).toBe(HttpStatus.OK);
 
     checkBasicPageEquality(

--- a/tests/unit/proxy-api/proxy-api.service.spec.ts
+++ b/tests/unit/proxy-api/proxy-api.service.spec.ts
@@ -23,7 +23,7 @@ class ConfluenceServiceMock {
       pageContent: {
         title: 'Page title',
         body: { view: { value: '<Content>page content</Content>' } },
-        version: { number: 21, friendlyWhen: '19 January 2021', publicName: 'Name LastName'},
+        version: { number: 21, createdAt: '19 January 2021' },
         createdAt: '2020-01-01T01:30:00.000',
       },
       authorContent: {
@@ -91,10 +91,10 @@ describe('proxy-api.service', () => {
     });
 
     it('should call initPageContext construct the basic page context', async () => {
-      jest.spyOn(contextService, 'initPageContext');
+      jest.spyOn(contextService, 'initPageContextRestAPIv2');
       await proxyApiService.getPage('space', '1234', 'type');
 
-      expect(contextService.initPageContext).toHaveBeenCalledTimes(1);
+      expect(contextService.initPageContextRestAPIv2).toHaveBeenCalledTimes(1);
     });
 
     it('should not call addLibrariesCSS as CSS cannot be injected by setting innerHTML', async () => {

--- a/tests/unit/proxy-api/proxy-api.service.spec.ts
+++ b/tests/unit/proxy-api/proxy-api.service.spec.ts
@@ -20,24 +20,33 @@ class ConfluenceServiceMock {
   getPage(spaceKey: string, pageId: string, version?: string): DeepPartial<Content>{
 
     const confluenceContent: DeepPartial<Content> = {
-      title: 'Page title',
-      history: {
-        createdBy: {
-          email: 'email@somewhere.com',
-          displayName: 'Author name',
-          profilePicture: {
-            path: '//profilepic',
-          },
-        },
-        createdDate: '2020-01-01T01:30:00.000',
+      pageContent: {
+        title: 'Page title',
+        body: { view: { value: '<Content>page content</Content>' } },
+        version: { number: 21, friendlyWhen: '19 January 2021', publicName: 'Name LastName'},
+        createdAt: '2020-01-01T01:30:00.000',
       },
-      body: { view: { value: '<Content>page content</Content>' } },
-      version: { number: 21, friendlyWhen: '19 January 2021', by: { publicName: 'Name LastName' } },
-      _expandable: {space: '/rest/api/space/MySpace'},
-      metadata: {
-        labels: {results: [{name: 'one'},{name: 'two'},{name: 'three'}]},
-        properties: {}
-      }
+      authorContent: {
+        email: 'email@somewhere.com',
+        publicName: 'Author name',
+        profilePicture: {
+          path: '//profilepic',
+        },
+      },
+      versionAuthorContent: {
+        email: 'email@somewhere.com',
+        publicName: 'Author name',
+        profilePicture: {
+          path: '//profilepic',
+        },
+      },
+      spaceContent: {
+        key: 'MySpace',
+      },
+      labelsContent: {
+        results: [{name: 'one'}, {name: 'two'}, {name: 'three'}],
+      },
+      propertiesContent: {},
     };
 
     return confluenceContent

--- a/tests/unit/proxy-api/proxy-api.service.spec.ts
+++ b/tests/unit/proxy-api/proxy-api.service.spec.ts
@@ -91,10 +91,10 @@ describe('proxy-api.service', () => {
     });
 
     it('should call initPageContext construct the basic page context', async () => {
-      jest.spyOn(contextService, 'initPageContextRestAPIv2');
+      jest.spyOn(contextService, 'initPageContext');
       await proxyApiService.getPage('space', '1234', 'type');
 
-      expect(contextService.initPageContextRestAPIv2).toHaveBeenCalledTimes(1);
+      expect(contextService.initPageContext).toHaveBeenCalledTimes(1);
     });
 
     it('should not call addLibrariesCSS as CSS cannot be injected by setting innerHTML', async () => {

--- a/tests/unit/speed/speedSteps.spec.ts
+++ b/tests/unit/speed/speedSteps.spec.ts
@@ -66,7 +66,7 @@ describe('Speed / Steps', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it(`Should execute each step under ${timeExpected}ms ${iteration} times in a row`, async () => {

--- a/tests/unit/speed/speedSteps.spec.ts
+++ b/tests/unit/speed/speedSteps.spec.ts
@@ -66,7 +66,7 @@ describe('Speed / Steps', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it(`Should execute each step under ${timeExpected}ms ${iteration} times in a row`, async () => {

--- a/tests/unit/steps/addCustomCss.spec.ts
+++ b/tests/unit/steps/addCustomCss.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / addCustomCss', () => {
   });
 
   it('should add custom CSS', () => {
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     const step = addCustomCss(config);
     const version = config.get('version');
     const basePath = config.get('web.basePath');

--- a/tests/unit/steps/addCustomCss.spec.ts
+++ b/tests/unit/steps/addCustomCss.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / addCustomCss', () => {
   });
 
   it('should add custom CSS', () => {
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     const step = addCustomCss(config);
     const version = config.get('version');
     const basePath = config.get('web.basePath');

--- a/tests/unit/steps/addHeaderTitle.spec.ts
+++ b/tests/unit/steps/addHeaderTitle.spec.ts
@@ -13,7 +13,7 @@ describe('ConfluenceProxy / addHeaderTitle', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should add just the h1 title', async () => {

--- a/tests/unit/steps/addHeaderTitle.spec.ts
+++ b/tests/unit/steps/addHeaderTitle.spec.ts
@@ -13,7 +13,7 @@ describe('ConfluenceProxy / addHeaderTitle', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should add just the h1 title', async () => {

--- a/tests/unit/steps/addJira.spec.ts
+++ b/tests/unit/steps/addJira.spec.ts
@@ -63,7 +63,7 @@ describe('Confluence Proxy / addJira', () => {
       config.get('confluence.baseURL');
     step = addJira(config, new JiraServiceMock() as any);
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   afterAll(() => {

--- a/tests/unit/steps/addJira.spec.ts
+++ b/tests/unit/steps/addJira.spec.ts
@@ -63,7 +63,7 @@ describe('Confluence Proxy / addJira', () => {
       config.get('confluence.baseURL');
     step = addJira(config, new JiraServiceMock() as any);
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   afterAll(() => {

--- a/tests/unit/steps/addLibrariesCSS.spec.ts
+++ b/tests/unit/steps/addLibrariesCSS.spec.ts
@@ -11,7 +11,7 @@ describe('ConfluenceProxy / addLibrariesCSS', () => {
   });
 
   it('should add highlight.js css', () => {
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     const step = addLibrariesCSS();
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addLibrariesCSS.spec.ts
+++ b/tests/unit/steps/addLibrariesCSS.spec.ts
@@ -11,7 +11,7 @@ describe('ConfluenceProxy / addLibrariesCSS', () => {
   });
 
   it('should add highlight.js css', () => {
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     const step = addLibrariesCSS();
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addLibrariesJS.spec.ts
+++ b/tests/unit/steps/addLibrariesJS.spec.ts
@@ -8,7 +8,7 @@ describe('ConfluenceProxy / addLibrariesJS', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     const step = addLibrariesJS();
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addLibrariesJS.spec.ts
+++ b/tests/unit/steps/addLibrariesJS.spec.ts
@@ -8,7 +8,7 @@ describe('ConfluenceProxy / addLibrariesJS', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     const step = addLibrariesJS();
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addNewSlides.spec.ts
+++ b/tests/unit/steps/addNewSlides.spec.ts
@@ -12,7 +12,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
-        content.pageContent.body.storage.value = '<ac:structured-macro ac:name="slideSettings" ac:schema-version="1" data-layout="default" ' +
+        context.setBodyStorage('<ac:structured-macro ac:name="slideSettings" ac:schema-version="1" data-layout="default" ' +
         'ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793" ac:macro-id="00d0b33919f6759e73e5e7699a6238fc">' +
         '<ac:parameter ac:name="slide_settings_title">Test</ac:parameter><ac:parameter ac:name="slide_settings_theme">' +
         'iadc</ac:parameter><ac:parameter ac:name="slide_settings_transition">convex</ac:parameter>' +
@@ -21,9 +21,9 @@ describe('ConfluenceProxy / addNewSlides', () => {
         '<ac:parameter ac:name="slide_type">bubble</ac:parameter><ac:parameter ac:name="slide_id">1</ac:parameter>' +
         '<ac:parameter ac:name="slide_transition">concave</ac:parameter><ac:parameter ac:name="slide_background_attachment">' +
         '<ri:attachment ri:filename="1529923467_Javascript.png" ri:version-at-save="1" /></ac:parameter>' +
-        '<ac:rich-text-body><p>Content of slide</p></ac:rich-text-body></ac:structured-macro><p />';
+        '<ac:rich-text-body><p>Content of slide</p></ac:rich-text-body></ac:structured-macro><p />');
         config = moduleRef.get<ConfigService>(ConfigService);
-        context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+        context.initPageContext('v2', 'XXX', '123456', 'dark');
     });
 
     it('Add new slides parameters defined in slide macro are overriding slide deck', () => {
@@ -34,7 +34,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         'data-macro-name="slide"><p>Content of slide</p></div><p />';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         expect(context.getHtmlBody().includes('data-transition="concave"')).toBe(true);
     });
 
@@ -42,7 +42,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         const mockBody = '';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         const result = '<html><head></head><body><div id="Content"><section id="slides-logo"></section>' +
         '<div class="reveal slide"><div class="slides"></div></div></div></body></html>';
         expect(context.getHtmlBody()).toEqual(result);
@@ -56,7 +56,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         'data-macro-id="e8dea08a24d1c4cb8a2be48f9e7de56c" data-macro-name="slide"><p>Content of slide</p></div><p />';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         const fileAttribiute = 'data-background-image="'
         const fileName = '1529923467_Javascript.png'
         const htmlBody = context.getHtmlBody();
@@ -71,7 +71,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         'data-macro-name="slide"><p>Content of slide</p></div><p />';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         expect(context.getHtmlBody().includes('Content of slide')).toBe(true);
     });
 
@@ -83,7 +83,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         'data-macro-name="slide"><p>Content of slide</p></div><p />';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         expect(context.getHtmlBody().includes('data-state="bubble"')).toBe(true);
     });
 
@@ -95,8 +95,8 @@ describe('ConfluenceProxy / addNewSlides', () => {
         'data-macro-name="slide"><p>Content of slide</p></div><p />';
         content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        addNewSlides(config, content)(context);
+        addNewSlides(config)(context);
         expect(mockBody.includes('data-macro-id="e8dea08a24d1c4cb8a2be48f9e7de56c"'))
-            .toBe(content.pageContent.body.storage.value.includes('ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793"'));
+            .toBe(context.getBodyStorage().includes('ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793"'));
     });
 });

--- a/tests/unit/steps/addNewSlides.spec.ts
+++ b/tests/unit/steps/addNewSlides.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import { Content } from '../../../src/confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../../src/confluence/confluence.interface';
 import { ContextService } from '../../../src/context/context.service';
 import addNewSlides from '../../../src/proxy-page/steps/addNewSlides';
 import { createModuleRefForStep } from './utils';
@@ -7,12 +7,12 @@ import { createModuleRefForStep } from './utils';
 describe('ConfluenceProxy / addNewSlides', () => {
     let context: ContextService;
     let config: ConfigService;
-    let content: Content & { body: { storage: { value: string } } } = { body: { storage: { value: '' } } } as any;
+    let content: ConfluenceRestAPIv2PageContent = { pageContent: { body: { storage: { value: '' } } }} as any;
 
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
-        content.body.storage.value = '<ac:structured-macro ac:name="slideSettings" ac:schema-version="1" data-layout="default" ' +
+        content.pageContent.body.storage.value = '<ac:structured-macro ac:name="slideSettings" ac:schema-version="1" data-layout="default" ' +
         'ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793" ac:macro-id="00d0b33919f6759e73e5e7699a6238fc">' +
         '<ac:parameter ac:name="slide_settings_title">Test</ac:parameter><ac:parameter ac:name="slide_settings_theme">' +
         'iadc</ac:parameter><ac:parameter ac:name="slide_settings_transition">convex</ac:parameter>' +
@@ -97,6 +97,6 @@ describe('ConfluenceProxy / addNewSlides', () => {
         context.setHtmlBody(mockBody);
         addNewSlides(config, content)(context);
         expect(mockBody.includes('data-macro-id="e8dea08a24d1c4cb8a2be48f9e7de56c"'))
-            .toBe(content.body.storage.value.includes('ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793"'));
+            .toBe(content.pageContent.body.storage.value.includes('ac:local-id="141105b0-1baf-44ce-9c96-27004ad82793"'));
     });
 });

--- a/tests/unit/steps/addNewSlides.spec.ts
+++ b/tests/unit/steps/addNewSlides.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import { ConfluenceRestAPIv2PageContent } from '../../../src/confluence/confluence.interface';
+import { Content } from '../../../src/confluence/confluence.interface';
 import { ContextService } from '../../../src/context/context.service';
 import addNewSlides from '../../../src/proxy-page/steps/addNewSlides';
 import { createModuleRefForStep } from './utils';
@@ -7,7 +7,7 @@ import { createModuleRefForStep } from './utils';
 describe('ConfluenceProxy / addNewSlides', () => {
     let context: ContextService;
     let config: ConfigService;
-    let content: ConfluenceRestAPIv2PageContent = { pageContent: { body: { storage: { value: '' } } }} as any;
+    let content: Content = { pageContent: { body: { storage: { value: '' } } }} as any;
 
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
@@ -23,7 +23,7 @@ describe('ConfluenceProxy / addNewSlides', () => {
         '<ri:attachment ri:filename="1529923467_Javascript.png" ri:version-at-save="1" /></ac:parameter>' +
         '<ac:rich-text-body><p>Content of slide</p></ac:rich-text-body></ac:structured-macro><p />';
         config = moduleRef.get<ConfigService>(ConfigService);
-        context.initPageContext('XXX', '123456', 'dark');
+        context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     });
 
     it('Add new slides parameters defined in slide macro are overriding slide deck', () => {

--- a/tests/unit/steps/addSlides.spec.ts
+++ b/tests/unit/steps/addSlides.spec.ts
@@ -9,7 +9,7 @@ describe('ConfluenceProxy / addSlides', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should add slides', () => {

--- a/tests/unit/steps/addSlides.spec.ts
+++ b/tests/unit/steps/addSlides.spec.ts
@@ -9,7 +9,7 @@ describe('ConfluenceProxy / addSlides', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should add slides', () => {

--- a/tests/unit/steps/addSlidesJS.spec.ts
+++ b/tests/unit/steps/addSlidesJS.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / addLibrariesJS', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     basePath = config.get('web.basePath');
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     const step = addSlidesJS(config);
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addSlidesJS.spec.ts
+++ b/tests/unit/steps/addSlidesJS.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / addLibrariesJS', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     basePath = config.get('web.basePath');
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     const step = addSlidesJS(config);
     context.setHtmlBody('<html><head></head><body></body></html>');
     step(context);

--- a/tests/unit/steps/addTheme.spec.ts
+++ b/tests/unit/steps/addTheme.spec.ts
@@ -14,7 +14,7 @@ describe('Confluence Proxy / addTheme', () => {
   });
 
   it('should add dark theme', () => {
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())
@@ -27,7 +27,7 @@ describe('Confluence Proxy / addTheme', () => {
   });
 
   it('should add light theme', () => {
-    context.initPageContext('XXX', '123456', 'light');
+    context.initPageContextRestAPIv2('XXX', '123456', 'light');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())

--- a/tests/unit/steps/addTheme.spec.ts
+++ b/tests/unit/steps/addTheme.spec.ts
@@ -14,7 +14,7 @@ describe('Confluence Proxy / addTheme', () => {
   });
 
   it('should add dark theme', () => {
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())
@@ -27,7 +27,7 @@ describe('Confluence Proxy / addTheme', () => {
   });
 
   it('should add light theme', () => {
-    context.initPageContextRestAPIv2('XXX', '123456', 'light');
+    context.initPageContext('v2', 'XXX', '123456', 'light');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())

--- a/tests/unit/steps/delUnnecessaryCode.spec.ts
+++ b/tests/unit/steps/delUnnecessaryCode.spec.ts
@@ -19,7 +19,7 @@ describe('ConfluenceProxy / del unnecessary code', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('Remove CDATA blocks from Drawio ap-iframe-body-script', () => {

--- a/tests/unit/steps/delUnnecessaryCode.spec.ts
+++ b/tests/unit/steps/delUnnecessaryCode.spec.ts
@@ -19,7 +19,7 @@ describe('ConfluenceProxy / del unnecessary code', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('Remove CDATA blocks from Drawio ap-iframe-body-script', () => {

--- a/tests/unit/steps/fixCaptionImage.spec.ts
+++ b/tests/unit/steps/fixCaptionImage.spec.ts
@@ -1,5 +1,4 @@
 import { ConfigService } from '@nestjs/config';
-import { Content } from '../../../src/confluence/confluence.interface';
 import { ContextService } from '../../../src/context/context.service';
 import fixCaptionImage from '../../../src/proxy-page/steps/fixCaptionImage';
 import { createModuleRefForStep } from './utils';
@@ -7,21 +6,19 @@ import { createModuleRefForStep } from './utils';
 describe('ConfluenceProxy / fixCaptionImage', () => {
     let context: ContextService;
     let config: ConfigService;
-    let content: Content & { pageContent: { body: { storage: { value: string } } }} = { pageContent: { body: { storage: { value: '' } } }} as any;
 
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
-        content.pageContent.body.storage.value = '<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />';
+        context.setBodyStorage('<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />');
         config = moduleRef.get<ConfigService>(ConfigService);
-        context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+        context.initPageContext('v2', 'XXX', '123456', 'dark');
     });
 
     it('FixCaptionImage should create caption', () => {
         const mockBody = '<span class="confluence-embedded-file-wrapper image-center-wrapper"><img class="confluence-embedded-image image-center" loading="lazy" src="http://localhost:4000/cpv/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-image-src="https://sanofi.atlassian.net/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-height="512" data-width="512" data-unresolved-comment-count="0" data-linked-resource-id="64030409395" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="unnamed (1).png" data-base-url="https://sanofi.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="64024054246" data-linked-resource-container-version="3" data-media-id="2e93e007-c7d0-4f79-a397-a2b14158b4ff" data-media-type="file" width="512"></span>';
-        content.getCheerioBody = () => mockBody;
         context.setHtmlBody(mockBody);
-        fixCaptionImage(content)(context);
+        fixCaptionImage()(context);
         expect(context.getHtmlBody().includes('<p class="image-caption">exampleCaption</p>')).toBe(true);
     });
 });

--- a/tests/unit/steps/fixCaptionImage.spec.ts
+++ b/tests/unit/steps/fixCaptionImage.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import { ConfluenceRestAPIv2PageContent } from '../../../src/confluence/confluence.interface';
+import { Content } from '../../../src/confluence/confluence.interface';
 import { ContextService } from '../../../src/context/context.service';
 import fixCaptionImage from '../../../src/proxy-page/steps/fixCaptionImage';
 import { createModuleRefForStep } from './utils';
@@ -7,14 +7,14 @@ import { createModuleRefForStep } from './utils';
 describe('ConfluenceProxy / fixCaptionImage', () => {
     let context: ContextService;
     let config: ConfigService;
-    let content: ConfluenceRestAPIv2PageContent & { pageContent: { body: { storage: { value: string } } }} = { pageContent: { body: { storage: { value: '' } } }} as any;
+    let content: Content & { pageContent: { body: { storage: { value: string } } }} = { pageContent: { body: { storage: { value: '' } } }} as any;
 
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
         content.pageContent.body.storage.value = '<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />';
         config = moduleRef.get<ConfigService>(ConfigService);
-        context.initPageContext('XXX', '123456', 'dark');
+        context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     });
 
     it('FixCaptionImage should create caption', () => {

--- a/tests/unit/steps/fixCaptionImage.spec.ts
+++ b/tests/unit/steps/fixCaptionImage.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import { Content } from '../../../src/confluence/confluence.interface';
+import { ConfluenceRestAPIv2PageContent } from '../../../src/confluence/confluence.interface';
 import { ContextService } from '../../../src/context/context.service';
 import fixCaptionImage from '../../../src/proxy-page/steps/fixCaptionImage';
 import { createModuleRefForStep } from './utils';
@@ -7,12 +7,12 @@ import { createModuleRefForStep } from './utils';
 describe('ConfluenceProxy / fixCaptionImage', () => {
     let context: ContextService;
     let config: ConfigService;
-    let content: Content & { body: { storage: { value: string } } } = { body: { storage: { value: '' } } } as any;
+    let content: ConfluenceRestAPIv2PageContent & { pageContent: { body: { storage: { value: string } } }} = { pageContent: { body: { storage: { value: '' } } }} as any;
 
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
-        content.body.storage.value = '<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />';
+        content.pageContent.body.storage.value = '<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />';
         config = moduleRef.get<ConfigService>(ConfigService);
         context.initPageContext('XXX', '123456', 'dark');
     });

--- a/tests/unit/steps/fixChart.spec.ts
+++ b/tests/unit/steps/fixChart.spec.ts
@@ -119,7 +119,7 @@ describe('ConfluenceProxy / fixChartMacro', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   describe('Chart created in the same page', () => {

--- a/tests/unit/steps/fixChart.spec.ts
+++ b/tests/unit/steps/fixChart.spec.ts
@@ -117,9 +117,9 @@ describe('ConfluenceProxy / fixChartMacro', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    webBasePath = config.get('web.absoluteBasePath');
+    webBasePath = config.get('web.absoluteBasePath') ?? '';
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   describe('Chart created in the same page', () => {

--- a/tests/unit/steps/fixCode.spec.ts
+++ b/tests/unit/steps/fixCode.spec.ts
@@ -8,7 +8,7 @@ describe('ConfluenceProxy / fixCode', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should wrap code with <pre><code>', () => {

--- a/tests/unit/steps/fixCode.spec.ts
+++ b/tests/unit/steps/fixCode.spec.ts
@@ -8,7 +8,7 @@ describe('ConfluenceProxy / fixCode', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should wrap code with <pre><code>', () => {

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -10,7 +10,7 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body></body></html>');
   });
 

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -10,7 +10,7 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body></body></html>');
   });
 

--- a/tests/unit/steps/fixConfluenceSpace.spec.ts
+++ b/tests/unit/steps/fixConfluenceSpace.spec.ts
@@ -16,7 +16,7 @@ describe('ConfluenceProxy / fixConfluenceSpace', () => {
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
     http = moduleRef.get<HttpService>(HttpService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should replace confluence space icon', async () => {

--- a/tests/unit/steps/fixConfluenceSpace.spec.ts
+++ b/tests/unit/steps/fixConfluenceSpace.spec.ts
@@ -16,7 +16,7 @@ describe('ConfluenceProxy / fixConfluenceSpace', () => {
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
     http = moduleRef.get<HttpService>(HttpService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should replace confluence space icon', async () => {

--- a/tests/unit/steps/fixDrawio.spec.ts
+++ b/tests/unit/steps/fixDrawio.spec.ts
@@ -48,9 +48,9 @@ describe('ConfluenceProxy / fixDrawio', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    webBasePath = config.get('web.absoluteBasePath');
+    webBasePath = config.get('web.absoluteBasePath') ?? '';
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     const step = fixDrawio(config);
     context.setHtmlBody(example);
     step(context);

--- a/tests/unit/steps/fixDrawio.spec.ts
+++ b/tests/unit/steps/fixDrawio.spec.ts
@@ -50,7 +50,7 @@ describe('ConfluenceProxy / fixDrawio', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     const step = fixDrawio(config);
     context.setHtmlBody(example);
     step(context);

--- a/tests/unit/steps/fixEmojis.spec.ts
+++ b/tests/unit/steps/fixEmojis.spec.ts
@@ -12,7 +12,7 @@ describe('ConfluenceProxy / fixEmojis', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('Emojis inserted in headings are displaying correctly', async () => {

--- a/tests/unit/steps/fixEmojis.spec.ts
+++ b/tests/unit/steps/fixEmojis.spec.ts
@@ -12,7 +12,7 @@ describe('ConfluenceProxy / fixEmojis', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('Emojis inserted in headings are displaying correctly', async () => {

--- a/tests/unit/steps/fixFrameAllowFullscreen.spec.ts
+++ b/tests/unit/steps/fixFrameAllowFullscreen.spec.ts
@@ -10,7 +10,7 @@ describe('ConfluenceProxy / fixFrameAllowFullscreen', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('Enable fullscreen lazy loading and other attributes', () => {

--- a/tests/unit/steps/fixFrameAllowFullscreen.spec.ts
+++ b/tests/unit/steps/fixFrameAllowFullscreen.spec.ts
@@ -10,7 +10,7 @@ describe('ConfluenceProxy / fixFrameAllowFullscreen', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('Enable fullscreen lazy loading and other attributes', () => {

--- a/tests/unit/steps/fixHtmlHead.spec.ts
+++ b/tests/unit/steps/fixHtmlHead.spec.ts
@@ -1,4 +1,4 @@
-import { Step } from 'src/proxy-page/proxy-page.step';
+import { Step } from '../../../src/proxy-page/proxy-page.step'
 import { ContextService } from '../../../src/context/context.service';
 import { ConfigService } from '@nestjs/config';
 import fixHtmlHead from '../../../src/proxy-page/steps/fixHtmlHead';
@@ -14,12 +14,12 @@ describe('Confluence Proxy / addTheme', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
-    basePath = config.get('web.basePath');
+    basePath = config.get('web.basePath') ?? '';
     step = fixHtmlHead(config);
   });
 
   it('should add dark theme', () => {
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     context.setTitle('This is the title');
     step(context);

--- a/tests/unit/steps/fixImageSize.spec.ts
+++ b/tests/unit/steps/fixImageSize.spec.ts
@@ -9,7 +9,7 @@ describe('ConfluenceProxy / fixImageSize', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body></body></html>');
   });
 

--- a/tests/unit/steps/fixImageSize.spec.ts
+++ b/tests/unit/steps/fixImageSize.spec.ts
@@ -9,7 +9,7 @@ describe('ConfluenceProxy / fixImageSize', () => {
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body></body></html>');
   });
 

--- a/tests/unit/steps/fixLinks.spec.ts
+++ b/tests/unit/steps/fixLinks.spec.ts
@@ -18,7 +18,7 @@ describe('ConfluenceProxy / fixLinks', () => {
     http = moduleRef.get<HttpService>(HttpService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should replace page absolute URLs', async () => {

--- a/tests/unit/steps/fixLinks.spec.ts
+++ b/tests/unit/steps/fixLinks.spec.ts
@@ -18,7 +18,7 @@ describe('ConfluenceProxy / fixLinks', () => {
     http = moduleRef.get<HttpService>(HttpService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should replace page absolute URLs', async () => {

--- a/tests/unit/steps/fixSVG.spec.ts
+++ b/tests/unit/steps/fixSVG.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / fixLinks', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('should replace the img src, width and class', () => {

--- a/tests/unit/steps/fixSVG.spec.ts
+++ b/tests/unit/steps/fixSVG.spec.ts
@@ -14,7 +14,7 @@ describe('ConfluenceProxy / fixLinks', () => {
     config = moduleRef.get<ConfigService>(ConfigService);
     webBasePath = config.get('web.absoluteBasePath');
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('should replace the img src, width and class', () => {

--- a/tests/unit/steps/fixToc.spec.ts
+++ b/tests/unit/steps/fixToc.spec.ts
@@ -28,7 +28,7 @@ describe('ConfluenceProxy / fix TOC', () => {
     context = moduleRef.get<ContextService>(ContextService);
     step = fixToc();
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
     context.setHtmlBody(example);
   });
 

--- a/tests/unit/steps/fixToc.spec.ts
+++ b/tests/unit/steps/fixToc.spec.ts
@@ -28,7 +28,7 @@ describe('ConfluenceProxy / fix TOC', () => {
     context = moduleRef.get<ContextService>(ContextService);
     step = fixToc();
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody(example);
   });
 

--- a/tests/unit/steps/fixUserProfile.spec.ts
+++ b/tests/unit/steps/fixUserProfile.spec.ts
@@ -32,7 +32,7 @@ describe('ConfluenceProxy / fixUserProfile', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('User Profiles fixed', () => {

--- a/tests/unit/steps/fixUserProfile.spec.ts
+++ b/tests/unit/steps/fixUserProfile.spec.ts
@@ -32,7 +32,7 @@ describe('ConfluenceProxy / fixUserProfile', () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('User Profiles fixed', () => {

--- a/tests/unit/steps/fixVideo.spec.ts
+++ b/tests/unit/steps/fixVideo.spec.ts
@@ -16,7 +16,7 @@ describe('ConfluenceProxy / add html5 video tag to visualize video attachment', 
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
   it('Adds video tag and poster image as preview', () => {

--- a/tests/unit/steps/fixVideo.spec.ts
+++ b/tests/unit/steps/fixVideo.spec.ts
@@ -16,7 +16,7 @@ describe('ConfluenceProxy / add html5 video tag to visualize video attachment', 
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
 
-    context.initPageContext('XXX', '123456', 'dark');
+    context.initPageContextRestAPIv2('XXX', '123456', 'dark');
   });
 
   it('Adds video tag and poster image as preview', () => {


### PR DESCRIPTION
- Migration getPage method to use Confluence REST API v2
- Unfortunately tight coupling in initPageContext during migration and because of that I had to for migration process for now create some helpers, because /search is using initPageContext with different output.