### PR TITLE
fix: new release for fixes WEB-2133 and WEB-2137

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "konviw",
   "version": "3.20.1",
-  "description": "Enterprise public viewer for your Confluence pages.",
+  "description": "Enterprise viewer for your Confluence pages",
   "author": "Jose Gascon",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
- WEB-2137 Smart link cards do not display properly images from meta twitter or opengraph
- WEB-2133 retrieve properly head images from twitter (twitter:image) and opengraph (og:image)
- separate and organize styles in _links.scss for better maintenance and  fix tests with new styles
- draft page visualization as per changes from new API v2 which expect params get-draft
- https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-id-get

Resolves WEB-2137, WEB-2133