### PR TITLE
Fix: WEB-2209 Display inline text embedded files

### DIFF
--- a/src/assets/scss/_links.scss
+++ b/src/assets/scss/_links.scss
@@ -127,3 +127,63 @@ a.user-mention {
   width: 20px;
   padding-bottom: 0;
 }
+
+// Hyperlinks for embedded files ==================================
+a.konviw-embedded-file-icon {
+  &::before {
+    content: '\f15c';
+    font-family: "Font Awesome 6 free";
+    font-size: 24px;
+    font-weight: 100;
+    padding-right: 5px;
+    color: grey;
+  }
+  &[href*='.pdf']::before {
+    content: '\f1c1';
+  }
+  &[href*='.doc']::before {
+    content: '\f1c2';
+  }
+  &[href*='.ppt']::before {
+    content: '\f1c4';
+  }
+  &[href*='.xls']::before {
+    content: '\f1c3';
+  }
+  &[href*='.zip']::before {
+    content: '\f1c6';
+  }
+  &:is([href*='.mp3'], [href*='.aac'], [href*='.ac3'], [href*='.aif'],
+    [href*='.m4a'], [href*='.mid'], [href*='.ogg'], [href*='.wav'])::before {
+    content: '\f1c7';
+  }
+}
+
+p.media-group {
+  padding: 0px;
+  margin: 0px;
+}
+
+div.konviw-embedded-file {
+  width: 250px;
+  /* To correctly align image, regardless of content height: */
+  padding-top: 10px;
+  vertical-align: top;
+  display: inline-block;
+  /* To horizontally center images and caption */
+  text-align: center;
+  img {
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    padding: 0px;
+    border: 1px;
+    border-style:solid;
+    border-color: lightgrey;
+    border-radius: 2%;
+  }
+  span.konviw-embedded-file-caption {
+    /* Make the caption a block so it occupies its own line. */
+    padding: 5px;
+    font-size: 0.6em;
+    display: block;
+  }
+}

