### PR TITLE
fix: WEB-2830 render draw.io Forge ecosystem extensions and keep failure text out of the excerpt

### DIFF
--- a/src/proxy-api/steps/getExcerptAndHeaderImage.ts
+++ b/src/proxy-api/steps/getExcerptAndHeaderImage.ts
@@ -4,6 +4,21 @@ import { ContextService } from '../../context/context.service';
 import { Step } from '../proxy-api.step';
 import { ConfluenceService } from '../../confluence/confluence.service';
 
+// When Atlassian fails to pre-render a drawio diagram server-side, it injects
+// a generic "Failed to load the diagram preview image. / Authentication
+// Required / Page ID: <id>" warning macro in place of the diagram. fixDrawio
+// recovers the diagram in the rendered body, but this step runs first, so we
+// must strip the same text here to avoid leaking it into the excerpt /
+// konviwExcerpt metadata.
+const DRAWIO_FAILURE_TEXT_REGEX = /Failed to load the diagram preview image\.?\s*Authentication Required\s*Page ID:\s*\d+/gi;
+
+const stripDrawioFailureText = (text: string): string =>
+  text.replace(DRAWIO_FAILURE_TEXT_REGEX, '').replace(/\s+/g, ' ').trim();
+
+const isDrawioFailureWarning = ($el: cheerio.Cheerio<cheerio.Element>): boolean =>
+  $el.is('.confluence-information-macro-warning')
+    && $el.text().includes('Failed to load the diagram preview image');
+
 // This module search for the right image and a blockquote to set them as blog post header image and headline
 export default (config: ConfigService, confluence: ConfluenceService): Step => async (context: ContextService): Promise<void> => {
   context.setPerfMark('getExcerptAndHeaderImage');
@@ -33,7 +48,21 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
     .first()
     .each((_index: number, elementExcerpt: cheerio.Element) => {
       const excerptPage = $(elementExcerpt);
-      context.setExcerpt(excerptPage.text());
+      // If the excerpt macro IS the drawio preview-failure warning, treat
+      // it as empty: fixDrawio will recover the diagram and we don't want
+      // the failure text leaking into konviwExcerpt.
+      if (isDrawioFailureWarning(excerptPage)) {
+        return;
+      }
+      // Otherwise the excerpt may still embed a failure warning as a
+      // descendant; clone before mutating so we don't disturb the page DOM
+      // that fixDrawio still needs to operate on.
+      const cleaned = excerptPage.clone();
+      cleaned
+        .find('.confluence-information-macro-warning')
+        .filter((_i, el) => $(el).text().includes('Failed to load the diagram preview image'))
+        .remove();
+      context.setExcerpt(stripDrawioFailureText(cleaned.text()));
     });
 
   // TODO: [WEB-344] to be removed and release new major version
@@ -58,7 +87,7 @@ export default (config: ConfigService, confluence: ConfluenceService): Step => a
 
   // if not excerpt at all then alternatively we take a summary of the body of the document
   if (context.getExcerpt() === '') {
-    const tmpTextBody = context.getTextBody();
+    const tmpTextBody = stripDrawioFailureText(context.getTextBody());
     context.setExcerpt(
       tmpTextBody.substring(0, tmpTextBody.lastIndexOf(' ', 500)),
     );

--- a/src/proxy-page/steps/fixDrawio.ts
+++ b/src/proxy-page/steps/fixDrawio.ts
@@ -20,6 +20,75 @@ import { Step } from '../proxy-page.step';
  * @param  {ConfigService} config
  * @returns void
  */
+
+type StorageDrawioMacro = {
+  diagramName: string;
+  pageId: string;
+};
+
+/**
+ * Walk the storage XML and collect every drawio macro in document order, no
+ * matter which storage shape Atlassian produced for it:
+ *
+ * - Legacy `<ac:structured-macro ac:name="drawio">`
+ *   (also `drawio-sketch` and `inc-drawio`).
+ * - New Forge ecosystem extension nodes
+ *   `<ac:adf-node type="extension">` whose `extension-key` ends with
+ *   `/static/drawio` (or `/static/drawio-sketch`). In that case Atlassian also
+ *   emits a duplicate copy inside `<ac:adf-fallback>` which we MUST skip to
+ *   keep the document-order indexing aligned with the rendered placeholders.
+ */
+const collectStorageDrawioMacros = (
+  storageBody: string,
+  fallbackPageId: string,
+): StorageDrawioMacro[] => {
+  const $xml = cheerio.load(storageBody, { xmlMode: true });
+  const candidates = $xml(
+    String.raw`ac\:structured-macro[ac\:name="drawio"],`
+      + String.raw`ac\:structured-macro[ac\:name="drawio-sketch"],`
+      + String.raw`ac\:structured-macro[ac\:name="inc-drawio"],`
+      + String.raw`ac\:adf-node[type="extension"]`,
+  );
+
+  const macros: StorageDrawioMacro[] = [];
+  candidates.each((_i, el) => {
+    const $el = $xml(el);
+
+    if ($el.is(String.raw`ac\:structured-macro`)) {
+      const diagramName = $el
+        .find(String.raw`ac\:parameter[ac\:name="diagramName"]`)
+        .first()
+        .text();
+      if (!diagramName) return;
+      const pageId = $el
+        .find(String.raw`ac\:parameter[ac\:name="pageId"]`)
+        .first()
+        .text() || fallbackPageId;
+      macros.push({ diagramName, pageId });
+      return;
+    }
+
+    // Forge ecosystem extension: only drawio extensions, and only the
+    // primary node (skip the duplicate inside <ac:adf-fallback>).
+    if ($el.parents(String.raw`ac\:adf-fallback`).length > 0) return;
+    const extensionKey = $el
+      .find(String.raw`ac\:adf-attribute[key="extension-key"]`)
+      .first()
+      .text();
+    if (!/\/static\/drawio(?:-sketch)?$/i.test(extensionKey)) return;
+    const diagramName = $el
+      .find(String.raw`ac\:adf-parameter[key="diagram-name"]`)
+      .first()
+      .text();
+    if (!diagramName) return;
+    const pageId = $el
+      .find(String.raw`ac\:adf-parameter[key="page-id"]`)
+      .first()
+      .text() || fallbackPageId;
+    macros.push({ diagramName, pageId });
+  });
+  return macros;
+};
 /* eslint-disable no-useless-escape, prefer-regex-literals */
 export default (config: ConfigService): Step => (context: ContextService): void => {
   context.setPerfMark('fixDrawio');
@@ -91,40 +160,43 @@ export default (config: ConfigService): Step => (context: ContextService): void 
     },
   );
 
-  // Confluence API v2 view format renders drawio macros as plain <div>draw.io Board</div>.
-  // When the old ap-container selectors didn't match, fall back to parsing the storage body
-  // to extract diagram metadata and replace the placeholder divs with proper image tags.
-  const drawioPlaceholders = $('div').filter(
+  // Confluence API v2 view format renders drawio macros as plain <div>draw.io Board</div>
+  // (when the macro pre-render succeeded) or, since 2026-05-19, as a generic warning macro
+  // body containing "Failed to load the diagram preview image. / Authentication Required /
+  // Page ID: <id>" when Atlassian's server-side preview generation fails. In both cases the
+  // ap-container selectors above don't match, so we fall back to parsing the storage body
+  // and reconstruct the proper image tag from the drawio macro parameters. The warning-macro
+  // and "draw.io Board" cases are mutually exclusive in practice (Atlassian emits one shape
+  // for the whole page), so a single index-aligned correlation against the storage drawio
+  // macros covers both.
+  const drawioBoardPlaceholders = $('div').filter(
     (_i, el) => $(el).text().trim() === 'draw.io Board',
+  );
+  // We do NOT constrain on data-macro-name here: depending on the original
+  // macro structure, Atlassian renders the same failure with data-macro-name
+  // set to "warning", "excerpt", or other values. The drawio-specific body
+  // text "Failed to load the diagram preview image" is what makes this
+  // selection safe.
+  const drawioWarningPlaceholders = $(
+    '.confluence-information-macro-warning',
+  ).filter((_i, el) =>
+    $(el).text().includes('Failed to load the diagram preview image'));
+  const drawioPlaceholders = drawioBoardPlaceholders.add(
+    drawioWarningPlaceholders,
   );
   if (drawioPlaceholders.length > 0) {
     const storageBody = context.getBodyStorage();
     if (storageBody) {
-      const $xml = cheerio.load(storageBody, { xmlMode: true });
-      const macros = $xml(
-        String.raw`ac\:structured-macro[ac\:name="drawio"],`
-        + String.raw`ac\:structured-macro[ac\:name="drawio-sketch"],`
-        + String.raw`ac\:structured-macro[ac\:name="inc-drawio"]`,
-      );
+      const macros = collectStorageDrawioMacros(storageBody, context.getPageId());
 
       drawioPlaceholders.each((idx: number, el: cheerio.Element) => {
-        const macro = macros.eq(idx);
-        if (!macro.length) return;
-
-        const diagramName = macro
-          .find(String.raw`ac\:parameter[ac\:name="diagramName"]`)
-          .text();
-        const pageId = macro
-          .find(String.raw`ac\:parameter[ac\:name="pageId"]`)
-          .text() || context.getPageId();
-
-        if (diagramName) {
-          $(el).replaceWith(
-            `<figure><img class="drawio-zoomable"
-              src="${webBasePath}/wiki/download/attachments/${pageId}/${diagramName}.png"
-              alt="${diagramName}" /></figure>`,
-          );
-        }
+        const macro = macros[idx];
+        if (!macro) return;
+        $(el).replaceWith(
+          `<figure><img class="drawio-zoomable"
+              src="${webBasePath}/wiki/download/attachments/${macro.pageId}/${macro.diagramName}.png"
+              alt="${macro.diagramName}" /></figure>`,
+        );
       });
     }
   }

--- a/tests/unit/steps/fixDrawio.spec.ts
+++ b/tests/unit/steps/fixDrawio.spec.ts
@@ -143,6 +143,216 @@ describe('ConfluenceProxy / fixDrawio (API v2 placeholder fallback)', () => {
   });
 });
 
