### PR TITLE
Bugfix: regression legacy images

### DIFF
--- a/src/proxy-page/steps/fixImageSize.ts
+++ b/src/proxy-page/steps/fixImageSize.ts
@@ -19,14 +19,25 @@ export default (): Step => (context: ContextService): void => {
   const logger = new Logger('fixImageSize');
   const $ = context.getCheerioBody();
 
+  // for images with classes 'image-center', 'image-left' or 'image-right' we force the width
+  // attribute if this is not existing. This is a fix for the images before Confluence
+  // added the configuration of fixed size in the images
+  $(`img.confluence-embedded-image.image-center,
+     img.confluence-embedded-image.image-left,
+     confluence-embedded-image.image-right`)
+    .each((_index: number, elementImg: cheerio.Element) => {
+      const imgURL = $(elementImg).attr('src') || $(elementImg).attr('_src');
+      const imgDataWidth = $(elementImg).attr('data-width');
+      if (imgURL != null && imgDataWidth != null && !$(elementImg).attr('width')) {
+        $(elementImg).attr('width', imgDataWidth);
+        logger.log('Fixed width to ', imgDataWidth);
+      }
+    });
+
+  // for the other images without 'image-xxxxx' class then we assume it is an inline image
   $('img.confluence-embedded-image').each((_index: number, elementImg: cheerio.Element) => {
     const imgURL = $(elementImg).attr('src') || $(elementImg).attr('_src');
-    const imgDataWidth = $(elementImg).attr('data-width');
-    if (
-      imgURL != null
-        && imgDataWidth != null
-        && !$(elementImg).attr('width')
-    ) {
+    if (imgURL != null && !$(elementImg).attr('width')) {
       $(elementImg).attr('width', '27px');
       logger.log('Fixed width to inline icon');
     }


### PR DESCRIPTION
- Fix regression for legacy Confluence images width Introduces a solution to the regression caused by WEB-2291, where legacy Confluence images were incorrectly displayed as inline images due to the absence of width attributes in API data. This fix identifies images with specific 'image-center', 'image-left', or 'image-right' classes and ensures their width attributes are properly set based on their 'data-width' if not previously defined. This adjustment prevents legacy images from being treated as inline elements, addressing display issues and preserving the intended layout.

Resolves WEB-2292