### PR TITLE
Bugfix: WEB-2298-images-displayed-without-separation

### DIFF
--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -15,7 +15,7 @@ iframe.conf-macro {
 img {
   max-width: 100%;
   height: auto;
-  padding: 5px; // adjacent images should not touch each others
+  padding: 5px;
   &.image-left {
     display: block;
     align-content: left;
@@ -50,5 +50,6 @@ span.confluence-embedded-file-wrapper {
   vertical-align:middle;
   img.confluence-embedded-image {
     padding: 0;
+    margin-top: 20;
   }
 }

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -50,5 +50,6 @@ span.confluence-embedded-file-wrapper {
   vertical-align:middle;
   img.confluence-embedded-image {
     padding: 0;
+    margin-top: 20;
   }
 }


### PR DESCRIPTION
Add a 20px top margiin go images
resolves WEB-2298