+/**
+ * Since 2026-05-19, Atlassian's drawio macro server-side preview generation
+ * has been failing for some pages and Atlassian replaces the rendered diagram
+ * with a generic warning macro body in the v2 view-format response:
+ *
+ *   <div class="confluence-information-macro confluence-information-macro-warning"
+ *        data-macro-name="warning">
+ *     <div class="confluence-information-macro-body">
+ *       <p>Failed to load the diagram preview image.</p>
+ *       <p>Authentication Required</p>
+ *       <p>Page ID: 12345</p>
+ *     </div>
+ *   </div>
+ *
+ * konviw must recover by reading the diagram metadata from the storage body
+ * (same trick as for the `<div>draw.io Board</div>` placeholder branch).
+ */
+describe('ConfluenceProxy / fixDrawio (Failed-to-load-preview warning fallback)', () => {
+  let context: ContextService;
+  let config: ConfigService;
+  let webBasePath = '';
+
+  const pageId = '63988664015';
+  const diagram1 = 'Landing page structure.drawio';
+  const diagram2 = 'Menu Structure.drawio';
+  const diagram3 = 'Other resources.drawio';
+
+  const buildWarning = (id: string, macroName = 'warning') => `
+    <div class="confluence-information-macro confluence-information-macro-warning conf-macro output-block"
+         data-hasbody="true" data-macro-name="${macroName}">
+      <span class="aui-icon aui-icon-small aui-iconfont-error confluence-information-macro-icon"> </span>
+      <div class="confluence-information-macro-body">
+        <p>Failed to load the diagram preview image.</p>
+        <p>Authentication Required</p>
+        <p>Page ID: ${id}</p>
+      </div>
+    </div>`;
+
+  // Atlassian emits the failure with various data-macro-name values
+  // depending on the original macro context (warning, excerpt, etc.).
+  // All shapes must be detected and replaced.
+  const viewHtml = `
+<html>
+  <body>
+    <h3>Three failed drawio diagrams plus a legitimate warning</h3>
+    ${buildWarning(pageId, 'warning')}
+    <p>some text</p>
+    ${buildWarning(pageId, 'excerpt')}
+    <p>more text</p>
+    ${buildWarning(pageId, 'info')}
+    <div class="confluence-information-macro confluence-information-macro-warning conf-macro output-block"
+         data-macro-name="warning">
+      <div class="confluence-information-macro-body">
+        <p>This is a normal author-written warning, not a drawio failure.</p>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+  const buildStorageMacro = (name: string) => `
+    <ac:structured-macro ac:name="drawio" ac:schema-version="1" ac:macro-id="m-${name}">
+      <ac:parameter ac:name="pageId">${pageId}</ac:parameter>
+      <ac:parameter ac:name="diagramName">${name}</ac:parameter>
+    </ac:structured-macro>`;
+
+  const storageXml = `
+${buildStorageMacro(diagram1)}
+${buildStorageMacro(diagram2)}
+${buildStorageMacro(diagram3)}
+`;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    config = moduleRef.get<ConfigService>(ConfigService);
+    webBasePath = config.get('web.absoluteBasePath') ?? '';
+
+    context.initPageContext('v2', 'XXX', pageId, 'dark');
+    context.setHtmlBody(viewHtml);
+    context.setBodyStorage(storageXml);
+    const step = fixDrawio(config);
+    step(context);
+  });
+
+  it('replaces every drawio-failure warning with a proper image, in document order', () => {
+    const $ = context.getCheerioBody();
+    const imgs = $('img.drawio-zoomable');
+    expect(imgs.length).toBe(3);
+    expect(imgs.eq(0).attr('src')).toBe(
+      `${webBasePath}/wiki/download/attachments/${pageId}/${diagram1}.png`,
+    );
+    expect(imgs.eq(1).attr('src')).toBe(
+      `${webBasePath}/wiki/download/attachments/${pageId}/${diagram2}.png`,
+    );
+    expect(imgs.eq(2).attr('src')).toBe(
+      `${webBasePath}/wiki/download/attachments/${pageId}/${diagram3}.png`,
+    );
+    expect(imgs.eq(0).attr('alt')).toBe(diagram1);
+  });
+
+  it('removes the drawio-failure warning text from the rendered body', () => {
+    const $ = context.getCheerioBody();
+    expect($.html()).not.toContain('Failed to load the diagram preview image');
+  });
+
+  it('leaves unrelated author-written warning macros untouched', () => {
+    const $ = context.getCheerioBody();
+    expect($.html()).toContain(
+      'This is a normal author-written warning, not a drawio failure.',
+    );
+  });
+});
+
+/**
+ * Some pages store the drawio macro as a Forge ecosystem extension instead of
+ * the legacy `<ac:structured-macro ac:name="drawio">`. The extension can also
+ * be wrapped inside another macro (e.g. `excerpt`), which causes the rendered
+ * failure macro to come back with `data-macro-name="excerpt"`. The storage XML
+ * additionally contains a duplicate `<ac:adf-fallback>` copy that must be
+ * skipped when correlating placeholders to macros by document order.
+ */
+describe('ConfluenceProxy / fixDrawio (Forge ecosystem extension shape)', () => {
+  let context: ContextService;
+  let config: ConfigService;
+  let webBasePath = '';
+
+  const pageId = '63881347657';
+  const diagramFileName = 'C4-Diagram-L1.drawio';
+
+  const viewHtml = `
+<html>
+  <body>
+    <h3>One drawio inside an excerpt</h3>
+    <div class="confluence-information-macro confluence-information-macro-warning"
+         data-hasbody="true" data-macro-name="excerpt">
+      <div class="confluence-information-macro-body">
+        <p>Failed to load the diagram preview image.</p>
+        <p>Authentication Required</p>
+        <p>Page ID: ${pageId}</p>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+  const storageXml = `
+<ac:structured-macro ac:name="excerpt" ac:schema-version="1" ac:macro-id="0c948a1c29bbb52288703451a698b483">
+  <ac:parameter ac:name="name">c2 overview</ac:parameter>
+  <ac:rich-text-body>
+    <ac:adf-extension>
+      <ac:adf-node type="extension">
+        <ac:adf-attribute key="extension-key">ari:cloud:ecosystem::extension/.../static/drawio</ac:adf-attribute>
+        <ac:adf-attribute key="extension-type">com.atlassian.ecosystem</ac:adf-attribute>
+        <ac:adf-attribute key="parameters">
+          <ac:adf-parameter key="extension-title">draw.io Diagram</ac:adf-parameter>
+          <ac:adf-parameter key="guest-params">
+            <ac:adf-parameter key="diagram-name">${diagramFileName}</ac:adf-parameter>
+            <ac:adf-parameter key="diagram-display-name">C4-Diagram-L2.drawio</ac:adf-parameter>
+            <ac:adf-parameter key="page-id">${pageId}</ac:adf-parameter>
+          </ac:adf-parameter>
+        </ac:adf-attribute>
+      </ac:adf-node>
+      <ac:adf-fallback>
+        <ac:adf-node type="extension">
+          <ac:adf-attribute key="extension-key">ari:cloud:ecosystem::extension/.../static/drawio</ac:adf-attribute>
+          <ac:adf-attribute key="parameters">
+            <ac:adf-parameter key="guest-params">
+              <ac:adf-parameter key="diagram-name">SHOULD-NOT-BE-USED.drawio</ac:adf-parameter>
+              <ac:adf-parameter key="page-id">${pageId}</ac:adf-parameter>
+            </ac:adf-parameter>
+          </ac:adf-attribute>
+        </ac:adf-node>
+      </ac:adf-fallback>
+    </ac:adf-extension>
+  </ac:rich-text-body>
+</ac:structured-macro>`;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    config = moduleRef.get<ConfigService>(ConfigService);
+    webBasePath = config.get('web.absoluteBasePath') ?? '';
+
+    context.initPageContext('v2', 'XXX', pageId, 'dark');
+    context.setHtmlBody(viewHtml);
+    context.setBodyStorage(storageXml);
+    const step = fixDrawio(config);
+    step(context);
+  });
+
+  it('replaces the Forge-extension drawio failure with the proper image', () => {
+    const $ = context.getCheerioBody();
+    const imgs = $('img.drawio-zoomable');
+    expect(imgs.length).toBe(1);
+    expect(imgs.eq(0).attr('src')).toBe(
+      `${webBasePath}/wiki/download/attachments/${pageId}/${diagramFileName}.png`,
+    );
+    expect(imgs.eq(0).attr('alt')).toBe(diagramFileName);
+  });
+
+  it('removes the failure warning from the rendered body', () => {
+    const $ = context.getCheerioBody();
+    expect($.html()).not.toContain('Failed to load the diagram preview image');
+  });
+
+  it('does not pick up the diagram-name from the <ac:adf-fallback> copy', () => {
+    const $ = context.getCheerioBody();
+    expect($.html()).not.toContain('SHOULD-NOT-BE-USED');
+  });
+});
+
 const getImgSrc = (image): string => {
   const regex = new RegExp('src="([^"]*)');
   return regex.exec(image)[1];

--- a/tests/unit/steps/getExcerptAndHeaderImage.spec.ts
+++ b/tests/unit/steps/getExcerptAndHeaderImage.spec.ts
@@ -1,0 +1,118 @@
+import { ConfigService } from '@nestjs/config';
+import { ContextService } from '../../../src/context/context.service';
+import { ConfluenceService } from '../../../src/confluence/confluence.service';
+import getExcerptAndHeaderImage from '../../../src/proxy-api/steps/getExcerptAndHeaderImage';
+import { createModuleRefForStep } from './utils';
+
+const FAILURE_TEXT = 'Failed to load the diagram preview image';
+
+const buildFailureWarning = (pageId: string, classes = '') => `
+  <div class="confluence-information-macro confluence-information-macro-warning conf-macro output-block conf-macro output-inline ${classes}"
+       data-hasbody="true" data-macro-name="excerpt">
+    <span class="aui-icon aui-icon-small aui-iconfont-error confluence-information-macro-icon"> </span>
+    <div class="confluence-information-macro-body">
+      <p>Failed to load the diagram preview image.</p>
+      <p>Authentication Required</p>
+      <p>Page ID: ${pageId}</p>
+    </div>
+  </div>`;
+
+describe('ConfluenceProxy / getExcerptAndHeaderImage (drawio failure scrubbing)', () => {
+  const pageId = '63881347657';
+  let context: ContextService;
+  let config: ConfigService;
+  let confluence: ConfluenceService;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    config = moduleRef.get<ConfigService>(ConfigService);
+    // ConfluenceService isn't registered in createModuleRefForStep, but the
+    // step only invokes it when there is a non-URL header image. We pass a
+    // stub instead of bringing the full module up.
+    confluence = {
+      getAttachments: jest.fn(),
+    } as unknown as ConfluenceService;
+    context.initPageContext('v2', 'XXX', pageId, 'dark');
+  });
+
+  it('returns a scrubbed excerpt when the excerpt macro IS the drawio failure warning', async () => {
+    context.setHtmlBody(`
+      <html><body>
+        <p>Real body summary that should survive scrubbing.</p>
+        ${buildFailureWarning(pageId)}
+      </body></html>
+    `);
+
+    await getExcerptAndHeaderImage(config, confluence)(context);
+
+    expect(context.getExcerpt()).not.toContain(FAILURE_TEXT);
+    expect(context.getExcerpt()).not.toContain('Authentication Required');
+    expect(context.getExcerpt()).not.toMatch(/Page ID:\s*\d+/);
+    // Falls back to the body text which is also scrubbed of the failure
+    // pattern; some real body content remains.
+    expect(context.getExcerpt()).toContain('Real body summary');
+  });
+
+  it('strips the drawio failure warning when nested inside a richer excerpt macro', async () => {
+    context.setHtmlBody(`
+      <html><body>
+        <div class="conf-macro output-inline" data-macro-name="excerpt">
+          <p>Useful summary about the page.</p>
+          ${buildFailureWarning(pageId)}
+          <p>More summary text.</p>
+        </div>
+      </body></html>
+    `);
+
+    await getExcerptAndHeaderImage(config, confluence)(context);
+
+    expect(context.getExcerpt()).not.toContain(FAILURE_TEXT);
+    expect(context.getExcerpt()).toContain('Useful summary');
+    expect(context.getExcerpt()).toContain('More summary text');
+  });
+
+  it('strips the drawio failure pattern from the body-text fallback when no excerpt macro is present', async () => {
+    context.setHtmlBody(`
+      <html><body>
+        <p>Some real body text appears here.</p>
+        ${buildFailureWarning(pageId)}
+      </body></html>
+    `);
+
+    await getExcerptAndHeaderImage(config, confluence)(context);
+
+    expect(context.getExcerpt()).not.toContain(FAILURE_TEXT);
+    expect(context.getExcerpt()).toContain('Some real body text');
+  });
+
+  it('does not modify the cheerio body when scrubbing the excerpt (fixDrawio still needs the warning)', async () => {
+    context.setHtmlBody(`
+      <html><body>
+        <div class="conf-macro output-inline" data-macro-name="excerpt">
+          <p>Useful summary.</p>
+          ${buildFailureWarning(pageId)}
+        </div>
+      </body></html>
+    `);
+
+    await getExcerptAndHeaderImage(config, confluence)(context);
+
+    // Body still carries the warning macro for fixDrawio to replace.
+    expect(context.getHtmlBody()).toContain(FAILURE_TEXT);
+  });
+
+  it('leaves a normal excerpt untouched', async () => {
+    context.setHtmlBody(`
+      <html><body>
+        <div class="conf-macro output-inline" data-macro-name="excerpt">
+          <p>This is a perfectly normal page summary.</p>
+        </div>
+      </body></html>
+    `);
+
+    await getExcerptAndHeaderImage(config, confluence)(context);
+
+    expect(context.getExcerpt()).toContain('This is a perfectly normal page summary');
+  });
+});


