### PR TITLE
fix: web-2685 vertical slide fix

### DIFF
--- a/src/proxy-page/steps/addSlides.ts
+++ b/src/proxy-page/steps/addSlides.ts
@@ -18,11 +18,15 @@ export default (): Step => (context: ContextService): void => {
   // Div with class plugin-tabmeta-details (Confluence macro "properties") is framing the sections for each slide
   $(".plugin-tabmeta-details[data-macro-name='details']").each(
     (_index: number, pageProperties: cheerio.Element) => {
+      const HR_REGEX = /<hr\b[^>]*\/?>/gi;
       // we will generate vertical slides if there are 'hr' tags
-      const verticalSlides = ($(pageProperties).html() as string).split('<hr>').length > 1;
-      const sections = ($(pageProperties).html() as string)
-        .split('<hr>')
-        .map((body) => cheerio.load(body));
+  const verticalSlides = (($(pageProperties).html() as string).match(HR_REGEX)?.length ?? 0) > 0;
+  // Split into sections by any <hr ...> variant
+  const sectionStrings = ($(pageProperties).html() as string)
+    .split(HR_REGEX)
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+      const sections = sectionStrings.map(body => cheerio.load(body));
         // Iterate thru the sections split by the 'hr' horizontal lines
         // only one if no split done
       sectionsHtml += verticalSlides ? '<section>' : '';


### PR DESCRIPTION
### **Problem ** 
Vertical Slides were not showing up on konviw slides

### **Solution ** 

- Pervious code was looking for just _`<hr>`_ tag in html code form confluence.
- New code added "id" as well with _`<hr>`_ tag making it _`<hr id="xyz">`_
- Added REGEX to search for _`<hr id="xyz">`_ tag in the HTML and split the HTML based on HR to form vertical side

### Screenshots
**Before:**
<img width="1498" height="764" alt="Screenshot 2026-01-22 at 11 00 17 AM" src="https://github.com/user-attachments/assets/e649cff4-1516-46e4-8f8d-32ecf75e7463" />

**After:**
<img width="1482" height="741" alt="Screenshot 2026-01-22 at 10 59 25 AM" src="https://github.com/user-attachments/assets/a03736e3-5288-455a-b1ac-0143fd85267b" />
