### PR TITLE
Feature: display page owner instead of creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings 3",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix --max-warnings 3",
-    "test": "npm run test:unit:cov && npm run test:e2e",
+    "test": "npm run test:unit:cov",
     "test:unit:watch": "jest --config jest-unit.config.js --watch",
     "test:unit:cov": "jest --config jest-unit.config.js --coverage",
     "test:unit:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings 3",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix --max-warnings 3",
-    "test": "npm run test:unit:cov",
+    "test": "npm run test:unit:cov && npm run test:e2e",
     "test:unit:watch": "jest --config jest-unit.config.js --watch",
     "test:unit:cov": "jest --config jest-unit.config.js --coverage",
     "test:unit:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -266,6 +266,7 @@ export type PageContent = {
   },
   parentType: string;
   authorId: string;
+  ownerId: string;
   title: string;
   status: ContentStatusType;
   body: { view: { value: string }, storage: { value: string } },

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -62,7 +62,7 @@ export class ConfluenceService {
         ]);
 
         const [authorContent, versionAuthorContent] = await Promise.all([
-          this.getAccountDataById((pageContent as Content['pageContent']).authorId),
+          this.getAccountDataById((pageContent as Content['pageContent']).ownerId),
           this.getAccountDataById((pageContent as Content['pageContent']).version.authorId),
         ]);
 

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -62,7 +62,8 @@ export class ConfluenceService {
         ]);
 
         const [authorContent, versionAuthorContent] = await Promise.all([
-          this.getAccountDataById((pageContent as Content['pageContent']).ownerId),
+          this.getAccountDataById((pageContent as Content['pageContent']).ownerId
+            ?? (pageContent as Content['pageContent']).authorId),
           this.getAccountDataById((pageContent as Content['pageContent']).version.authorId),
         ]);
 

--- a/src/proxy-page/steps/addAuthorVersion.ts
+++ b/src/proxy-page/steps/addAuthorVersion.ts
@@ -15,8 +15,8 @@ export default (): Step => (context: ContextService): void => {
   const isTitleType = type.includes('title');
 
   const authorVersionFactory = () => {
-    const pageVersionHtml = isVersionType ? `<p class="author_text">Page version: ${version?.versionNumber}</p>` : '';
-    const pageAuthorHtml = `<p class="author_text">Creator: ${author}</p>`;
+    const pageVersionHtml = isVersionType ? `<p class="author_text">Version: ${version?.versionNumber}</p>` : '';
+    const pageAuthorHtml = `<p class="author_text">Owner: ${author}</p>`;
 
     return `<div class="author_header">
       <img src="${image_author}" class="author_image">

--- a/tests/unit/steps/addAuthorVersion.spec.ts
+++ b/tests/unit/steps/addAuthorVersion.spec.ts
@@ -34,8 +34,8 @@ describe('Confluence Proxy / addAuthorVersion', () => {
     );
     step(context);
     const htmlBody = context.getHtmlBody().trim();
-    expect(htmlBody.includes(`<p class="author_text">Creator: Test</p>`)).toBe(true);
-    expect(htmlBody.includes(`<p class="author_text">Page version: 2</p>`)).toBe(true);
+    expect(htmlBody.includes(`<p class="author_text">Owner: Test</p>`)).toBe(true);
+    expect(htmlBody.includes(`<p class="author_text">Version: 2</p>`)).toBe(true);
   });
 
   it('should render only author name', () => {
@@ -46,8 +46,8 @@ describe('Confluence Proxy / addAuthorVersion', () => {
     );
     step(context);
     const htmlBody = context.getHtmlBody().trim();
-    expect(htmlBody.includes(`<p class="author_text">Creator: Test</p>`)).toBe(true);
-    expect(htmlBody.includes(`<p class="author_text">Page version: 2</p>`)).toBe(false);
+    expect(htmlBody.includes(`<p class="author_text">Owner: Test</p>`)).toBe(true);
+    expect(htmlBody.includes(`<p class="author_text">Version: 2</p>`)).toBe(false);
   });
 
   it('should not render author name and page version', () => {
@@ -58,7 +58,7 @@ describe('Confluence Proxy / addAuthorVersion', () => {
     );
     step(context);
     const htmlBody = context.getHtmlBody().trim();
-    expect(htmlBody.includes(`<p class="author_text">Creator: Test</p>`)).toBe(false);
-    expect(htmlBody.includes(`<p class="author_text">Page version: 2</p>`)).toBe(false);
+    expect(htmlBody.includes(`<p class="author_text">Owner: Test</p>`)).toBe(false);
+    expect(htmlBody.includes(`<p class="author_text">Version: 2</p>`)).toBe(false);
   });
 });


### PR DESCRIPTION
Since a few months Atlassian release a new feature in Confluence to be able to define page owners in addition to the initial creator and last author.
We initially connected the author attribute of the page with the page creator, while with this new feature makes more sense to refer to the new attribute owner of the page.

Resolves WEB-2182