### PR TITLE
BugFix Web 2132 adjust konviw to new table width

### DIFF
--- a/src/assets/scss/_content-layout.scss
+++ b/src/assets/scss/_content-layout.scss
@@ -9,7 +9,7 @@
   margin: auto;
 
   &.fullWidth {
-    max-width: 100%;
+    max-width: 95%;
   }
 
   .contentLayout2 {

--- a/src/assets/scss/_links.scss
+++ b/src/assets/scss/_links.scss
@@ -54,6 +54,20 @@ a.external-link {
   max-width: 850px;
   max-height: 150px;
   align-items: flex-start;
+
+  &:hover {
+    filter: invert(3%);
+  }
+
+  a {
+    color: var(--primary-color-link);
+    transition: none;
+    background-image: none;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .link-card-content {

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -10,7 +10,7 @@ table.confluenceTable {
 
   // Fix 'default' tables to 60% of the layout width
   &[data-layout='default'] {
-    max-width: 60%;
+    max-width: 100%;
   }
 
   // Fix 'wide' tables to fit the 100% of the layout
@@ -57,6 +57,8 @@ table.confluenceTable th.confluenceTh {
   min-width: 8px; /* CONF-39943: set table cell min-width to which cursor can be focused */
   word-wrap: break-word;
   // word-break: break-word; // breaking words will fix the max-width properties for all tables
+  font-size: 1rem;
+  font-weight: lighter;
 
   h1,
   h2,

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -38,6 +38,7 @@ html {
 h1.titlePage {
   color: var(--heading-color);
   font-size: var(--title-font-size);
+  padding-top: 0.8rem;
 
   & .specialAtlassian {
     display: flex;

--- a/src/assets/scss/iadc/_content-layout.scss
+++ b/src/assets/scss/iadc/_content-layout.scss
@@ -9,7 +9,7 @@
   margin: auto;
 
   &.fullWidth {
-    max-width: 100%;
+    max-width: 95%;
   }
 
   .contentLayout2 {

--- a/src/assets/scss/iadc/_links.scss
+++ b/src/assets/scss/iadc/_links.scss
@@ -54,6 +54,20 @@ a.external-link {
   max-width: 850px;
   max-height: 150px;
   align-items: flex-start;
+
+  &:hover {
+    filter: invert(3%);
+  }
+
+  a {
+    color: var(--primary-color-link);
+    transition: none;
+    background-image: none;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .link-card-content {

--- a/src/assets/scss/iadc/_variables.scss
+++ b/src/assets/scss/iadc/_variables.scss
@@ -7,7 +7,7 @@ $font-body: 'Lora', serif;
 $font-title: 'Gotu', serif;
 $font-icons: 'Material Icons', serif;
 
-$base-width: 700px;
+$base-width: 900px;
 $main-font-mobile: 18px;
 $main-font-screen: 20px;
 $main-font-weight: 300;

--- a/src/assets/scss/iadc/custom.scss
+++ b/src/assets/scss/iadc/custom.scss
@@ -38,6 +38,7 @@ html {
 h1.titlePage {
   color: var(--heading-color);
   font-size: var(--title-font-size);
+  padding-top: 0.8rem;
 
   & .specialAtlassian {
     display: flex;

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -45,6 +45,7 @@ import addSlideContextByStrategy from './strategySteps/addSlideContextByStrategy
 import fixCaptionImage from './steps/fixCaptionImage';
 import fixConfluenceSpace from './steps/fixConfluenceSpace';
 import addTableResponsive from './steps/addTableResponsive';
+import fixTableSize from './steps/fixTableSize';
 import addAuthorVersion from './steps/addAuthorVersion';
 import addMessageLastSlide from './steps/addMessageLastSlide';
 import addPDF from './steps/addPDF';
@@ -133,6 +134,7 @@ export class ProxyPageService {
     }
     fixSVG(this.config)(this.context);
     fixTableBackground()(this.context);
+    fixTableSize()(this.context);
     addTableResponsive()(this.context);
     addAuthorVersion()(this.context);
     delUnnecessaryCode()(this.context);
@@ -200,7 +202,7 @@ export class ProxyPageService {
     fixFrameAllowFullscreen()(this.context);
     fixSVG(this.config)(this.context);
     fixTableBackground()(this.context);
-    addTableResponsive()(this.context);
+    // addTableResponsive()(this.context);
     delUnnecessaryCode()(this.context);
     await addJiraPromise;
     addSlideTypeByStrategy(this.config)(this.context);

--- a/src/proxy-page/steps/fixLinks.ts
+++ b/src/proxy-page/steps/fixLinks.ts
@@ -134,7 +134,7 @@ export default (config: ConfigService, http: HttpService, jira: JiraService): St
             <div class="link-card-content">
               <a target="_blank" href="${url}"> <img class="${classIconName}" src="${path}"/> ${title}</a>
               <p class="link-card-description">${description ?? ''}</p>
-              <a target="_blank" href="${getDomain(url)}">${getDomain(url)}</a>
+              <a target="_blank" href="${getOrigin(url)}">${getDomain(url)}</a>
             </div>
             ${imgTag}
           </div>`;
@@ -254,3 +254,6 @@ export default (config: ConfigService, http: HttpService, jira: JiraService): St
 
 // Get the domain of a url
 const getDomain = (url: string) => new URL(url).host;
+
+// Get the origin of a url (domain with protocol)
+const getOrigin = (url: string) => new URL(url).origin;

--- a/src/proxy-page/steps/fixTableSize.ts
+++ b/src/proxy-page/steps/fixTableSize.ts
@@ -1,0 +1,24 @@
+import * as cheerio from 'cheerio';
+import { ContextService } from '../../context/context.service';
+import { Step } from '../proxy-page.step';
+
+export default (): Step => (context: ContextService): void => {
+  context.setPerfMark('fixTableSize');
+  const $ = context.getCheerioBody();
+
+  $('table').each(
+    (_macroIndex: number, tableElement: cheerio.Element) => {
+      const tableWidth = $(tableElement).attr('data-table-width');
+      if (tableWidth) {
+        const tableWidthValue = Number(tableWidth);
+        if (tableWidthValue > 1400) {
+          $(tableElement).css('width', '100%');
+        } else {
+          $(tableElement).css('width', tableWidth);
+        }
+      }
+    },
+  );
+
+  context.getPerfMeasure('fixTableSize');
+};

--- a/tests/unit/steps/fixTableSize.spec.ts
+++ b/tests/unit/steps/fixTableSize.spec.ts
@@ -1,0 +1,55 @@
+import { ContextService } from '../../../src/context/context.service';
+import { Step } from '../../../src/proxy-page/proxy-page.step';
+import fixTableSize from '../../../src/proxy-page/steps/fixTableSize';
+import { createModuleRefForStep } from './utils';
+
+describe('Confluence Proxy / fixTableSize', () => {
+  let context: ContextService;
+  let step: Step;
+
+  beforeEach(async () => {
+    step = fixTableSize();
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+  });
+
+  it('should add style with width equal to attribute data-table-width', () => {
+    context.setHtmlBody('<html><head></head><body><h1 class="titlePage"> Demo table</h1>'+
+    '<div class="table-wrap">'+
+    '<table data-table-width="760" data-layout="default" class="confluenceTable">'+
+    '<colgroup><col><col><col></colgroup>'+
+    '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
+    '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
+    '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
+    '</tbody></table></div><p></p></body></html>');
+    step(context);
+    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
+    '<div class=\"table-wrap\">'+
+    '<table data-table-width=\"760\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 760;\">'+
+    '<colgroup><col><col><col></colgroup>'+
+    '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
+    '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
+    '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
+    '</tbody></table></div><p></p></div></body></html>');
+  });
+
+  it('should add style with width 100% if attribute data-table-width is > 1400px', () => {
+    context.setHtmlBody('<html><head></head><body><h1 class="titlePage"> Demo table</h1>'+
+    '<div class="table-wrap">'+
+    '<table data-table-width="1500" data-layout="default" class="confluenceTable">'+
+    '<colgroup><col><col><col></colgroup>'+
+    '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
+    '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
+    '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
+    '</tbody></table></div><p></p></body></html>');
+    step(context);
+    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
+    '<div class=\"table-wrap\">'+
+    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 100%;\">'+
+    '<colgroup><col><col><col></colgroup>'+
+    '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
+    '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
+    '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
+    '</tbody></table></div><p></p></div></body></html>');
+  });
+});


### PR DESCRIPTION
- as described in https://community.atlassian.com/t5/Confluence-articles/Resize-Confluence-tables-to-any-width/ba-p/2483925
- if table width > 1400 then width will be set to 100%
- using url.origin instead of domain to display properly the URL
- include a hover effect for the full smart link card
- increase 5% the padding between page borders in fullWidth
- increase slightly title separation from top border