### PR TITLE
ci(jira-snapshot): pass CPV_XRAY_* secrets to CI env (WEB-2475)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       CPV_JIRA_READER_API_USERNAME: ${{ secrets.CPV_JIRA_READER_API_USERNAME }}
       CPV_JIRA_READER_API_TOKEN: ${{ secrets.CPV_JIRA_READER_API_TOKEN }}
+      CPV_XRAY_BASE_URL: ${{ secrets.CPV_XRAY_BASE_URL }}
+      CPV_XRAY_CLIENT_ID: ${{ secrets.CPV_XRAY_CLIENT_ID }}
+      CPV_XRAY_CLIENT_SECRET: ${{ secrets.CPV_XRAY_CLIENT_SECRET }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Wire the Xray Cloud API credentials (CPV_XRAY_BASE_URL, CPV_XRAY_CLIENT_ID, CPV_XRAY_CLIENT_SECRET) into the CI quality job env for build/test parity with the other CPV_* credentials.