### PR TITLE
Bugfix: Web 2476 proper rendering of titles of confluence roadmap in bars

### DIFF
--- a/src/assets/scss/_macro-decisions.scss
+++ b/src/assets/scss/_macro-decisions.scss
@@ -4,12 +4,17 @@ ul.decision-list {
   margin: 0;
   padding: 0;
 
-  > li {
-    padding: 5px 20px 0px;
+  li {
+    padding: 0px 5px 10px 5px;
+    margin: 5px 0 5px 0;
+    background: var(--bg-blockquote);
+    border-radius: 5px;
+    vertical-align: top;
 
     &::before {
       content: var(--macro-decision-symbol);
       padding-right: 5px;
     }
   }
+
 }

--- a/src/assets/scss/_macro-insert-excerpt.scss
+++ b/src/assets/scss/_macro-insert-excerpt.scss
@@ -14,7 +14,7 @@
   border-radius: 5px;
   width: 100%;
   p {
-    margin: 0;
+    margin: 10;
   }
 
   .panelHeader {


### PR DESCRIPTION
- margin 10px to properly display the title in roadmap bar when embedded in a page
- better display of decisions with shade background
