### PR TITLE
fix: proxy attachment downloads

### DIFF
--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -246,6 +246,10 @@ export interface Attachment {
   _links: GenericLinks
 }
 
+export type MediaResponse =
+  | { type: 'redirect'; url: string }
+  | { type: 'proxy'; data: Buffer; mediaType: string };
+
 export type Properties = {
   [key: string]: {
     value: string;

--- a/src/confluence/confluence.interface.ts
+++ b/src/confluence/confluence.interface.ts
@@ -246,10 +246,6 @@ export interface Attachment {
   _links: GenericLinks
 }
 
-export type MediaResponse =
-  | { type: 'redirect'; url: string }
-  | { type: 'proxy'; data: Buffer; mediaType: string };
-
 export type Properties = {
   [key: string]: {
     value: string;

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -12,13 +12,12 @@ import {
   Content,
   SearchResults,
   Attachment,
-  MediaResponse,
 } from './confluence.interface';
 
 @Injectable()
 export class ConfluenceService {
   private readonly logger = new Logger(ConfluenceService.name);
-  private attachmentCache = new Map<string, { data: Attachment[], timestamp: number }>();
+  private readonly attachmentCache = new Map<string, { data: Attachment[], timestamp: number }>();
   private readonly ATTACHMENT_CACHE_TTL = 60_000; // 60s
 
   constructor(
@@ -157,7 +156,7 @@ export class ConfluenceService {
   }
 
   async getMediaContent(uri: string): Promise<{ data: Buffer; mediaType: string } | null> {
-    const match = uri.match(/download\/attachments\/(\d+)\/([^?]+)/);
+    const match = /download\/attachments\/(\d+)\/([^?]+)/.exec(uri);
     if (!match) return null;
     const [, pageId, filename] = match;
     try {

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -17,7 +17,9 @@ import {
 @Injectable()
 export class ConfluenceService {
   private readonly logger = new Logger(ConfluenceService.name);
+
   private readonly attachmentCache = new Map<string, { data: Attachment[], timestamp: number }>();
+
   private readonly ATTACHMENT_CACHE_TTL = 60_000; // 60s
 
   constructor(

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -123,28 +123,6 @@ export class ConfluenceService {
     }
   }
 
-  /**
-   * @function getRedirectUrlForMedia Service
-   * @description Route to retrieve the standard media files like images and videos (usually attachments)
-   * @return Promise {string} 'url' - URL of the media to display
-   * @param uri {string}
-   */
-  async getRedirectUrlForMedia(uri: string): Promise<string | null> {
-    try {
-      const results = await firstValueFrom(
-        this.http.get(`/wiki/${uri}`, {
-          maxRedirects: 0,
-          validateStatus: (status) => status === 302,
-        }),
-      );
-      this.logger.log(`Retrieving media from ${uri}`);
-      return results.headers.location;
-    } catch (err) {
-      this.logger.warn(`getRedirectUrlForMedia failed for ${uri}, will try v2 fallback - ${this.getSafeErrorMessage(err)}`);
-      return null;
-    }
-  }
-
   async getCachedAttachments(pageId: string): Promise<Attachment[]> {
     const cached = this.attachmentCache.get(pageId);
     if (cached && Date.now() - cached.timestamp < this.ATTACHMENT_CACHE_TTL) {

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -12,11 +12,14 @@ import {
   Content,
   SearchResults,
   Attachment,
+  MediaResponse,
 } from './confluence.interface';
 
 @Injectable()
 export class ConfluenceService {
   private readonly logger = new Logger(ConfluenceService.name);
+  private attachmentCache = new Map<string, { data: Attachment[], timestamp: number }>();
+  private readonly ATTACHMENT_CACHE_TTL = 60_000; // 60s
 
   constructor(
     private http: HttpService,
@@ -125,7 +128,7 @@ export class ConfluenceService {
    * @return Promise {string} 'url' - URL of the media to display
    * @param uri {string}
    */
-  async getRedirectUrlForMedia(uri: string): Promise<string> {
+  async getRedirectUrlForMedia(uri: string): Promise<string | null> {
     try {
       const results = await firstValueFrom(
         this.http.get(`/wiki/${uri}`, {
@@ -136,8 +139,52 @@ export class ConfluenceService {
       this.logger.log(`Retrieving media from ${uri}`);
       return results.headers.location;
     } catch (err) {
-      this.logger.error(`error:getRedirectUrlForMedia - ${this.getSafeErrorMessage(err)}`);
-      throw new HttpException('error:getRedirectUrlForMedia', 404);
+      this.logger.warn(`getRedirectUrlForMedia failed for ${uri}, will try v2 fallback - ${this.getSafeErrorMessage(err)}`);
+      return null;
+    }
+  }
+
+  async getCachedAttachments(pageId: string): Promise<Attachment[]> {
+    const cached = this.attachmentCache.get(pageId);
+    if (cached && Date.now() - cached.timestamp < this.ATTACHMENT_CACHE_TTL) {
+      return cached.data;
+    }
+    const data = await this.getAttachments(pageId);
+    if (data) {
+      this.attachmentCache.set(pageId, { data, timestamp: Date.now() });
+    }
+    return data;
+  }
+
+  async getMediaContent(uri: string): Promise<{ data: Buffer; mediaType: string } | null> {
+    const match = uri.match(/download\/attachments\/(\d+)\/([^?]+)/);
+    if (!match) return null;
+    const [, pageId, filename] = match;
+    try {
+      // Decode percent-encoding then normalise to NFC so accented filenames
+      // (e.g. "é" stored as NFC in Confluence, but NFD-encoded in the URL) match correctly.
+      const decodedFilename = decodeURIComponent(filename).normalize('NFC');
+      const attachments = await this.getCachedAttachments(pageId);
+      const attachment = attachments?.find((a) => a.title.normalize('NFC') === decodedFilename);
+      if (!attachment) {
+        this.logger.warn(`getMediaContent: attachment "${decodedFilename}" not found on page ${pageId}`);
+        return null;
+      }
+      // The legacy /wiki/download/attachments/ path returns 401 for API tokens.
+      // The v2 API has no binary download endpoint.
+      // The v1 REST endpoint /wiki/rest/api/content/{pageId}/child/attachment/{id}/download
+      // properly supports Basic Auth with API tokens.
+      const { data }: { data: ArrayBuffer } = await firstValueFrom(
+        this.http.get(
+          `/wiki/rest/api/content/${pageId}/child/attachment/${attachment.id}/download`,
+          { responseType: 'arraybuffer' },
+        ),
+      );
+      this.logger.log(`Downloaded attachment "${decodedFilename}" via REST v1 for page ${pageId}`);
+      return { data: Buffer.from(data), mediaType: attachment.mediaType };
+    } catch (err) {
+      this.logger.error(`error:getMediaContent for ${uri} - ${this.getSafeErrorMessage(err)}`);
+      return null;
     }
   }
 

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -546,7 +546,12 @@ export class ProxyApiService {
    */
   async getAttachmentDownloadUrl(uri: string): Promise<string> {
     const downloadUrl = await this.confluence.getRedirectUrlForMedia(uri);
-    return downloadUrl;
+    if (downloadUrl) {
+      return downloadUrl;
+    }
+    const baseHost = this.config.get('web.baseHost');
+    const basePath = this.config.get('web.basePath');
+    return `${baseHost}${basePath}/wiki/${uri}`;
   }
 
   /**

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -545,10 +545,6 @@ export class ProxyApiService {
    * @returns Promise {string} A promise that resolves to the download URL of the attachment.
    */
   async getAttachmentDownloadUrl(uri: string): Promise<string> {
-    const downloadUrl = await this.confluence.getRedirectUrlForMedia(uri);
-    if (downloadUrl) {
-      return downloadUrl;
-    }
     const baseHost = this.config.get('web.baseHost');
     const basePath = this.config.get('web.basePath');
     return `${baseHost}${basePath}/wiki/${uri}`;

--- a/src/proxy-page/proxy-page.controller.ts
+++ b/src/proxy-page/proxy-page.controller.ts
@@ -129,12 +129,8 @@ export class ProxyPageController {
   @Get(['/download/*path', '/aa-avatar/*path'])
   async getMedia(@Req() req: Request, @Res() res: Response) {
     const reqUrl = req.url.replace(/\/cpv\/wiki\//, '');
-    const mediaResponse = await this.proxyPage.getMediaResponse(reqUrl);
-    if (mediaResponse.type === 'redirect') {
-      res.redirect(mediaResponse.url);
-    } else {
-      res.setHeader('Content-Type', mediaResponse.mediaType);
-      res.send(mediaResponse.data);
-    }
+    const { data, mediaType } = await this.proxyPage.getMediaResponse(reqUrl);
+    res.setHeader('Content-Type', mediaType);
+    res.send(data);
   }
 }

--- a/src/proxy-page/proxy-page.controller.ts
+++ b/src/proxy-page/proxy-page.controller.ts
@@ -129,7 +129,12 @@ export class ProxyPageController {
   @Get(['/download/*path', '/aa-avatar/*path'])
   async getMedia(@Req() req: Request, @Res() res: Response) {
     const reqUrl = req.url.replace(/\/cpv\/wiki\//, '');
-    const mediaCdnUrl = await this.proxyPage.getMediaCdnUrl(reqUrl);
-    res.redirect(mediaCdnUrl);
+    const mediaResponse = await this.proxyPage.getMediaResponse(reqUrl);
+    if (mediaResponse.type === 'redirect') {
+      res.redirect(mediaResponse.url);
+    } else {
+      res.setHeader('Content-Type', mediaResponse.mediaType);
+      res.send(mediaResponse.data);
+    }
   }
 }

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, HttpException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import getExcerptAndHeaderImage from '../proxy-api/steps/getExcerptAndHeaderImage';
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
 import { ContextService } from '../context/context.service';
-import { Content } from '../confluence/confluence.interface';
+import { Content, MediaResponse } from '../confluence/confluence.interface';
 import delUnnecessaryCode from './steps/delUnnecessaryCode';
 import fixLinks from './steps/fixLinks';
 import fixEmojis from './steps/fixEmojis';
@@ -225,12 +225,20 @@ export class ProxyPageService {
   }
 
   /**
-   * @function getMediaCdnUrl Service
-   * @return Promise string
-   * @param uri {string} 'iadc' - URL of the media file to return
+   * @function getMediaResponse Service
+   * @return Promise MediaResponse
+   * @param uri {string} - URL of the media file to return
    */
-  getMediaCdnUrl(uri: string): Promise<string> {
-    const modifiedUri = uri.replace('/thumbnails/', '/attachments/');// replaced thumbnails due to end of support
-    return this.confluence.getRedirectUrlForMedia(modifiedUri);
+  async getMediaResponse(uri: string): Promise<MediaResponse> {
+    const modifiedUri = uri.replace('/thumbnails/', '/attachments/');
+    const redirectUrl = await this.confluence.getRedirectUrlForMedia(modifiedUri);
+    if (redirectUrl) {
+      return { type: 'redirect', url: redirectUrl };
+    }
+    const content = await this.confluence.getMediaContent(modifiedUri);
+    if (content) {
+      return { type: 'proxy', data: content.data, mediaType: content.mediaType };
+    }
+    throw new HttpException('Media not found', 404);
   }
 }

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -5,7 +5,7 @@ import getExcerptAndHeaderImage from '../proxy-api/steps/getExcerptAndHeaderImag
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
 import { ContextService } from '../context/context.service';
-import { Content, MediaResponse } from '../confluence/confluence.interface';
+import { Content } from '../confluence/confluence.interface';
 import delUnnecessaryCode from './steps/delUnnecessaryCode';
 import fixLinks from './steps/fixLinks';
 import fixEmojis from './steps/fixEmojis';
@@ -226,18 +226,14 @@ export class ProxyPageService {
 
   /**
    * @function getMediaResponse Service
-   * @return Promise MediaResponse
+   * @return Promise with binary content and media type
    * @param uri {string} - URL of the media file to return
    */
-  async getMediaResponse(uri: string): Promise<MediaResponse> {
+  async getMediaResponse(uri: string): Promise<{ data: Buffer; mediaType: string }> {
     const modifiedUri = uri.replace('/thumbnails/', '/attachments/');
-    const redirectUrl = await this.confluence.getRedirectUrlForMedia(modifiedUri);
-    if (redirectUrl) {
-      return { type: 'redirect', url: redirectUrl };
-    }
     const content = await this.confluence.getMediaContent(modifiedUri);
     if (content) {
-      return { type: 'proxy', data: content.data, mediaType: content.mediaType };
+      return content;
     }
     throw new HttpException('Media not found', 404);
   }


### PR DESCRIPTION
 ## Summary
  - Confluence Cloud now returns 401 on `/wiki/download/attachments/` with API tokens
  - Page content (v2 API) still loads fine — only images/attachments are broken
  - Added content-proxy fallback: tries legacy redirect first, then downloads via
    v1 REST API (`/rest/api/content/{pageId}/child/attachment/{id}/download`) and
    serves the binary directly through konviw
  - In-memory attachment metadata cache (60s TTL) avoids repeated API calls when a
    page has many images
  - Fixed Unicode normalization (NFC) for filenames with accented characters (é, à, etc.)