### PR TITLE
fix: WEB-2763 blgImg_null_fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "konviw",
-  "version": "3.49.2",
+  "version": "3.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "konviw",
-      "version": "3.49.2",
+      "version": "3.49.3",
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^4.0.1",

--- a/src/proxy-page/steps/fixEmojis.ts
+++ b/src/proxy-page/steps/fixEmojis.ts
@@ -13,17 +13,18 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
     const atlassianSpecialEmojis = await confluence.getSpecialAtlassianIcons();
     const uploadedSpecialEmojis = await confluence.getSpecialUploadedIcons();
 
-    const imgEmoticonsPromises = imgEmoticons.map((element: cheerio.Element) => {
+    imgEmoticons.forEach((element: cheerio.Element) => {
       const emojiData = $(element).data() as { emojiId: string | number, emojiFallback: string };
-      const emojiIdIsStringInstance = typeof emojiData.emojiId === 'string';
+      const emojiId = typeof emojiData.emojiId === 'string' ? emojiData.emojiId : '';
+      const emojiFallback = typeof emojiData.emojiFallback === 'string' ? emojiData.emojiFallback : '';
 
       // define all cases for emojis
-      const emojiIdIsCustomAtlassianEmmoticon = emojiData.emojiFallback.startsWith(':') && emojiData.emojiFallback.endsWith(':');
-      const emojiIdIsSpecialAtlassianEmoticon = emojiIdIsStringInstance && (emojiData.emojiId as string).startsWith('atlassian');
-      const emojiIdIsSpecialUploadedEmoticon = (((emojiData.emojiId as string).length > 10) && (!emojiIdIsSpecialAtlassianEmoticon));
+      const emojiIdIsCustomAtlassianEmmoticon = emojiFallback.startsWith(':') && emojiFallback.endsWith(':');
+      const emojiIdIsSpecialAtlassianEmoticon = emojiId.startsWith('atlassian');
+      const emojiIdIsSpecialUploadedEmoticon = emojiId.length > 10 && !emojiIdIsSpecialAtlassianEmoticon;
 
       if (emojiIdIsSpecialUploadedEmoticon) {
-        const relatedIcon = uploadedSpecialEmojis.emojis.find(({ fallback }) => fallback === emojiData.emojiFallback);
+        const relatedIcon = uploadedSpecialEmojis.emojis.find(({ fallback }) => fallback === emojiFallback);
         if (relatedIcon) {
           const { representation: { imagePath } } = relatedIcon;
           const { meta } = uploadedSpecialEmojis;
@@ -33,7 +34,7 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
       }
 
       if (emojiIdIsCustomAtlassianEmmoticon) {
-        const relatedIcon = atlassianSpecialEmojis.find(({ fallback }) => fallback === emojiData.emojiFallback);
+        const relatedIcon = atlassianSpecialEmojis.find(({ fallback }) => fallback === emojiFallback);
         if (relatedIcon) {
           const { representation: { imagePath } } = relatedIcon;
           return asignEmojiSource(element, $, imagePath);
@@ -41,10 +42,8 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
         return $(element).replaceWith(null);
       }
 
-      return $(element).replaceWith(emojiData.emojiFallback);
+      return $(element).replaceWith(emojiFallback);
     });
-
-    await imgEmoticonsPromises;
   }
 
   const convertUnicodeToChar = (text: string) =>


### PR DESCRIPTION
Implemented defensive null/undefined handling for blog header image and emoji parsing to prevent runtime failures caused by calling string methods on missing values.

**Changes made:**
Hardened header image handling in ` [getExcerptAndHeaderImage.ts]`
Normalized the header image value before checking it with startsWith
Defaulted invalid or missing header image values to an empty string so the page flow continues safely
Hardened emoji parsing in `[fixEmojis.ts]`
Normalized both emojiId and emojiFallback before using startsWith, endsWith, or length
Prevented failures when Confluence emoji metadata is incomplete or missing
Removed an unnecessary await on a synchronous emoji iteration path

**Root cause:**
Some Confluence-derived values were assumed to always be present as strings. In practice, header image and emoji metadata can be empty or undefined, which caused runtime TypeErrors when startsWith was called on missing values.

**Resolution:**
Added defensive normalization for these values before any string operations are performed. Missing or invalid values now fall back to empty strings, allowing rendering to continue without breaking the request. The emoji loop was also cleaned up to remove an unnecessary await on a non-Promise path.