### PR TITLE
BugFix: WEB-2291-new-confluence-feature-inline-images-not-working-in-konviw

### DIFF
--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -46,3 +46,9 @@ img {
   }
 }
 
+span.confluence-embedded-file-wrapper {
+  vertical-align:middle;
+  img.confluence-embedded-image {
+    padding: 0;
+  }
+}

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -40,7 +40,7 @@ table.confluenceTable th.confluenceTh {
   font-weight: bold;
 
   p {
-    font-weight: initial;
+    font-weight: var(--main-font-weight);
   }
 }
 
@@ -132,12 +132,6 @@ table.confluenceTable td.confluenceTd {
   }
 }
 
-table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */
-table.confluenceTable th.confluenceTh.nohighlight > p {
-  /* deprecated */
-  font-weight: normal;
-  background-color: transparent;
-}
 
 table.confluenceTable td.confluenceTd img,
 table.confluenceTable td.confluenceTd .confluence-embedded-file-wrapper img,

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -45,3 +45,10 @@ img {
     margin-top: -5px;
   }
 }
+
+span.confluence-embedded-file-wrapper {
+  vertical-align:middle;
+  img.confluence-embedded-image {
+    padding: 0;
+  }
+}

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -40,7 +40,7 @@ table.confluenceTable th.confluenceTh {
   font-weight: bold;
 
   p {
-    font-weight: initial;
+    font-weight: var(--main-font-weight);
   }
 }
 
@@ -128,13 +128,6 @@ table.confluenceTable td.confluenceTd {
   &.highlight-yellow > p {
     background-color: var(--highlight-yellow);
   }
-}
-
-table.confluenceTable th.confluenceTh.nohighlight, /* deprecated */
-table.confluenceTable th.confluenceTh.nohighlight > p {
-  /* deprecated */
-  font-weight: normal;
-  background-color: transparent;
 }
 
 table.confluenceTable td.confluenceTd img,

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -45,7 +45,7 @@ import addSlideContextByStrategy from './strategySteps/addSlideContextByStrategy
 import fixCaptionImage from './steps/fixCaptionImage';
 import fixConfluenceSpace from './steps/fixConfluenceSpace';
 import addTableResponsive from './steps/addTableResponsive';
-import fixTableSize from './steps/fixTableSize';
+// import fixTableSize from './steps/fixTableSize';
 import addAuthorVersion from './steps/addAuthorVersion';
 import addMessageLastSlide from './steps/addMessageLastSlide';
 import addPDF from './steps/addPDF';
@@ -136,7 +136,7 @@ export class ProxyPageService {
     fixSVG(this.config)(this.context);
     fixEmbeddedFile()(this.context);
     fixTableBackground()(this.context);
-    fixTableSize()(this.context);
+    // fixTableSize()(this.context);
     addTableResponsive()(this.context);
     addAuthorVersion()(this.context);
     delUnnecessaryCode()(this.context);

--- a/src/proxy-page/steps/fixImageSize.ts
+++ b/src/proxy-page/steps/fixImageSize.ts
@@ -1,4 +1,5 @@
 import * as cheerio from 'cheerio';
+import { Logger } from '@nestjs/common';
 import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-page.step';
 
@@ -6,17 +7,19 @@ import { Step } from '../proxy-page.step';
  * ### Proxy page step to fix image width
  *
  * This module gets Cheerio to search all images ('img')
- * and set the width according to attribute 'data-width'
+ * with class 'confluence-embedded-image' and
  * if the width attr was not directly provided by the API
+ * sets the width to display as mini-icon
  *
  * @param  {ConfigService} config
  * @returns void
  */
 export default (): Step => (context: ContextService): void => {
   context.setPerfMark('fixImageSize');
+  const logger = new Logger('fixImageSize');
   const $ = context.getCheerioBody();
 
-  $('img').each((_index: number, elementImg: cheerio.Element) => {
+  $('img.confluence-embedded-image').each((_index: number, elementImg: cheerio.Element) => {
     const imgURL = $(elementImg).attr('src') || $(elementImg).attr('_src');
     const imgDataWidth = $(elementImg).attr('data-width');
     if (
@@ -24,7 +27,8 @@ export default (): Step => (context: ContextService): void => {
         && imgDataWidth != null
         && !$(elementImg).attr('width')
     ) {
-      $(elementImg).attr('width', imgDataWidth);
+      $(elementImg).attr('width', '27px');
+      logger.log('Fixed width to inline icon');
     }
   });
 


### PR DESCRIPTION
- fixImageSize now fixes inline icons
- disable the fixTableSize as it is not needed anymore

resolves WEB-2291