### PR TITLE
BugFix: WEB-2133 visualize draft pages

### DIFF
--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -48,14 +48,12 @@ export class ConfluenceService {
       const contentType = this.getApiEndPoint(typeContentResponse, pageId);
 
       if (contentType) {
-        const params = {
-          version,
-          status: status ?? 'current',
-        };
+        const params = { version };
 
-        if (spaceContent) {
-          params['space-id'] = spaceContent.id;
-        }
+        params['space-id'] = (spaceContent) ? spaceContent.id : null;
+        // get-draft parameter expected by the new API v2
+        // https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-id-get
+        params['get-draft'] = (status === 'draft');
 
         const [pageContent, labelsContent, propertiesContent] = await Promise.all([
           this.getContentTypeBody(contentType, pageId, params),


### PR DESCRIPTION
- Keep draft version visualization as per changes from new API v2 which expect params get-draft
- https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-id-get