### PR TITLE
feat: WEB-2143 zoom effect images with Alt=(zoom)

### DIFF
--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -21,7 +21,7 @@ import addCustomCss from './steps/addCustomCss';
 import addScrollToTop from './steps/addScrollToTop';
 import addHeaderTitle from './steps/addHeaderTitle';
 import addTheme from './steps/addTheme';
-import addNoZoom from './steps/addNoZoom';
+import addZoom from './steps/addZoom';
 import addHeaderBlog from './steps/addHeaderBlog';
 import addCopyLinks from './steps/addCopyLinks';
 import addReadingProgressBar from './steps/addReadingProgressBar';
@@ -140,7 +140,7 @@ export class ProxyPageService {
     delUnnecessaryCode()(this.context);
     addCustomCss(this.config, style)(this.context);
     addLibrariesCSS()(this.context);
-    addNoZoom()(this.context);
+    addZoom()(this.context);
     addTheme()(this.context);
     if (view !== 'iframe-resizer') {
       addScrollToTop()(this.context);

--- a/src/proxy-page/steps/addLibrariesJS.ts
+++ b/src/proxy-page/steps/addLibrariesJS.ts
@@ -48,7 +48,7 @@ export default (): Step => (context: ContextService): void => {
             onClose: (target) => toggleOverflowStyling(getParentZommingElement(target), 'auto'),
           });
           zooming.listen('.drawio-zoomable');
-          zooming.listen('.confluence-embedded-image');
+          zooming.listen('.konviw-image-zoom-effect');
         })
          </script>`,
     );
@@ -58,9 +58,9 @@ export default (): Step => (context: ContextService): void => {
   // and auto resizer of the iframe to the content of the konviw page
   // https://github.com/davidjbradshaw/iframe-resizer
   $('body').append(
-    `<script 
-      src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js" 
-      crossorigin="anonymous" 
+    `<script
+      src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js"
+      crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
       <script type="module">

--- a/src/proxy-page/steps/addZoom.ts
+++ b/src/proxy-page/steps/addZoom.ts
@@ -3,7 +3,7 @@ import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 
 export default (): Step => (context: ContextService): void => {
-  context.setPerfMark('addNoZoom');
+  context.setPerfMark('addZoom');
   const $ = context.getCheerioBody();
 
   // Div with class profile-macro is used for User Profile VCard
@@ -11,13 +11,13 @@ export default (): Step => (context: ContextService): void => {
     (_index: number, embeddedImage: cheerio.Element) => {
       const thisBlock = $(embeddedImage).attr('alt');
       if (thisBlock) {
-        const foundBlock = thisBlock.match(/\(nozoom\)/g);
+        const foundBlock = thisBlock.match(/\(zoom\)/g);
         if (foundBlock) {
-          $(embeddedImage).removeClass('confluence-embedded-image');
+          $(embeddedImage).addClass('konviw-image-zoom-effect');
         }
       }
     },
   );
 
-  context.getPerfMeasure('addNoZoom');
+  context.getPerfMeasure('addZoom');
 };

--- a/tests/unit/steps/addZoom.spec.ts
+++ b/tests/unit/steps/addZoom.spec.ts
@@ -1,0 +1,32 @@
+import addZoom from '../../../src/proxy-page/steps/addZoom';
+import { ContextService } from '../../../src/context/context.service';
+import { createModuleRefForStep } from './utils';
+
+describe('ConfluenceProxy / addZoom', () => {
+  let context: ContextService;
+  const step = addZoom();
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
+    context.setHtmlBody('<html><head></head><body></body></html>');
+  });
+
+  it('should add the class konviw-image-zoom-effect to trigger zoom effect', () => {
+    const imgTagWithoutWidth =
+      '<img id = "imgId1" class="confluence-embedded-image image-center" alt="(zoom)" src="" data-height="291" data-width="289">';
+    context.setHtmlBody(imgTagWithoutWidth);
+    step(context);
+    expect(context.getHtmlBody()).toContain('konviw-image-zoom-effect');
+  });
+
+  it('should not add zoom effect to the img tag', () => {
+    const imgTagWithoutWidth =
+      '<img id = "imgId1" class="confluence-embedded-image image-center" alt="this will not zoom" src="" data-height="291" data-width="289">';
+    context.setHtmlBody(imgTagWithoutWidth);
+    step(context);
+    expect(context.getHtmlBody()).not.toContain('konviw-image-zoom-effect');
+  });
+
+});


### PR DESCRIPTION
- inverting the previous behaviour with zoom by default
- now the attribute Alt must contain (zoom) to trigger the zoom effect