### PR TITLE
BugFix: WEB-2293-rendering-of-tables-changed-by-confluence-with-fixed-table-width

### DIFF
--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -10,17 +10,17 @@ table.confluenceTable {
 
   // Fix 'default' tables to 60% of the layout width
   &[data-layout='default'] {
-    max-width: 100%;
+    width: 100%;
   }
 
   // Fix 'wide' tables to fit the 100% of the layout
   &[data-layout='wide'] {
-    max-width: 100%;
+    width: 100%;
   }
 
   // Fix 'full-width' tables to fit the 100% of the layout
   &[data-layout='full-width'] {
-    max-width: 100%;
+    width: 100%;
   }
 
   // Fix SVG's width embedded in tables like roadmap macros
@@ -47,6 +47,7 @@ table.confluenceTable th.confluenceTh {
 .table-wrap {
   box-sizing: border-box;
   // with sticky table headersm we cannot have the horizontal scroll.
+  // overflow:auto; // make tables that are too wide horizontally scrollable
 }
 
 .confluenceTh,

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -129,20 +129,6 @@ ul.childpages-macro li {
   padding-top: 5px;
 }
 
-// Tables embedded in a ‘Page Properties’ Macro will be displayed borderless
-// this technique will be used to embed footers or menus with tables used for better layout organization
-.conf-macro .plugin-tabmeta-details {
-  padding-top: 40px;
-  .table-wrap {
-    .confluenceTd {
-      border: 0px;
-      padding: 10px;
-      vertical-align: top;
-      font-size: 12px;
-    }
-  }
-}
-
 // Macro image with caption
 .image-caption {
   margin-top: .5rem;

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -46,7 +46,8 @@ table.confluenceTable th.confluenceTh {
 
 .table-wrap {
   box-sizing: border-box;
-  overflow: auto; // make tables that are too wide horizontally scrollable
+  // with sticky table headersm we cannot have the horizontal scroll.
+  // overflow:auto; // make tables that are too wide horizontally scrollable
 }
 
 .confluenceTh,

--- a/src/assets/scss/iadc/custom.scss
+++ b/src/assets/scss/iadc/custom.scss
@@ -141,20 +141,6 @@ ul.childpages-macro li {
   padding-top: 5px;
 }
 
-// Tables embedded in a ‘Page Properties’ Macro will be displayed borderless
-// this technique will be used to embed footers or menus with tables used for better layout organization
-.conf-macro .plugin-tabmeta-details {
-  padding-top: 40px;
-  .table-wrap {
-    .confluenceTd {
-      border: 0px;
-      padding: 10px;
-      vertical-align: top;
-      font-size: 12px;
-    }
-  }
-}
-
 // Macro image with caption
 .image-caption {
   margin-top: .5rem;

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,12 +68,23 @@ async function bootstrap() {
     prefix: `${basePath}`,
   });
 
-  // Views folder for Handlebar templates
-  app.setBaseViewsDir(join(__dirname, '..', '/views'));
-  app.setViewEngine('hbs');
-  hbs.registerPartials(join(__dirname, '..', '/views/partials'));
+  // Activate Handlebars
+  useHandlebars(app);
 
-  // Set up Swagger
+  // Activate OpenAPI
+  useOpenApi(app);
+
+  // Listen to server PORT
+  await app.listen(process.env.PORT || 3000);
+}
+
+bootstrap();
+
+// ================= Setup Swagger (OpenAPI) specification
+const useOpenApi = (app: NestExpressApplication) => {
+  const config = app.get(ConfigService);
+  const basePath = config.get('web.basePath');
+
   const configSwagger = new DocumentBuilder()
     .setTitle('konviw')
     .setDescription('Enterprise public viewer for your Confluence pages')
@@ -89,10 +100,13 @@ async function bootstrap() {
     customCssUrl: `${basePath}/css/swagger-theme-outline.css`,
   };
 
-  const document = SwaggerModule.createDocument(app, configSwagger);
+  const document = SwaggerModule.createDocument(app, configSwagger, { ignoreGlobalPrefix: false });
   SwaggerModule.setup(`${basePath}/oas3`, app, document, customOptions);
+};
 
-  // Listen to server PORT
-  await app.listen(process.env.PORT || 3000);
-}
-bootstrap();
+// ================= Setup Handlebars folders and templates
+const useHandlebars = (app:NestExpressApplication) => {
+  app.setBaseViewsDir(join(__dirname, '..', '/views'));
+  app.setViewEngine('hbs');
+  hbs.registerPartials(join(__dirname, '..', '/views/partials'));
+};

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -45,7 +45,7 @@ import addSlideContextByStrategy from './strategySteps/addSlideContextByStrategy
 import fixCaptionImage from './steps/fixCaptionImage';
 import fixConfluenceSpace from './steps/fixConfluenceSpace';
 import addTableResponsive from './steps/addTableResponsive';
-// import fixTableSize from './steps/fixTableSize';
+import fixTableSize from './steps/fixTableSize';
 import addAuthorVersion from './steps/addAuthorVersion';
 import addMessageLastSlide from './steps/addMessageLastSlide';
 import addPDF from './steps/addPDF';
@@ -136,7 +136,7 @@ export class ProxyPageService {
     fixSVG(this.config)(this.context);
     fixEmbeddedFile()(this.context);
     fixTableBackground()(this.context);
-    // fixTableSize()(this.context);
+    fixTableSize()(this.context);
     addTableResponsive()(this.context);
     addAuthorVersion()(this.context);
     delUnnecessaryCode()(this.context);

--- a/src/proxy-page/steps/fixColGroupWidth.ts
+++ b/src/proxy-page/steps/fixColGroupWidth.ts
@@ -18,7 +18,12 @@ export default (): Step => (context: ContextService): void => {
   const $ = context.getCheerioBody();
   $(
     // similar to 'table:not([data-layout="default"])>colgroup' we apply to fill-width and wide tables
-    "table[data-layout='full-width']>colgroup, table[data-layout= 'wide']> colgroup",
+    // Since Atlassian changed to fixed tabled it does not return anymore the data-layout via API
+    // https://community.atlassian.com/t5/Confluence-articles/Resize-Confluence-tables-to-any-width/ba-p/2483925
+    // consequently we apply now the calculation in % for all size of tables, while always returns "default"
+    `table[data-layout='full-width']>colgroup,
+    table[data-layout= 'wide']> colgroup,
+    table[data-layout='default']>colgroup`,
   ).each((_index: number, elementColgroup: cheerio.Element) => {
     let sumColWidth = 0;
     elementColgroup.childNodes.forEach((elementColumn: cheerio.Element) => {
@@ -39,6 +44,6 @@ export default (): Step => (context: ContextService): void => {
 function getElementValue(elementColumn: cheerio.Element): number {
   const attribs = JSON.parse(JSON.stringify(elementColumn.attribs));
   // default value for columns where there is no width defined
-  const defaultWidth = 20;
+  const defaultWidth = 50;
   return attribs.style ? Number(attribs?.style?.match(/\d+/)[0] ?? 0) : defaultWidth;
 }

--- a/src/proxy-page/steps/fixTableSize.ts
+++ b/src/proxy-page/steps/fixTableSize.ts
@@ -11,9 +11,8 @@ export default (): Step => (context: ContextService): void => {
       const tableWidth = $(tableElement).attr('data-table-width');
       if (tableWidth) {
         const tableWidthValue = Number(tableWidth);
-        if (tableWidthValue > 1400) {
-          $(tableElement).css('width', '100%');
-        } else {
+        // when data-table-width is <760 the table will not be full width but actual size
+        if (tableWidthValue < 760) {
           $(tableElement).css('width', tableWidth);
         }
       }

--- a/tests/unit/steps/fixTableSize.spec.ts
+++ b/tests/unit/steps/fixTableSize.spec.ts
@@ -16,7 +16,7 @@ describe('Confluence Proxy / fixTableSize', () => {
   it('should add style with width equal to attribute data-table-width', () => {
     context.setHtmlBody('<html><head></head><body><h1 class="titlePage"> Demo table</h1>'+
     '<div class="table-wrap">'+
-    '<table data-table-width="760" data-layout="default" class="confluenceTable">'+
+    '<table data-table-width="750" data-layout="default" class="confluenceTable">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
@@ -25,7 +25,7 @@ describe('Confluence Proxy / fixTableSize', () => {
     step(context);
     expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
     '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"760\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 760;\">'+
+    '<table data-table-width=\"750\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 750;\">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
@@ -45,7 +45,7 @@ describe('Confluence Proxy / fixTableSize', () => {
     step(context);
     expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
     '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 100%;\">'+
+    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+


### PR DESCRIPTION
- display former wide and full-width tables with 100% width
- display with fixed size smaller tables than 760
- refactor main.ts moving handlbars and openAPI initialization to routines

resolves WEB-2293