### PR TITLE
fix: WEB-2893 fix nested table rendering for confluence pages in konviw

### DIFF
--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -53,13 +53,16 @@ table.confluenceTable th.confluenceTh table.confluenceTable {
   width: 100%;
   max-width: 100%;
   margin-top: 0;
+  // Auto layout lets the nested table shrink to fit its cell whatever the
+  // colgroup widths are (px or %); with the inherited 'fixed' layout a pixel
+  // colgroup would force the table wider than the cell and overflow.
+  table-layout: auto;
 }
 
 table.confluenceTable td.confluenceTd .table-wrap,
 table.confluenceTable th.confluenceTh .table-wrap {
   max-width: 100%;
   margin-top: 0;
-  overflow-x: auto;
 }
 
 table.confluenceTable th.confluenceTh {

--- a/src/assets/scss/_tables.scss
+++ b/src/assets/scss/_tables.scss
@@ -45,6 +45,23 @@ table.confluenceTable {
   }
 }
 
+// Nested tables (one level deep) ==========================
+// Confluence allows a table inside a cell. Constrain it to the width of its
+// parent cell so it never overflows into the column on the right.
+table.confluenceTable td.confluenceTd table.confluenceTable,
+table.confluenceTable th.confluenceTh table.confluenceTable {
+  width: 100%;
+  max-width: 100%;
+  margin-top: 0;
+}
+
+table.confluenceTable td.confluenceTd .table-wrap,
+table.confluenceTable th.confluenceTh .table-wrap {
+  max-width: 100%;
+  margin-top: 0;
+  overflow-x: auto;
+}
+
 table.confluenceTable th.confluenceTh {
   position: -webkit-sticky;
   position: sticky;

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -38,13 +38,16 @@ table.confluenceTable th.confluenceTh table.confluenceTable {
   width: 100%;
   max-width: 100%;
   margin-top: 0;
+  // Auto layout lets the nested table shrink to fit its cell whatever the
+  // colgroup widths are (px or %); with the inherited 'fixed' layout a pixel
+  // colgroup would force the table wider than the cell and overflow.
+  table-layout: auto;
 }
 
 table.confluenceTable td.confluenceTd .table-wrap,
 table.confluenceTable th.confluenceTh .table-wrap {
   max-width: 100%;
   margin-top: 0;
-  overflow-x: auto;
 }
 
 table.confluenceTable th.confluenceTh {

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -30,6 +30,23 @@ table.confluenceTable {
   }
 }
 
+// Nested tables (one level deep) ==========================
+// Confluence allows a table inside a cell. Constrain it to the width of its
+// parent cell so it never overflows into the column on the right.
+table.confluenceTable td.confluenceTd table.confluenceTable,
+table.confluenceTable th.confluenceTh table.confluenceTable {
+  width: 100%;
+  max-width: 100%;
+  margin-top: 0;
+}
+
+table.confluenceTable td.confluenceTd .table-wrap,
+table.confluenceTable th.confluenceTh .table-wrap {
+  max-width: 100%;
+  margin-top: 0;
+  overflow-x: auto;
+}
+
 table.confluenceTable th.confluenceTh {
   position: -webkit-sticky;
   position: sticky;

--- a/src/proxy-page/steps/addTableResponsive.ts
+++ b/src/proxy-page/steps/addTableResponsive.ts
@@ -15,11 +15,13 @@ export default (): Step => (context: ContextService): void => {
     const tbody = $(tbodyElement);
 
     // for each row in the table
-    const trElements = tbody.find('tr');
+    // Only look at direct children so a nested table (one level deep) is not
+    // traversed here: it owns its own <tbody> and is processed on its own turn.
+    const trElements = tbody.children('tr');
     trElements.each((_: number, trElement: cheerio.Element) => {
       const tr = $(trElement);
-      const thElement = tr.find('th');
-      const tdElement = tr.find('td');
+      const thElement = tr.children('th');
+      const tdElement = tr.children('td');
 
       // row headers and column headers have 2 different patterns, the column headers are in the first
       // tr full of th, so there are no td elements in the first tr
@@ -45,7 +47,7 @@ export default (): Step => (context: ContextService): void => {
     trElements.slice(slice_number).each((_index_row: number, trElement: cheerio.Element) => {
       const row = _index_row;
       const tr = $(trElement);
-      const tdElements = tr.find('td');
+      const tdElements = tr.children('td');
       tdElements.each((_index_column: number, tdElement: cheerio.Element) => {
         const td = $(tdElement);
         const header_column = headers_column[_index_column + slice_number];

--- a/src/proxy-page/steps/fixColGroupWidth.ts
+++ b/src/proxy-page/steps/fixColGroupWidth.ts
@@ -25,7 +25,13 @@ export default (): Step => (context: ContextService): void => {
     table[data-layout= 'wide']> colgroup,
     table[data-layout='default']>colgroup,
     table[data-layout= 'align-start']> colgroup,
-    table[data-layout= 'center']> colgroup`,
+    table[data-layout= 'center']> colgroup,
+    td.confluenceTd table.confluenceTable>colgroup,
+    th.confluenceTh table.confluenceTable>colgroup`,
+    // Nested tables (one level deep) rarely carry a data-layout attribute, so we
+    // also target confluence tables living inside a cell. Converting their
+    // colgroup widths to % keeps the columns proportional to the parent cell and
+    // prevents the nested table from overflowing into the column on the right.
     // 'table[data-table-display-mode=\'fixed\']',   // eventually to define whether we need special style to display fixed tables
   ).each((_index: number, elementColgroup: cheerio.Element) => {
     let sumColWidth = 0;

--- a/src/proxy-page/steps/fixTableSize.ts
+++ b/src/proxy-page/steps/fixTableSize.ts
@@ -6,7 +6,12 @@ export default (): Step => (context: ContextService): void => {
   context.setPerfMark('fixTableSize');
   const $ = context.getCheerioBody();
 
-  $('table').each(
+  // Only size top-level tables. A nested table (one level deep) must keep its
+  // natural size so it fits inside its cell instead of overflowing the column.
+  const isTopLevelTable = (_index: number, tableElement: cheerio.Element): boolean =>
+    $(tableElement).parents('table').length === 0;
+
+  $('table').filter(isTopLevelTable).each(
     (_macroIndex: number, tableElement: cheerio.Element) => {
       const tableWidth = $(tableElement).attr('data-table-width');
       if (tableWidth) {

--- a/tests/unit/steps/addResponsiveTable.spec.ts
+++ b/tests/unit/steps/addResponsiveTable.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import * as cheerio from 'cheerio';
 import { ContextService } from '../../../src/context/context.service';
 import { Step } from '../../../src/proxy-page/proxy-page.step';
 import addResponsiveTable from '../../../src/proxy-page/steps/addTableResponsive';
@@ -59,5 +60,43 @@ describe('Confluence Proxy / addTheme', () => {
     '<tr><th><p><strong>B</strong></p></th><td data-column-id=\"2\" data-lign-id=\"B\"><p>Test3</p></td><td data-column-id=\"3\" data-lign-id=\"B\"><p>Test4</p></td></tr></tbody>'+
     '</table></div><p></p></div></div></body></html>'
     );
+  });
+
+  it('should not leak outer table headers into a nested table (one level deep)', () => {
+    context.setHtmlBody('<html><head></head><body><div id="Content"><div class="table-wrap">'+
+    '<table data-layout="default" class="confluenceTable"><colgroup><col><col></colgroup>'+
+    '<tbody>'+
+    '<tr><th><p><strong>Outer1</strong></p></th><th><p><strong>Outer2</strong></p></th></tr>'+
+    '<tr>'+
+    '<td class="confluenceTd"><div class="table-wrap"><table class="confluenceTable"><colgroup><col><col></colgroup>'+
+    '<tbody>'+
+    '<tr><th><p><strong>Inner1</strong></p></th><th><p><strong>Inner2</strong></p></th></tr>'+
+    '<tr><td class="confluenceTd"><p>n1</p></td><td class="confluenceTd"><p>n2</p></td></tr>'+
+    '</tbody></table></div></td>'+
+    '<td class="confluenceTd"><p>right</p></td>'+
+    '</tr>'+
+    '</tbody></table></div></div></body></html>');
+    step(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    const outerTable = $('table.confluenceTable').first();
+    const nestedTable = outerTable.find('table.confluenceTable').first();
+
+    // Outer data cells are labelled from the outer header row.
+    const outerDataCells = outerTable.children('tbody').children('tr').last().children('td');
+    expect(outerDataCells.eq(0).attr('data-column-id')).toBe('Outer1');
+    expect(outerDataCells.eq(1).attr('data-column-id')).toBe('Outer2');
+
+    // Nested data cells are labelled from the nested header row only.
+    const nestedDataCells = nestedTable.children('tbody').children('tr').last().children('td');
+    expect(nestedDataCells.eq(0).attr('data-column-id')).toBe('Inner1');
+    expect(nestedDataCells.eq(1).attr('data-column-id')).toBe('Inner2');
+
+    // The outer headers must never bleed into the nested cells.
+    nestedDataCells.each((_i, cell) => {
+      expect($(cell).attr('data-column-id')).not.toBe('Outer1');
+      expect($(cell).attr('data-column-id')).not.toBe('Outer2');
+      expect($(cell).attr('data-lign-id')).toBeUndefined();
+    });
   });
 });

--- a/tests/unit/steps/fixColgroupWidth.spec.ts
+++ b/tests/unit/steps/fixColgroupWidth.spec.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import fixColgroupWidth from '../../../src/proxy-page/steps/fixColGroupWidth';
 import { ContextService } from '../../../src/context/context.service';
 import { createModuleRefForStep } from './utils';
@@ -21,6 +22,25 @@ describe('ConfluenceProxy / fixColGroupWidth', () => {
     step(context);
     expect(context.getHtmlBody()).toContain('width: 224.0px;');
     expect(context.getHtmlBody()).not.toContain('width: 25%;');
+  });
+
+  it('should convert a nested table colgroup from px to proportional percentage % so it fits its cell', () => {
+    context.setHtmlBody('<html><head></head><body>'+
+    '<table data-layout="default" class="confluenceTable"><colgroup><col style="width: 500.0px;"/><col style="width: 500.0px;"/></colgroup>'+
+    '<tbody><tr>'+
+    '<td class="confluenceTd"><table class="confluenceTable"><colgroup><col style="width: 300.0px;"/><col style="width: 300.0px;"/></colgroup>'+
+    '<tbody><tr><td><p>n1</p></td><td><p>n2</p></td></tr></tbody></table></td>'+
+    '<td class="confluenceTd"><p>right</p></td>'+
+    '</tr></tbody></table>'+
+    '</body></html>');
+    step(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    const nestedCols = $('td.confluenceTd table.confluenceTable > colgroup > col');
+    expect(nestedCols.length).toBe(2);
+    nestedCols.each((_i, col) => {
+      expect($(col).attr('style')).toBe('width: 50%;');
+    });
   });
 
 })

--- a/tests/unit/steps/fixTableSize.spec.ts
+++ b/tests/unit/steps/fixTableSize.spec.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import { ContextService } from '../../../src/context/context.service';
 import { Step } from '../../../src/proxy-page/proxy-page.step';
 import fixTableSize from '../../../src/proxy-page/steps/fixTableSize';
@@ -51,5 +52,28 @@ describe('Confluence Proxy / fixTableSize', () => {
     '</th></tr><tr><td><p>Test1</p></td><td><p>Test2</p></td><td><p>Test3</p>'+
     '</td></tr><tr><td><p>Test4</p></td><td><p>Test5</p></td><td><p>Test6</p></td></tr>'+
     '</tbody></table></div><p></p></div></body></html>');
+  });
+
+  it('should not size a nested table (one level deep)', () => {
+    context.setHtmlBody('<html><head></head><body>'+
+    '<div class="table-wrap">'+
+    '<table data-table-width="1500" data-layout="default" class="confluenceTable"><colgroup><col><col></colgroup>'+
+    '<tbody><tr>'+
+    '<td class="confluenceTd"><div class="table-wrap"><table data-table-width="750" class="confluenceTable"><colgroup><col></colgroup>'+
+    '<tbody><tr><td><p>nested</p></td></tr></tbody></table></div></td>'+
+    '<td class="confluenceTd"><p>right</p></td>'+
+    '</tr></tbody></table></div></body></html>');
+    step(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    const outerTable = $('table.confluenceTable').first();
+    const nestedTable = outerTable.find('table.confluenceTable').first();
+
+    // The top-level table is still sized.
+    expect(outerTable.attr('data-konviw-table-size')).toBe('large');
+
+    // The nested table must be left untouched so it can fit its cell.
+    expect(nestedTable.attr('data-konviw-table-size')).toBeUndefined();
+    expect(nestedTable.attr('style')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## WEB-2893: Fix nested table rendering

### Problem
Confluence supports tables nested inside table cells (one level deep). Konviw
did not render them correctly — a nested table overflowed its cell and overlapped
the column on the right. None of the table pipeline steps or CSS were
nesting-aware, so the outer-table logic also leaked into the nested table.

### Root cause
- **CSS**: every `table.confluenceTable` gets `table-layout: fixed`, but a width
  cap was only applied to top-level layout tables. A nested table (which normally
  has no `data-layout`) had no width constraint, so with a pixel `colgroup` it was
  forced to the sum of its column widths and spilled over the adjacent column.
- **Steps** used descendant/unscoped selectors, so they mutated the nested table
  too: `addTableResponsive` leaked the outer `data-column-id`/`data-lign-id` onto
  nested cells and shifted column indexing; `fixTableSize` applied a size/inline
  width to nested tables; `fixColGroupWidth` skipped nested colgroups, leaving
  them in pixels.

### Changes
- `addTableResponsive`: traverse only direct children (`tr`/`th`/`td`) so each
  table labels only its own cells — no leakage into nested tables.
- `fixTableSize`: only size top-level tables (no `table` ancestor); nested tables
  keep their natural size.
- `fixColGroupWidth`: also convert nested tables' `colgroup` widths to `%` so their
  columns are proportional to the parent cell.
- `_tables.scss` + `iadc/_tables.scss`: constrain nested tables to their cell
  (`width/max-width: 100%`) and use `table-layout: auto` so they shrink to fit
  regardless of colgroup units. Removed an `overflow-x` rule that was clipping the
  nested table's right border.

### Testing
- TDD: each step change was driven by a new failing unit test first, then fixed.
  New nested-table specs added to `addResponsiveTable`, `fixTableSize`, and
  `fixColgroupWidth`. Full suite green (163/163), lint clean.
- Live rendering against Confluence could not be exercised in this environment due
  to org restrictions on Confluence API access; the fix was validated with the unit
  tests and a local before/after visual check of the pipeline output + CSS.


Before:
<img width="1443" height="852" alt="image" src="https://github.com/user-attachments/assets/8eec285f-ba99-4afd-a92a-62e596d2ccfe" />

After:
<img width="1456" height="805" alt="image" src="https://github.com/user-attachments/assets/145959c4-57a6-4123-a022-b869003bf744" />