--- a/src/assets/scss/_links.scss
+++ b/src/assets/scss/_links.scss
@@ -131,8 +131,8 @@ a.user-mention {
 // Hyperlinks for embedded files ==================================
 a.konviw-embedded-file-icon {
   &::before {
+    font-family: 'Font Awesome 5 Free', sans-serif;
     content: '\f15c';
-    font-family: "Font Awesome 6 free";
     font-size: 24px;
     font-weight: 100;
     padding-right: 5px;

--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -46,7 +46,3 @@ img {
   }
 }
 
-p.media-group {
-  padding: 0px;
-  margin: 0px;
-}

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -83,6 +83,11 @@ $small-text: 12px;
   --macro-info-panel-symbol-warning: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' color='orange' viewBox='0 0 24 24' focusable='false' role='presentation'><path d='M12.938 4.967c-.518-.978-1.36-.974-1.876 0L3.938 18.425c-.518.978-.045 1.771 1.057 1.771h14.01c1.102 0 1.573-.797 1.057-1.771L12.938 4.967z' fill='currentColor' fill-rule='evenodd'/><path d='M12 15a1 1 0 0 1-1-1V9a1 1 0 0 1 2 0v5a1 1 0 0 1-1 1m0 3a1 1 0 0 1 0-2 1 1 0 0 1 0 2' fill='white'/></svg>");
   --macro-info-panel-bg-warning: #fffae6;
   --macro-info-panel-border-warning: #edd130;
+
+  // shadow boxes
+  --tw-shadow: 0px 0px 24px -2px rgba(16,24,40,.16);
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-ring-offset-shadow: 0 0 #0000;
 }
 
 [data-theme='dark'] {

--- a/src/assets/scss/iadc/_links.scss
+++ b/src/assets/scss/iadc/_links.scss
@@ -127,3 +127,63 @@ a.user-mention {
   width: 20px;
   padding-bottom: 0;
 }
+
+// Hyperlinks for embedded files ==================================
+a.konviw-embedded-file-icon {
+  &::before {
+    content: '\f15c';
+    font-family: "Font Awesome 6 free";
+    font-size: 24px;
+    font-weight: 100;
+    padding-right: 5px;
+    color: grey;
+  }
+  &[href*='.pdf']::before {
+    content: '\f1c1';
+  }
+  &[href*='.doc']::before {
+    content: '\f1c2';
+  }
+  &[href*='.ppt']::before {
+    content: '\f1c4';
+  }
+  &[href*='.xls']::before {
+    content: '\f1c3';
+  }
+  &[href*='.zip']::before {
+    content: '\f1c6';
+  }
+  &:is([href*='.mp3'], [href*='.aac'], [href*='.ac3'], [href*='.aif'],
+    [href*='.m4a'], [href*='.mid'], [href*='.ogg'], [href*='.wav'])::before {
+    content: '\f1c7';
+  }
+}
+
+p.media-group {
+  padding: 0px;
+  margin: 0px;
+}
+
+div.konviw-embedded-file {
+  width: 250px;
+  /* To correctly align image, regardless of content height: */
+  padding-top: 10px;
+  vertical-align: top;
+  display: inline-block;
+  /* To horizontally center images and caption */
+  text-align: center;
+  img {
+    box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+    padding: 0px;
+    border: 1px;
+    border-style:solid;
+    border-color: lightgrey;
+    border-radius: 2%;
+  }
+  span.konviw-embedded-file-caption {
+    /* Make the caption a block so it occupies its own line. */
+    padding: 5px;
+    font-size: 0.6em;
+    display: block;
+  }
+}

--- a/src/assets/scss/iadc/_links.scss
+++ b/src/assets/scss/iadc/_links.scss
@@ -132,7 +132,7 @@ a.user-mention {
 a.konviw-embedded-file-icon {
   &::before {
     content: '\f15c';
-    font-family: "Font Awesome 6 free";
+    font-family: 'Font Awesome 5 Free', sans-serif;
     font-size: 24px;
     font-weight: 100;
     padding-right: 5px;

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -45,8 +45,3 @@ img {
     margin-top: -5px;
   }
 }
-
-p.media-group {
-  padding: 0px;
-  margin: 0px;
-}

--- a/src/assets/scss/iadc/_variables.scss
+++ b/src/assets/scss/iadc/_variables.scss
@@ -82,6 +82,11 @@ $small-text: 12px;
   --macro-info-panel-symbol-warning: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' color='orange' viewBox='0 0 24 24' focusable='false' role='presentation'><path d='M12.938 4.967c-.518-.978-1.36-.974-1.876 0L3.938 18.425c-.518.978-.045 1.771 1.057 1.771h14.01c1.102 0 1.573-.797 1.057-1.771L12.938 4.967z' fill='currentColor' fill-rule='evenodd'/><path d='M12 15a1 1 0 0 1-1-1V9a1 1 0 0 1 2 0v5a1 1 0 0 1-1 1m0 3a1 1 0 0 1 0-2 1 1 0 0 1 0 2' fill='white'/></svg>");
   --macro-info-panel-bg-warning: #fffae6;
   --macro-info-panel-border-warning: #edd130;
+
+  // shadow boxes
+  --tw-shadow: 0px 0px 24px -2px rgba(16,24,40,.16);
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-ring-offset-shadow: 0 0 #0000;
 }
 
 [data-theme='dark'] {

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -50,6 +50,7 @@ import addAuthorVersion from './steps/addAuthorVersion';
 import addMessageLastSlide from './steps/addMessageLastSlide';
 import addPDF from './steps/addPDF';
 import fixProfilePicture from './steps/fixProfilePicture';
+import fixEmbeddedFile from './steps/fixEmbeddedFile';
 
 @Injectable()
 export class ProxyPageService {
@@ -133,6 +134,7 @@ export class ProxyPageService {
       await addHeaderTitle(this.confluence)(this.context);
     }
     fixSVG(this.config)(this.context);
+    fixEmbeddedFile()(this.context);
     fixTableBackground()(this.context);
     fixTableSize()(this.context);
     addTableResponsive()(this.context);
@@ -187,6 +189,7 @@ export class ProxyPageService {
     fixHtmlHead(this.config)(this.context);
     fixUserProfile()(this.context);
     fixProfilePicture()(this.context);
+    fixEmbeddedFile()(this.context);
     await fixConfluenceSpace(this.config, this.confluence)(this.context);
     await fixLinks(this.config, this.http, this.jira)(this.context);
     fixToc()(this.context);

--- a/src/proxy-page/steps/fixEmbeddedFile.ts
+++ b/src/proxy-page/steps/fixEmbeddedFile.ts
@@ -1,0 +1,36 @@
+import * as cheerio from 'cheerio';
+import { Step } from '../proxy-page.step';
+import { ContextService } from '../../context/context.service';
+
+/* eslint-disable no-useless-escape, prefer-regex-literals */
+export default (): Step => async (context: ContextService): Promise<void> => {
+  context.setPerfMark('fixEmbeddedFile');
+
+  const $ = context.getCheerioBody();
+
+  $('a.confluence-embedded-file').each(
+    (_index: number, elementCode: cheerio.Element) => {
+      // retrieve the filename to display under the thumbnail or as text for the link
+      const fileName = $(elementCode).attr('data-linked-resource-default-alias');
+      if ($(elementCode).parent().parent().hasClass('media-group')) {
+        // for embedded files with media-group we wrap the whole a node with a new div and class
+        // to be able to customize accordingly the display of the thumbnail and caption
+        $(elementCode).parent().parent().wrap('<div class="konviw-embedded-file">');
+        $(elementCode).parent().parent().append(`<span class="konviw-embedded-file-caption">${fileName}</span>`);
+      } else {
+        // if there is no media-group class we will add simply the filename to the link
+        $(elementCode).text(fileName);
+        $(elementCode).addClass('konviw-embedded-file-icon');
+      }
+
+      // if debug then show the macro debug frame
+      if (context.getView() === 'debug') {
+        $(elementCode).wrap(
+          '<div class="debug-macro-indicator debug-macro-code">',
+        );
+      }
+    },
+  );
+
+  context.getPerfMeasure('fixEmbeddedFile');
+};

--- a/src/proxy-page/steps/fixEmbeddedFile.ts
+++ b/src/proxy-page/steps/fixEmbeddedFile.ts
@@ -3,7 +3,7 @@ import { Step } from '../proxy-page.step';
 import { ContextService } from '../../context/context.service';
 
 /* eslint-disable no-useless-escape, prefer-regex-literals */
-export default (): Step => async (context: ContextService): Promise<void> => {
+export default (): Step => (context: ContextService): void => {
   context.setPerfMark('fixEmbeddedFile');
 
   const $ = context.getCheerioBody();

--- a/tests/unit/steps/fixEmbedddedFile.spec.ts
+++ b/tests/unit/steps/fixEmbedddedFile.spec.ts
@@ -1,0 +1,121 @@
+import { ContextService } from '../../../src/context/context.service';
+import { createModuleRefForStep } from './utils';
+import fixEmbeddedFile from '../../../src/proxy-page/steps/fixEmbeddedFile';
+
+describe('ConfluenceProxy / fixEmbeddedFile', () => {
+  let context: ContextService;
+
+  const embeddedFile = '<span class="confluence-embedded-file-wrapper conf-macro output-inline">' +
+                        '<a class="confluence-embedded-file" ' +
+                          'href="http://localhost:4000/cpv/wiki/download/attachments/64425626715/file-name.pdf" ' +
+                          'data-nice-type="PDF Document" data-linked-resource-default-alias="file-name.pdf" ' +
+                          'data-mime-type="application/pdf" data-has-thumbnail="true" data-linked-resource-version="1" ' +
+                          'data-media-id="8601b073-105d-4f4a-90d1-82d45cfd3263" data-media-type="file">' +
+                          '<img src="http://localhost:4000/cpv/wiki/download/thumbnails/64425626715/file-name.pdf" height="250">' +
+                        '</a>'+
+                      '</span>'
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
+  });
+
+  it('should display thumbnail', () => {
+    const step = fixEmbeddedFile();
+    const example =
+    '<html><head></head><body>' +
+      '<p class="media-group">' + embeddedFile + '</p>' +
+    '</body></html>';
+
+    context.setHtmlBody(example);
+    step(context);
+    const expected = '<html><head></head><body>' +
+      '<div id="Content">' +
+        '<div class="konviw-embedded-file">' +
+          '<p class="media-group">' +
+            '<span class="confluence-embedded-file-wrapper conf-macro output-inline">' +
+              '<a class="confluence-embedded-file" '+
+                'href="http://localhost:4000/cpv/wiki/download/attachments/64425626715/file-name.pdf" ' +
+                'data-nice-type="PDF Document" data-linked-resource-default-alias="file-name.pdf" ' +
+                'data-mime-type="application/pdf" data-has-thumbnail="true" data-linked-resource-version="1" ' +
+                'data-media-id="8601b073-105d-4f4a-90d1-82d45cfd3263" data-media-type="file">' +
+                '<img src="http://localhost:4000/cpv/wiki/download/thumbnails/64425626715/file-name.pdf" height="250">' +
+              '</a>' +
+            '</span>' +
+            '<span class="konviw-embedded-file-caption">file-name.pdf</span>' +
+          '</p>' +
+        '</div>' +
+      '</div></body></html>';
+    expect(context.getHtmlBody()).toEqual(expected);
+  });
+
+  it('should display inline', () => {
+    const step = fixEmbeddedFile();
+    const example =
+    '<html><head></head><body>' +
+      '<p>' + embeddedFile + '</p>' +
+    '</body></html>';
+
+    context.setHtmlBody(example);
+    step(context);
+    const expected = '<html><head></head><body>' +
+      '<div id="Content">' +
+        '<p>' +
+          '<span class="confluence-embedded-file-wrapper conf-macro output-inline">' +
+            '<a class="confluence-embedded-file konviw-embedded-file-icon" '+
+              'href="http://localhost:4000/cpv/wiki/download/attachments/64425626715/file-name.pdf" ' +
+              'data-nice-type="PDF Document" data-linked-resource-default-alias="file-name.pdf" ' +
+              'data-mime-type="application/pdf" data-has-thumbnail="true" data-linked-resource-version="1" ' +
+              'data-media-id="8601b073-105d-4f4a-90d1-82d45cfd3263" data-media-type="file">' +
+              'file-name.pdf' +
+            '</a>' +
+          '</span>' +
+        '</p>' +
+      '</div></body></html>';
+    expect(context.getHtmlBody()).toEqual(expected);
+  });
+
+  it('should display one inline and one thumbnail', () => {
+    const step = fixEmbeddedFile();
+    const example =
+    '<html><head></head><body>' +
+      '<p>' + embeddedFile + '</p>' +
+      '<p class="media-group">' + embeddedFile + '</p>' +
+    '</body></html>';
+
+    context.setHtmlBody(example);
+    step(context);
+    const expected = '<html><head></head><body>' +
+      '<div id="Content">' +
+        '<p>' +
+          '<span class="confluence-embedded-file-wrapper conf-macro output-inline">' +
+            '<a class="confluence-embedded-file konviw-embedded-file-icon" '+
+              'href="http://localhost:4000/cpv/wiki/download/attachments/64425626715/file-name.pdf" ' +
+              'data-nice-type="PDF Document" data-linked-resource-default-alias="file-name.pdf" ' +
+              'data-mime-type="application/pdf" data-has-thumbnail="true" data-linked-resource-version="1" ' +
+              'data-media-id="8601b073-105d-4f4a-90d1-82d45cfd3263" data-media-type="file">' +
+              'file-name.pdf' +
+            '</a>' +
+          '</span>' +
+        '</p>' +
+        '<div class="konviw-embedded-file">' +
+          '<p class="media-group">' +
+            '<span class="confluence-embedded-file-wrapper conf-macro output-inline">' +
+              '<a class="confluence-embedded-file" '+
+                'href="http://localhost:4000/cpv/wiki/download/attachments/64425626715/file-name.pdf" ' +
+                'data-nice-type="PDF Document" data-linked-resource-default-alias="file-name.pdf" ' +
+                'data-mime-type="application/pdf" data-has-thumbnail="true" data-linked-resource-version="1" ' +
+                'data-media-id="8601b073-105d-4f4a-90d1-82d45cfd3263" data-media-type="file">' +
+                '<img src="http://localhost:4000/cpv/wiki/download/thumbnails/64425626715/file-name.pdf" height="250">' +
+              '</a>' +
+            '</span>' +
+            '<span class="konviw-embedded-file-caption">file-name.pdf</span>' +
+          '</p>' +
+        '</div>' +
+      '</div></body></html>';
+    expect(context.getHtmlBody()).toEqual(expected);
+  });
+
+
+});


### PR DESCRIPTION
- Fix to display inline text embeddd lines like a simple URL
- Thumbnails will remain visualized as an small image
- Enhancement to display a file-type icon before the inline text link

Resolves WEB-2209