### PR TITLE
Feature: WEB-2497-properly-render-new-macro-recently-updated

### DIFF
--- a/src/assets/scss/_macro-recently-updated.scss
+++ b/src/assets/scss/_macro-recently-updated.scss
@@ -1,0 +1,41 @@
+// Recently Updated ===========================================
+
+.recently-updated-social {
+
+  ul.update-groupings {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    li.grouping {
+      padding: 10px 10px 10px 10px;
+      margin: 10px 0px 10px 0px;
+      border-style: solid;
+      border-width: 0.5px;
+      border-color: var(--secondary-color);
+      border-radius: 5px;
+      vertical-align: top;
+
+      .update-item-profile {
+        float: left;
+      }
+
+      ul.update-items {
+
+        a.confluence-userlink {
+          font-size: large;
+          font-weight: bold;
+        }
+
+        li.update-item {
+          list-style-type: disc;
+          margin-left: 30px;
+        }
+
+        div+.update-item {
+          margin-top: 7px;
+        }
+      }
+    }
+  }
+}

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -15,6 +15,7 @@
 @import 'macro-expand-panel';
 @import 'macro-info-panel';
 @import 'macro-profile';
+@import 'macro-recently-updated';
 @import 'macro-toc';
 @import 'macro-insert-excerpt';
 @import 'macro-content-by-label';

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -52,6 +52,7 @@ import addPDF from './steps/addPDF';
 import fixProfilePicture from './steps/fixProfilePicture';
 import fixEmbeddedFile from './steps/fixEmbeddedFile';
 import addJiraSnapshot from './steps/addJiraSnapshot';
+import fixRecentlyUpdated from './steps/fixRecentlyUpdated';
 
 @Injectable()
 export class ProxyPageService {
@@ -139,6 +140,7 @@ export class ProxyPageService {
     fixEmbeddedFile()(this.context);
     fixTableBackground()(this.context);
     fixTableSize()(this.context);
+    fixRecentlyUpdated()(this.context);
     addTableResponsive()(this.context);
     addAuthorVersion()(this.context);
     delUnnecessaryCode()(this.context);

--- a/src/proxy-page/steps/fixRecentlyUpdated.ts
+++ b/src/proxy-page/steps/fixRecentlyUpdated.ts
@@ -1,0 +1,13 @@
+import { ContextService } from '../../context/context.service';
+import { Step } from '../proxy-page.step';
+
+export default (): Step => (context: ContextService): void => {
+  context.setPerfMark('fixRecentlyUpdated');
+  const $ = context.getCheerioBody();
+
+  // Remove Show More...
+  $('.recently-updated .hidden').remove();
+  $('.recently-updated .more-link-container').remove();
+
+  context.getPerfMeasure('fixRecentlyUpdated');
+};

--- a/tests/unit/steps/fixRecentlyUpdated.spec.ts
+++ b/tests/unit/steps/fixRecentlyUpdated.spec.ts
@@ -1,0 +1,36 @@
+import { ContextService } from '../../../src/context/context.service';
+import { createModuleRefForStep } from './utils';
+import fixRecentlyUpdated from '../../../src/proxy-page/steps/fixRecentlyUpdated';
+
+describe('ConfluenceProxy / fixRecentlyUpdated', () => {
+  let context: ContextService;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
+  });
+
+  it('should remove hidden parameters and the Show More link', () => {
+    const step = fixRecentlyUpdated();
+    const example =
+      '<html><head></head><body>' +
+      '<div class="recently-updated">' +
+      '<div class="hidden parameters"></div>' +
+      '<div class="results-container">' +
+      '<div class="more-link-container"><a class="more-link" href="URL">Show More</a>' +
+      '</div></div></div>' +
+      '</body></html>';
+    context.setHtmlBody(example);
+    step(context);
+    const expected =
+      '<html><head></head><body>' +
+      '<div id="Content">' +
+      '<div class="recently-updated">' +
+      '<div class="results-container">' +
+      '</div></div>' +
+      '</div>' +
+      '</body></html>';
+    expect(context.getHtmlBody()).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Integrates new stylesheet and processing step to clean up hidden parameters and redundant read more link in the recently updated macro view.

Resolves WEB-2497