### PR TITLE
fix: WEB-2100 Fixed creating image caption

### DIFF
--- a/src/proxy-page/steps/fixCaptionImage.ts
+++ b/src/proxy-page/steps/fixCaptionImage.ts
@@ -18,7 +18,11 @@ export default (): Step => (context: ContextService): void => {
   const getImageCaption = (elementImg: cheerio.Element) => {
     const filename = elementImg.attribs['data-linked-resource-default-alias'];
     const attachmentContent = xmlStorageFormat(`ri\\:attachment[ri\\:filename="${filename}"]`);
-    const caption = Array.from(attachmentContent.parent().children()).find((el) => el.name === 'ac:caption');
+    const caption = Array.from(attachmentContent.parent().children()).find((el) =>
+      el.name === 'ac:caption' && !el.attribs['custom-property-available']);
+    if (caption) {
+      caption.attribs['custom-property-available'] = '1';
+    }
     return $(caption).text();
   };
 

--- a/tests/unit/steps/fixCaptionImage.spec.ts
+++ b/tests/unit/steps/fixCaptionImage.spec.ts
@@ -10,7 +10,7 @@ describe('ConfluenceProxy / fixCaptionImage', () => {
     beforeEach(async () => {
         const moduleRef = await createModuleRefForStep();
         context = moduleRef.get<ContextService>(ContextService);
-        context.setBodyStorage('<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption</p></ac:caption></ac:image><p />');
+        context.setBodyStorage('<ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption 1</p></ac:caption></ac:image><p /><ac:image ac:align="center" ac:layout="center" ac:original-height="512" ac:original-width="512"><ri:attachment ri:filename="unnamed (1).png" ri:version-at-save="1" /><ac:caption><p>exampleCaption 2</p></ac:caption></ac:image><p />');
         config = moduleRef.get<ConfigService>(ConfigService);
         context.initPageContext('v2', 'XXX', '123456', 'dark');
     });
@@ -19,6 +19,14 @@ describe('ConfluenceProxy / fixCaptionImage', () => {
         const mockBody = '<span class="confluence-embedded-file-wrapper image-center-wrapper"><img class="confluence-embedded-image image-center" loading="lazy" src="http://localhost:4000/cpv/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-image-src="https://sanofi.atlassian.net/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-height="512" data-width="512" data-unresolved-comment-count="0" data-linked-resource-id="64030409395" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="unnamed (1).png" data-base-url="https://sanofi.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="64024054246" data-linked-resource-container-version="3" data-media-id="2e93e007-c7d0-4f79-a397-a2b14158b4ff" data-media-type="file" width="512"></span>';
         context.setHtmlBody(mockBody);
         fixCaptionImage()(context);
-        expect(context.getHtmlBody().includes('<p class="image-caption">exampleCaption</p>')).toBe(true);
+        expect(context.getHtmlBody().includes('<p class="image-caption">exampleCaption 1</p>')).toBe(true);
+    });
+
+    it('FixCaptionImage should take into account if same caption for the same file was already used', () => {
+        const mockBody = '<span class="confluence-embedded-file-wrapper image-center-wrapper"><img class="confluence-embedded-image image-center" loading="lazy" src="http://localhost:4000/cpv/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-image-src="https://sanofi.atlassian.net/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-height="512" data-width="512" data-unresolved-comment-count="0" data-linked-resource-id="64030409395" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="unnamed (1).png" data-base-url="https://sanofi.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="64024054246" data-linked-resource-container-version="3" data-media-id="2e93e007-c7d0-4f79-a397-a2b14158b4ff" data-media-type="file" width="512"></span><span class="confluence-embedded-file-wrapper image-center-wrapper"><img class="confluence-embedded-image image-center" loading="lazy" src="http://localhost:4000/cpv/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-image-src="https://sanofi.atlassian.net/wiki/download/attachments/64024054246/unnamed%20(1).png?version=1&amp;modificationDate=1680164613913&amp;cacheVersion=1&amp;api=v2" data-height="512" data-width="512" data-unresolved-comment-count="0" data-linked-resource-id="64030409395" data-linked-resource-version="1" data-linked-resource-type="attachment" data-linked-resource-default-alias="unnamed (1).png" data-base-url="https://sanofi.atlassian.net/wiki" data-linked-resource-content-type="image/png" data-linked-resource-container-id="64024054246" data-linked-resource-container-version="3" data-media-id="2e93e007-c7d0-4f79-a397-a2b14158b4ff" data-media-type="file" width="512"></span>';
+        context.setHtmlBody(mockBody);
+        fixCaptionImage()(context);
+        expect(context.getHtmlBody().includes('<p class="image-caption">exampleCaption 1</p>')).toBe(true);
+        expect(context.getHtmlBody().includes('<p class="image-caption">exampleCaption 2</p>')).toBe(true);
     });
 });


### PR DESCRIPTION
- Confluence does not provide a unique ID for a signature that is stored at the body-storage level. Using the same photos means that we are unable to distinguish exactly which signature matches the same photo. As part of this, we provide an additional property 'custom-property-available', which will help us avoid the error of overwriting the caption in the wrong photo.