### PR DESCRIPTION
## Summary

Two cases were leaving "Failed to load the diagram preview image" / "Authentication Required" / "Page ID: <id>" warnings visible on pages whose drawio macro Atlassian fails to pre-render server-side.

### `fixDrawio`
- Match the failure warning regardless of `data-macro-name` (it can be `warning`, `excerpt`, or other values depending on where the diagram is embedded); the body text is what makes the match drawio-specific.
- Recover diagram metadata from both storage shapes:
  - legacy `<ac:structured-macro ac:name="drawio|drawio-sketch|inc-drawio">`,
  - Forge ecosystem extension `<ac:adf-node type="extension">` whose `extension-key` ends with `/static/drawio` (or `/static/drawio-sketch`), reading `diagram-name` and `page-id` from `<ac:adf-parameter>`.
- Skip the duplicate copy emitted inside `<ac:adf-fallback>` so document-order indexing stays aligned with the rendered placeholders.

### `getExcerptAndHeaderImage`
- Drop the drawio failure text from the page excerpt and from the body-text fallback so it no longer leaks into `context.excerpt` or the `konviwExcerpt` postMessage payload.
- Cloning the excerpt element before mutating preserves the warning in the page DOM so that `fixDrawio` can still replace it with the proper image afterwards.

## Tests

