### PR TITLE
feat: add /health alias for health check endpoint

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -4,7 +4,7 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { ApiHealthService } from './health-atlassian.service';
 
 @ApiTags('health')
-@Controller('health')
+@Controller(['health', `${process.env.CPV_BASEPATH}/health`])
 export class HealthController {
   constructor(
     private readonly apiHealth: ApiHealthService,

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -4,7 +4,7 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { ApiHealthService } from './health-atlassian.service';
 
 @ApiTags('health')
-@Controller(['health', `${process.env.CPV_BASEPATH}/health`])
+@Controller('health')
 export class HealthController {
   constructor(
     private readonly apiHealth: ApiHealthService,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ if (
 }
 
 import { NestFactory } from '@nestjs/core';
-import { LogLevel, RequestMethod, ValidationPipe } from '@nestjs/common';
+import { LogLevel, ValidationPipe } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -21,6 +21,7 @@ import { join } from 'path';
 import hbs from 'hbs';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { AppModule } from './app.module';
+import { HealthController } from './health/health.controller';
 
 /**
  * Entry point of application. By using the NestFactory.create() method a new Nest application instance is created.
@@ -57,8 +58,13 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter(config));
 
   // Default path for all routes
-  app.setGlobalPrefix(`${basePath}`, {
-    exclude: [{ path: 'health', method: RequestMethod.GET }],
+  app.setGlobalPrefix(`${basePath}`);
+
+  // Alias /health to respond directly alongside the prefixed route
+  app.getHttpAdapter().get('/health', async (req, res) => {
+    const healthController = app.get(HealthController);
+    const result = await healthController.apiCheck();
+    res.json(result);
   });
 
   // Define headers defaults

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ if (
 }
 
 import { NestFactory } from '@nestjs/core';
-import { LogLevel, ValidationPipe } from '@nestjs/common';
+import { LogLevel, RequestMethod, ValidationPipe } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -56,16 +56,10 @@ async function bootstrap() {
 
   app.useGlobalFilters(new HttpExceptionFilter(config));
 
-  // Alias /health to respond directly without the global prefix
-  app.getHttpAdapter().getInstance().use((req, res, next) => {
-    if (req.url === '/health' || req.url === '/health/') {
-      req.url = `${basePath}/health`;
-    }
-    next();
-  });
-
   // Default path for all routes
-  app.setGlobalPrefix(`${basePath}`);
+  app.setGlobalPrefix(`${basePath}`, {
+    exclude: [{ path: 'health', method: RequestMethod.GET }],
+  });
 
   // Define headers defaults
   app.disable('x-powered-by');

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,14 @@ async function bootstrap() {
 
   app.useGlobalFilters(new HttpExceptionFilter(config));
 
+  // Alias /health to respond directly without the global prefix
+  app.getHttpAdapter().getInstance().use((req, res, next) => {
+    if (req.url === '/health' || req.url === '/health/') {
+      req.url = `${basePath}/health`;
+    }
+    next();
+  });
+
   // Default path for all routes
   app.setGlobalPrefix(`${basePath}`);
 


### PR DESCRIPTION
## Summary

  - Add URL rewriting middleware so the health check endpoint responds at both `/health `and `${basePath}/health` (e.g. **/cpv/health**)
  - This makes the health check accessible at a standard `/health` path regardless of the configured base path, which is useful for load balancers and orchestration tools that expect health checks at a well-known root-level path