### PR TITLE
fix: WEB-2806 migrate Confluence media URLs off deprecated download e…

### DIFF
--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
-import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'; // eslint-disable-line import/no-extraneous-dependencies
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'; // eslint-disable-line import/no-extraneous-dependencies
 import { firstValueFrom } from 'rxjs';
 import {
   Content,
@@ -120,22 +120,82 @@ export class ConfluenceService {
   }
 
   /**
+   * Parse a konviw media uri of the form
+   * `download/(attachments|thumbnails)/{pageId}/{filename}?...` into
+   * `{ pageId, filename }`. Returns `null` for any uri that does not match.
+   * Accepts optional leading `/` and `wiki/` prefix so both shapes work:
+   *   - `download/attachments/12345/file.png?...`               (proxy-page route)
+   *   - `/download/attachments/12345/file.png?...&api=v2`       (`downloadLink` from v2 attachment metadata)
+   *   - `/wiki/download/attachments/12345/file.png?...`         (absolute-style)
+   * Both `attachments` and `thumbnails` shapes are handled identically because
+   * Atlassian's supported migration endpoint serves the original file in both cases.
+   */
+  /* eslint-disable class-methods-use-this */
+  private parseMediaUri(uri: string): { pageId: string; filename: string } | null {
+    const normalized = uri.replace(/^\/+/, '').replace(/^wiki\//, '');
+    const match = normalized.match(/^download\/(?:attachments|thumbnails)\/(\d+)\/([^/?]+)(?:\?.*)?$/);
+    if (!match) return null;
+    const [, pageId, encodedFilename] = match;
+    try {
+      return { pageId, filename: decodeURIComponent(encodedFilename) };
+    } catch {
+      return { pageId, filename: encodedFilename };
+    }
+  }
+
+  /**
    * @function getRedirectUrlForMedia Service
-   * @description Route to retrieve the standard media files like images and videos (usually attachments)
+   * @description Resolve a Confluence attachment URL to its signed media-download URL
+   * via Atlassian's recommended migration path (CHANGE-2735):
+   *   1. v2 page-attachments lookup to resolve `{pageId, filename}` -> `attachmentId`
+   *   2. v1 REST `attachment/download` endpoint which returns a 302 to a signed
+   *      `media-download.confluence-data.com` URL.
+   * Replaces the now-deprecated direct `GET /wiki/download/attachments/...` call,
+   * which Atlassian no longer accepts with Basic Auth.
    * @return Promise {string} 'url' - URL of the media to display
-   * @param uri {string}
+   * @param uri {string} - e.g. `download/attachments/12345/file.png?api=v2`
    */
   async getRedirectUrlForMedia(uri: string): Promise<string> {
+    const parsed = this.parseMediaUri(uri);
+
     try {
-      const results = await firstValueFrom(
-        this.http.get(`/wiki/${uri}`, {
-          maxRedirects: 0,
-          validateStatus: (status) => status === 302,
+      // For non-`download/...` uris (e.g. `aa-avatar/{accountId}` for user
+      // profile pictures) we keep the original direct-call behavior because
+      // Atlassian's CHANGE-2735 deprecation only targets `/download/attachments/`.
+      if (!parsed) {
+        const passthrough: AxiosResponse = await firstValueFrom(
+          this.http.get(`/wiki/${uri.replace(/^\/+/, '')}`, {
+            maxRedirects: 0,
+            validateStatus: (status) => status === 302,
+          }),
+        );
+        this.logger.log(`Retrieving media from ${uri} via direct passthrough`);
+        return passthrough.headers.location;
+      }
+
+      const lookup: AxiosResponse = await firstValueFrom(
+        this.http.get(`/wiki/api/v2/pages/${parsed.pageId}/attachments`, {
+          params: { filename: parsed.filename, limit: 1 },
         }),
       );
-      this.logger.log(`Retrieving media from ${uri}`);
-      return results.headers.location;
+      const attachmentId: string | undefined = lookup.data?.results?.[0]?.id;
+      if (!attachmentId) {
+        this.logger.error(
+          `error:getRedirectUrlForMedia - attachment not found: pageId=${parsed.pageId} filename=${parsed.filename}`,
+        );
+        throw new HttpException('error:getRedirectUrlForMedia', 404);
+      }
+
+      const redirect: AxiosResponse = await firstValueFrom(
+        this.http.get(
+          `/wiki/rest/api/content/${parsed.pageId}/child/attachment/${attachmentId}/download`,
+          { maxRedirects: 0, validateStatus: (status) => status === 302 },
+        ),
+      );
+      this.logger.log(`Retrieving media from ${uri} via v1 attachment/download (attId=${attachmentId})`);
+      return redirect.headers.location;
     } catch (err) {
+      if (err instanceof HttpException) throw err;
       this.logger.error(`error:getRedirectUrlForMedia - ${this.getSafeErrorMessage(err)}`);
       throw new HttpException('error:getRedirectUrlForMedia', 404);
     }
@@ -394,11 +454,16 @@ export class ConfluenceService {
 
   async getAttachmentBase64(url: string): Promise<string> {
     try {
-      const { data }: AxiosResponse = await firstValueFrom(
-        this.http.get(`/wiki${url}`, { responseType: 'arraybuffer' }),
-      );
-      this.logger.log(`Retrieving attachmentBase64 from ${url} via REST API v2`);
-      return data.toString('base64');
+      // (1) Resolve the konviw media uri (typically a v2 `downloadLink` like
+      //     `/download/attachments/{pageId}/{filename}?...&api=v2`) to a
+      //     signed media-download URL via the supported migration path.
+      const signedUrl = await this.getRedirectUrlForMedia(url);
+      // (2) Fetch the bytes directly from the signed URL with a plain axios
+      //     call - the signed URL is on a different host (api.media.atlassian.com)
+      //     and must NOT receive our Atlassian Basic Auth header.
+      const { data } = await axios.get<ArrayBuffer>(signedUrl, { responseType: 'arraybuffer' });
+      this.logger.log(`Retrieving attachmentBase64 from ${url} via v1 attachment/download`);
+      return Buffer.from(data).toString('base64');
     } catch (err: any) {
       this.logger.error(`error:getAttachmentBase64 from ${url} - ${this.getSafeErrorMessage(err)}`);
       return undefined;

--- a/src/proxy-page/proxy-page.controller.ts
+++ b/src/proxy-page/proxy-page.controller.ts
@@ -119,14 +119,21 @@ export class ProxyPageController {
   /**
    * Route to retrieve the standard media files like images, videos or user profile avatar
    *
-   * @GET (controller) /download/* or /aa-avatar/*
+   * @GET (controller) /download/* or /aa-avatar/* or /rest/api/content/*
    * @return {string} 'url' - URL of the media to display
+   *
+   * The `/rest/api/content/*` route is needed for space icons. The v2 `/spaces`
+   * API exposes `icon.apiDownloadLink` of the form
+   *   /wiki/rest/api/content/{contentId}/child/attachment/{attId}/download
+   * which returns a 302 to the signed Atlassian media URL. Space icons cannot
+   * use the `/download/attachments/...` path because their parent content id is
+   * a space-level id (not a page id) and the v2 page-attachments lookup 404s.
    */
   @ApiOperation({
     summary: 'Redirect to media',
     description: 'Retrieve  media content defined in Confluence pages',
   })
-  @Get(['/download/*path', '/aa-avatar/*path'])
+  @Get(['/download/*path', '/aa-avatar/*path', '/rest/api/content/*path'])
   async getMedia(@Req() req: Request, @Res() res: Response) {
     const reqUrl = req.url.replace(/\/cpv\/wiki\//, '');
     const mediaCdnUrl = await this.proxyPage.getMediaCdnUrl(reqUrl);

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -226,11 +226,15 @@ export class ProxyPageService {
 
   /**
    * @function getMediaCdnUrl Service
+   * @description Resolves a konviw media uri to its signed Atlassian
+   * `media-download.confluence-data.com` redirect URL. The legacy
+   * `/thumbnails/` -> `/attachments/` rewrite is no longer needed because
+   * `ConfluenceService.getRedirectUrlForMedia` handles both shapes via the
+   * v2 lookup + v1 attachment/download migration path (CHANGE-2735).
    * @return Promise string
    * @param uri {string} 'iadc' - URL of the media file to return
    */
   getMediaCdnUrl(uri: string): Promise<string> {
-    const modifiedUri = uri.replace('/thumbnails/', '/attachments/');// replaced thumbnails due to end of support
-    return this.confluence.getRedirectUrlForMedia(modifiedUri);
+    return this.confluence.getRedirectUrlForMedia(uri);
   }
 }

--- a/src/proxy-page/steps/fixConfluenceSpace.ts
+++ b/src/proxy-page/steps/fixConfluenceSpace.ts
@@ -13,7 +13,7 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
   const confluenceSpaceClassList = 'confluence-space';
   const confluenceSpaceIconClassList = 'confluence-space-icon';
 
-  const confluenceBaseURL = config.get('confluence.baseURL');
+  const webBasePath = config.get('web.absoluteBasePath');
 
   const isValidURL = (value: string) => {
     try {
@@ -41,8 +41,17 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
     return data;
   };
 
-  const createImagePath = (icon: { path: string }) =>
-    `${confluenceBaseURL}${icon.path}`;
+  // Route space icons through the konviw proxy. Prefer `icon.apiDownloadLink`
+  // (the v1 REST attachment-download endpoint, which returns a 302 to the
+  // signed Atlassian media URL) because the legacy `/wiki/download/attachments/...`
+  // path served by `icon.path` is no longer accepted with Basic Auth
+  // (Atlassian CHANGE-2735) and its parent content id is a space-level id,
+  // so the v2 page-attachments fallback used by `/cpv/wiki/download/...` 404s.
+  const createImagePath = (icon: { path?: string; apiDownloadLink?: string }) => {
+    if (icon?.apiDownloadLink) return `${webBasePath}${icon.apiDownloadLink}`;
+    if (icon?.path) return `${webBasePath}${icon.path}`;
+    return '';
+  };
 
   $('a').each((_, anchor) => {
     const confluenceSpaceRegex = new RegExp('^(.*?)(/wiki/spaces/)(.*)$');

--- a/tests/unit/confluence/confluence.service.spec.ts
+++ b/tests/unit/confluence/confluence.service.spec.ts
@@ -2,6 +2,7 @@ import { ConfluenceService } from '../../../src/confluence/confluence.service'
 import configuration from '../../../src/config/configuration.test';
 import { HttpModule } from '../../../src/http/http.module';
 import { ConfigModule } from '@nestjs/config';
+import { HttpException } from '@nestjs/common';
 import { Test, TestingModule} from '@nestjs/testing';
 import { firstValueFrom } from 'rxjs';
 
@@ -62,5 +63,165 @@ describe('confluence.service', () => {
       ['blogposts', '1234', 'labels', { 'get-draft': false, 'space-id': null, version: 'type' }],
       ['blogposts', '1234', 'properties', { 'get-draft': false, 'space-id': null, version: 'type' }]
     ]);
+  });
+
+  describe('getRedirectUrlForMedia', () => {
+    const signedUrl = 'https://media-download.confluence-data.com/file?signature=abc';
+
+    beforeEach(() => {
+      (firstValueFrom as any).mockReset();
+    });
+
+    it('resolves an attachment uri via v2 lookup + v1 attachment/download', async () => {
+      const httpGet = jest.spyOn(confluenceService['http'], 'get');
+      (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: [{ id: 'att42' }] } })
+        .mockResolvedValueOnce({ headers: { location: signedUrl } });
+
+      const result = await confluenceService.getRedirectUrlForMedia(
+        'download/attachments/1234/file.png?api=v2',
+      );
+
+      expect(result).toBe(signedUrl);
+      expect(httpGet).toHaveBeenNthCalledWith(
+        1,
+        '/wiki/api/v2/pages/1234/attachments',
+        { params: { filename: 'file.png', limit: 1 } },
+      );
+      const secondCall = httpGet.mock.calls[1];
+      expect(secondCall[0]).toBe('/wiki/rest/api/content/1234/child/attachment/att42/download');
+      expect(secondCall[1]).toMatchObject({ maxRedirects: 0 });
+      expect(typeof (secondCall[1] as any).validateStatus).toBe('function');
+      expect((secondCall[1] as any).validateStatus(302)).toBe(true);
+      expect((secondCall[1] as any).validateStatus(200)).toBe(false);
+    });
+
+    it('resolves a thumbnail uri via the same path (no /thumbnails/ -> /attachments/ swap needed)', async () => {
+      const httpGet = jest.spyOn(confluenceService['http'], 'get');
+      (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: [{ id: 'att99' }] } })
+        .mockResolvedValueOnce({ headers: { location: signedUrl } });
+
+      const result = await confluenceService.getRedirectUrlForMedia(
+        'download/thumbnails/5678/photo.jpg?version=1&width=544&height=229&api=v2',
+      );
+
+      expect(result).toBe(signedUrl);
+      expect(httpGet).toHaveBeenNthCalledWith(
+        1,
+        '/wiki/api/v2/pages/5678/attachments',
+        { params: { filename: 'photo.jpg', limit: 1 } },
+      );
+      expect(httpGet.mock.calls[1][0]).toBe(
+        '/wiki/rest/api/content/5678/child/attachment/att99/download',
+      );
+    });
+
+    it('url-decodes the filename before the v2 lookup', async () => {
+      const httpGet = jest.spyOn(confluenceService['http'], 'get');
+      (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: [{ id: 'att1' }] } })
+        .mockResolvedValueOnce({ headers: { location: signedUrl } });
+
+      await confluenceService.getRedirectUrlForMedia(
+        'download/attachments/100/my%20file%20(v2).png?api=v2',
+      );
+
+      expect(httpGet).toHaveBeenNthCalledWith(
+        1,
+        '/wiki/api/v2/pages/100/attachments',
+        { params: { filename: 'my file (v2).png', limit: 1 } },
+      );
+    });
+
+    it('throws 404 when no attachment matches the filename', async () => {
+      (firstValueFrom as any).mockResolvedValueOnce({ data: { results: [] } });
+
+      await expect(
+        confluenceService.getRedirectUrlForMedia('download/attachments/1/missing.png'),
+      ).rejects.toBeInstanceOf(HttpException);
+      await expect(
+        confluenceService.getRedirectUrlForMedia('download/attachments/1/missing.png'),
+      ).rejects.toHaveProperty('status', 404);
+    });
+
+    it('throws 404 when the v1 attachment/download response is not a 302', async () => {
+      (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: [{ id: 'att1' }] } })
+        .mockRejectedValueOnce(new Error('Request failed with status code 401'));
+
+      await expect(
+        confluenceService.getRedirectUrlForMedia('download/attachments/1/file.png'),
+      ).rejects.toHaveProperty('status', 404);
+    });
+
+    it('falls back to a direct /wiki/{uri} passthrough for non-download uris (e.g. aa-avatar)', async () => {
+      const httpGet = jest.spyOn(confluenceService['http'], 'get');
+      (firstValueFrom as any).mockResolvedValueOnce({ headers: { location: signedUrl } });
+
+      const result = await confluenceService.getRedirectUrlForMedia(
+        'aa-avatar/5da80c30f273020c44682e47',
+      );
+
+      expect(result).toBe(signedUrl);
+      const call = httpGet.mock.calls[0];
+      expect(call[0]).toBe('/wiki/aa-avatar/5da80c30f273020c44682e47');
+      expect(call[1]).toMatchObject({ maxRedirects: 0 });
+      expect(typeof (call[1] as any).validateStatus).toBe('function');
+      expect((call[1] as any).validateStatus(302)).toBe(true);
+    });
+
+    it('also accepts a v2 downloadLink shape with leading slash', async () => {
+      const httpGet = jest.spyOn(confluenceService['http'], 'get');
+      (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: [{ id: 'attXX' }] } })
+        .mockResolvedValueOnce({ headers: { location: signedUrl } });
+
+      const result = await confluenceService.getRedirectUrlForMedia(
+        '/download/attachments/246153217/test.pdf?version=1&modificationDate=1692603703844&cacheVersion=1&api=v2',
+      );
+
+      expect(result).toBe(signedUrl);
+      expect(httpGet).toHaveBeenNthCalledWith(
+        1,
+        '/wiki/api/v2/pages/246153217/attachments',
+        { params: { filename: 'test.pdf', limit: 1 } },
+      );
+    });
+  });
+
+  describe('getAttachmentBase64', () => {
+    const signedUrl = 'https://api.media.atlassian.com/file/abc/binary?token=t';
+
+    beforeEach(() => {
+      (firstValueFrom as any).mockReset();
+    });
+
+    it('resolves the media uri and returns the base64-encoded bytes', async () => {
+      jest.spyOn(confluenceService, 'getRedirectUrlForMedia').mockResolvedValueOnce(signedUrl);
+      const axiosDefault = jest.requireActual('axios').default;
+      const axiosGetSpy = jest.spyOn(axiosDefault, 'get').mockResolvedValueOnce({
+        data: Buffer.from('%PDF-1.4 hello', 'utf8'),
+      } as any);
+
+      const result = await confluenceService.getAttachmentBase64(
+        '/download/attachments/1/test.pdf?api=v2',
+      );
+
+      expect(axiosGetSpy).toHaveBeenCalledWith(signedUrl, { responseType: 'arraybuffer' });
+      expect(result).toBe(Buffer.from('%PDF-1.4 hello', 'utf8').toString('base64'));
+    });
+
+    it('returns undefined when the underlying media resolution fails', async () => {
+      jest
+        .spyOn(confluenceService, 'getRedirectUrlForMedia')
+        .mockRejectedValueOnce(new HttpException('error:getRedirectUrlForMedia', 404));
+
+      const result = await confluenceService.getAttachmentBase64(
+        '/download/attachments/1/missing.pdf?api=v2',
+      );
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/tests/unit/mocks/confluenceService.ts
+++ b/tests/unit/mocks/confluenceService.ts
@@ -7,6 +7,7 @@ const GET_SPACE_METADATA = jest.fn().mockImplementation(() => ({
     name: 'konviw',
     icon: {
       path: '/wiki/download/attachments/63859916803/konviw?version=1&modificationDate=1664237784553&cacheVersion=1&api=v2',
+      apiDownloadLink: '/wiki/rest/api/content/63859916803/child/attachment/att63859916804/download',
       width: 48,
       height: 48,
       isDefault: false,

--- a/tests/unit/steps/fixConfluenceSpace.spec.ts
+++ b/tests/unit/steps/fixConfluenceSpace.spec.ts
@@ -9,6 +9,7 @@ describe('ConfluenceProxy / fixConfluenceSpace', () => {
   let context: ContextService;
   let config: ConfigService;
   let http: HttpService;
+  let webBasePath = '';
   let input = '<html><head></head><body><div id="Content" class="fullWidth"><p><a href="/wiki/spaces/konviw">https://sanofi.atlassian.net/wiki/spaces/konviw</a> </p></div></body></html>';
 
   beforeEach(async () => {
@@ -16,14 +17,15 @@ describe('ConfluenceProxy / fixConfluenceSpace', () => {
     context = moduleRef.get<ContextService>(ContextService);
     config = moduleRef.get<ConfigService>(ConfigService);
     http = moduleRef.get<HttpService>(HttpService);
+    webBasePath = config.get('web.absoluteBasePath') ?? '';
     context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
 
-  it('should replace confluence space icon', async () => {
+  it('should replace confluence space icon with a konviw-proxied apiDownloadLink', async () => {
     const step = fixConfluenceSpace(config, confluenceMockServiceFactory);
     context.setHtmlBody(input);
     await step(context);
-    const expected = '<img class="confluence-space-icon" src="https://test.atlassian.net/wiki/download/attachments/63859916803/konviw?version=1&amp;modificationDate=1664237784553&amp;cacheVersion=1&amp;api=v2">';
+    const expected = `<img class="confluence-space-icon" src="${webBasePath}/wiki/rest/api/content/63859916803/child/attachment/att63859916804/download">`;
     expect(context.getHtmlBody()).toContain(expected);
   });
 


### PR DESCRIPTION
…ndpoint

Atlassian CHANGE-2735 deprecated `/wiki/download/attachments/...` with Basic Auth, returning 401 with an OAuth challenge. This broke every media URL konviw served: attachment images, embedded PDFs, drawio/SVG/ chart exports, and space icons.

Resolve attachments through Atlassian's recommended migration path:
  1. v2 page-attachments lookup to map {pageId, filename} -> attachmentId
  2. v1 REST `/content/{id}/child/attachment/{att}/download` which returns a 302 to a signed media-download URL.

- confluence.service.ts: new `parseMediaUri` helper; rewrite `getRedirectUrlForMedia` to use v2 lookup + v1 download, with a direct passthrough fallback for non-`download/...` URIs (e.g. `aa-avatar/*` user avatars, `rest/api/content/.../download` space icons); refactor `getAttachmentBase64` to fetch via the resolved signed URL with no Basic Auth, restoring inline PDF embedding.
- proxy-page.service.ts: simplify `getMediaCdnUrl` to delegate to `getRedirectUrlForMedia` (the `/thumbnails/` -> `/attachments/` rewrite is no longer needed; both shapes are handled in the service).
- proxy-page.controller.ts: add `/rest/api/content/*path` to the media route list so browser-side space-icon URLs flow through konviw.
- fixConfluenceSpace.ts: emit `${web.absoluteBasePath}${icon.apiDownloadLink}` instead of the direct Atlassian URL. Required because a space's parent contentId is a space-level id, not a page id, so the v2 page-attachments fallback used by `/download/attachments/...` 404s.

Tests updated to cover the v2 lookup + v1 download flow, the avatar passthrough fallback, error cases, and the new space-icon URL shape.