- `tests/unit/steps/fixDrawio.spec.ts`: existing fallback-warning fixture now covers `data-macro-name` of `warning`, `excerpt`, and `info`. New describe block covers the Forge extension shape (drawio inside an `excerpt`), including the `<ac:adf-fallback>` duplicate that must be ignored.
- `tests/unit/steps/getExcerptAndHeaderImage.spec.ts` (new): covers all four scrubbing paths (excerpt macro IS the warning, warning nested inside a richer excerpt, body-text fallback, normal excerpt untouched) and asserts that scrubbing does not mutate the page DOM (so `fixDrawio` can still replace the warning).

`npx jest tests/unit/steps/fixDrawio.spec.ts tests/unit/steps/getExcerptAndHeaderImage.spec.ts` → 17 / 17 passing.

## Test plan

- [ ] Visit a page using the legacy `<ac:structured-macro ac:name="drawio">` storage shape (e.g. `/cpv/wiki/spaces/central-jira/pages/63988664015`) — diagrams render, no "Failed to load" anywhere in the response.
- [ ] Visit a page using the Forge ecosystem extension shape (e.g. `/cpv/wiki/spaces/SW/pages/63881347657`) — diagram renders, no "Failed to load" / "Authentication Required" anywhere in the response.
- [ ] Inspect the embedded `konviwMessage` in the page source: `konviwExcerpt` should contain real page content, never the failure text.

Made with [Cursor](https://cursor.com)