### PR TITLE
Feature (Web 2507) improve visualization of tables

### DIFF
--- a/src/assets/scss/_macro-insert-excerpt.scss
+++ b/src/assets/scss/_macro-insert-excerpt.scss
@@ -8,23 +8,23 @@
 .panel[data-macro-name='excerpt-include'],
 .panel[data-macro-name='include'] {
   color: #333;
-  margin: 0;
+  margin: 1em 0 0 0;
   border: 1px solid #d2cdcd;
   overflow: hidden;
   border-radius: 5px;
   width: 100%;
   p {
-    margin: 10;
+    margin: 0.2em;
   }
 
   .panelHeader {
-    padding: 20px;
-    font-size: 1.2em;
+    padding: 0.5em;
+    font-size: 1.1em;
     border-bottom: 1px solid #d2cdcd;
   }
 
   .panelContent {
-    padding: 20px;
+    padding: 0em 1em 1em 1em;
     blockquote {
       width: 70%;
       margin: 20px auto;

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -8,20 +8,35 @@ table.confluenceTable {
   margin-right: auto;
   table-layout: fixed;
 
-  // Fix 'default' tables to 60% of the layout width
+  // 'Large' tables to 100% of the layout width
+  &[data-konviw-table-size='large'] {
+    width: 100%;
+  }
+
+  // 'Small' tables may be centered
+  &[data-konviw-table-size='small'] {
+    &[data-layout='center'] {
+      margin-left: auto;
+      margin-right: auto;
+      table-layout: fixed;
+    }
+  }
+
+  // ===============================================
+  // Fix 'default', 'wide' and 'full-width' tables
+  // while this is only for leagacy visualization
+  // and to be dprecated when Altassian compleates
+  // the whole migration to the new tables layout
   &[data-layout='default'] {
     width: 100%;
   }
-
-  // Fix 'wide' tables to fit the 100% of the layout
   &[data-layout='wide'] {
     width: 100%;
   }
-
-  // Fix 'full-width' tables to fit the 100% of the layout
   &[data-layout='full-width'] {
     width: 100%;
   }
+  // ===============================================
 
   // Fix SVG's width embedded in tables like roadmap macros
   svg {
@@ -185,5 +200,45 @@ table.tasks-report {
     text-align: left;
     padding: 0.2em 0.5em 0.2em 0.5em;
     vertical-align: top;
+  }
+}
+
+
+// Responsive Tables for small width devices ==============
+@media (max-width: 700px) {
+  tbody {
+    margin: 0;
+    border-spacing: 0;
+    padding-bottom: 1rem;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  th {
+    display: none;
+  }
+
+  tbody tr td {
+    display: block;
+    width: 95vw;
+    box-sizing: border-box;
+  }
+  tr td:not(:first-of-type):not(:last-of-type):not(:only-of-type) {
+    border-bottom: none;
+    border-top: none;
+  }
+
+  tr td:first-of-type:not(:only-of-type) {
+    border-bottom: none;
+  }
+
+  tr td:last-of-type:not(:only-of-type) {
+    border-top: none;
+  }
+
+  tr td::before {
+    content: attr(data-column-id) " " attr(data-lign-id);
+    font-weight: bold;
+    text-transform: capitalize;
   }
 }

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -121,7 +121,6 @@ code {
   word-wrap: break-word;
 }
 
-
 // Macro Child Pages ==================================
 ul.childpages-macro {
   font-size: 16px;
@@ -144,40 +143,3 @@ ul.childpages-macro li {
   }
 }
 
-@media (max-width: 700px) {
-  tbody {
-    margin: 0;
-    border-spacing: 0;
-    padding-bottom: 1rem;
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  th {
-    display: none;
-  }
-
-  tbody tr td {
-    display: block;
-    width: 95vw;
-    box-sizing: border-box;
-  }
-  tr td:not(:first-of-type):not(:last-of-type):not(:only-of-type) {
-    border-bottom: none;
-    border-top: none;
-  }
-
-  tr td:first-of-type:not(:only-of-type) {
-    border-bottom: none;
-  }
-
-  tr td:last-of-type:not(:only-of-type) {
-    border-top: none;
-  }
-
-  tr td::before {
-    content: attr(data-column-id) " " attr(data-lign-id);
-    font-weight: bold;
-    text-transform: capitalize;
-  }
-}

--- a/src/assets/scss/debug.scss
+++ b/src/assets/scss/debug.scss
@@ -1,7 +1,7 @@
 // Mixin to display the name of the macro or content to debug
 @mixin debug-macro-frame($name) {
   position: relative;
-  top: -8px;
+  top: -2px;
   left: 10px;
   font-family: 'Courier New', Courier, monospace;
   content: $name;
@@ -139,17 +139,27 @@
   }
 }
 
-// Tables
+// Tables legacy layout
 table.confluenceTable {
-  &[data-layout='default'] {
-    background-color: rgb(180, 180, 245);
-  }
-
-  &[data-layout='wide'] {
-    background-color: rgb(138, 138, 242);
-  }
-
+  &[data-layout='default'],
+  &[data-layout='wide'],
   &[data-layout='full-width'] {
-    background-color: rgb(108, 108, 212);
+    background-color: #ffdada;
   }
+}
+
+// Tables legacy layout
+table.confluenceTable {
+  &[data-layout='center'],
+  &[data-layout='align-start'] {
+    background-color: #e5fdef;
+  }
+}
+
+// Excerpt included in a page
+.panel[data-macro-name='excerpt-include'] {
+  &::before {
+    @include debug-macro-frame('excerpt-include');
+  }
+  background-color: #d0f4d2;
 }

--- a/src/assets/scss/debug.scss
+++ b/src/assets/scss/debug.scss
@@ -144,12 +144,8 @@ table.confluenceTable {
   &[data-layout='default'],
   &[data-layout='wide'],
   &[data-layout='full-width'] {
-    background-color: #ffdada;
+    background-color: #ffe2e2;
   }
-}
-
-// Tables legacy layout
-table.confluenceTable {
   &[data-layout='center'],
   &[data-layout='align-start'] {
     background-color: #e5fdef;

--- a/src/proxy-page/steps/fixColGroupWidth.ts
+++ b/src/proxy-page/steps/fixColGroupWidth.ts
@@ -23,7 +23,10 @@ export default (): Step => (context: ContextService): void => {
     // consequently we apply now the calculation in % for all size of tables, while always returns "default"
     `table[data-layout='full-width']>colgroup,
     table[data-layout= 'wide']> colgroup,
-    table[data-layout='default']>colgroup`,
+    table[data-layout='default']>colgroup,
+    table[data-layout= 'align-start']> colgroup,
+    table[data-layout= 'center']> colgroup`,
+    // 'table[data-table-display-mode=\'fixed\']',   // eventually to define whether we need special style to display fixed tables
   ).each((_index: number, elementColgroup: cheerio.Element) => {
     let sumColWidth = 0;
     elementColgroup.childNodes.forEach((elementColumn: cheerio.Element) => {

--- a/src/proxy-page/steps/fixTableSize.ts
+++ b/src/proxy-page/steps/fixTableSize.ts
@@ -12,8 +12,11 @@ export default (): Step => (context: ContextService): void => {
       if (tableWidth) {
         const tableWidthValue = Number(tableWidth);
         // when data-table-width is <760 the table will not be full width but actual size
-        if (tableWidthValue < 760) {
+        if (tableWidthValue < 800) {
           $(tableElement).css('width', tableWidth);
+          $(tableElement).attr('data-konviw-table-size', 'small');
+        } else {
+          $(tableElement).attr('data-konviw-table-size', 'large');
         }
       }
     },

--- a/tests/unit/steps/fixTableSize.spec.ts
+++ b/tests/unit/steps/fixTableSize.spec.ts
@@ -25,7 +25,7 @@ describe('Confluence Proxy / fixTableSize', () => {
     step(context);
     expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
     '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"750\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 750;\">'+
+    '<table data-table-width=\"750\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 750;\" data-konviw-table-size=\"small\">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
@@ -45,7 +45,7 @@ describe('Confluence Proxy / fixTableSize', () => {
     step(context);
     expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
     '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\">'+
+    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\" data-konviw-table-size=\"large\">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+

--- a/tests/unit/steps/fixTableSize.spec.ts
+++ b/tests/unit/steps/fixTableSize.spec.ts
@@ -23,9 +23,9 @@ describe('Confluence Proxy / fixTableSize', () => {
     '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
     '</tbody></table></div><p></p></body></html>');
     step(context);
-    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
-    '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"750\" data-layout=\"default\" class=\"confluenceTable\" style=\"width: 750;\" data-konviw-table-size=\"small\">'+
+    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id="Content"><h1 class="titlePage"> Demo table</h1>'+
+    '<div class="table-wrap">'+
+    '<table data-table-width="750" data-layout="default" class="confluenceTable" style="width: 750;" data-konviw-table-size="small">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
@@ -43,9 +43,9 @@ describe('Confluence Proxy / fixTableSize', () => {
     '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
     '</tbody></table></div><p></p></body></html>');
     step(context);
-    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id=\"Content\"><h1 class=\"titlePage\"> Demo table</h1>'+
-    '<div class=\"table-wrap\">'+
-    '<table data-table-width=\"1500\" data-layout=\"default\" class=\"confluenceTable\" data-konviw-table-size=\"large\">'+
+    expect(context.getHtmlBody()).toEqual('<html><head></head><body><div id="Content"><h1 class="titlePage"> Demo table</h1>'+
+    '<div class="table-wrap">'+
+    '<table data-table-width="1500" data-layout="default" class="confluenceTable" data-konviw-table-size="large">'+
     '<colgroup><col><col><col></colgroup>'+
     '<tbody><tr><th><p><strong>A</strong></p></th><th><p><strong>B</strong></p></th><th><p><strong>C</strong></p>'+
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+


### PR DESCRIPTION
- Keep visualization of legacy  tables (default, wide, full-width)
- New tables with data-layout="center" are centred if width < 800
- New tables with data-layout="align-start" are aligned to left if width < 800