### PR TITLE
fix(web): WEB-2894 render layouts with more than 3 columns

### DIFF
--- a/src/assets/scss/_content-layout.scss
+++ b/src/assets/scss/_content-layout.scss
@@ -56,6 +56,10 @@
           width: 100%;
           max-width: 100%;
 
+          &[data-layout='center'] {
+            width: auto;
+          }
+
           td.confluenceTd img,
           td.confluenceTd .confluence-embedded-file-wrapper img,
           th.confluenceTh .confluence-embedded-file-wrapper img {

--- a/src/assets/scss/_content-layout.scss
+++ b/src/assets/scss/_content-layout.scss
@@ -29,6 +29,42 @@
         flex-direction: column;
       }
 
+      // Keep every column's content (images, tables, ...) inside its own
+      // column instead of overflowing and overlapping the neighbouring column.
+      // Content is scaled down to fit the column width so the cell never needs
+      // a horizontal scrollbar.
+      > .cell {
+        min-width: 0;
+      }
+
+      .innerCell {
+        .confluence-embedded-file-wrapper {
+          max-width: 100%;
+        }
+
+        img,
+        video {
+          max-width: 100%;
+          height: auto;
+        }
+
+        // Tables must fill - but never exceed - the column. Images inside
+        // table cells keep their natural width by default (see _tables.scss
+        // `max-width: auto`), which would overflow a narrow column and force a
+        // horizontal scrollbar, so we constrain them here as well.
+        table.confluenceTable {
+          width: 100%;
+          max-width: 100%;
+
+          td.confluenceTd img,
+          td.confluenceTd .confluence-embedded-file-wrapper img,
+          th.confluenceTh .confluence-embedded-file-wrapper img {
+            max-width: 100%;
+            height: auto;
+          }
+        }
+      }
+
       // 2 columns layout with smaller in the left
       &.two-left-sidebar {
         grid-template-columns: 30% 70%;
@@ -58,6 +94,26 @@
         grid-template-columns: 25% 50% 25%;
         grid-template-areas: 'sidebars normal sidebars2';
       }
+
+      // 4 equal columns layout
+      &.four-equal {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-template-areas: 'normal normal2 normal3 normal4';
+      }
+
+      // 5 equal columns layout
+      &.five-equal {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        grid-template-areas: 'normal normal2 normal3 normal4 normal5';
+      }
+
+      // The 4 and 5 column layouts are narrow enough to need extra spacing
+      // between columns. Their tracks use `minmax(0, 1fr)` so the gap is taken
+      // into account without overflowing (unlike the percentage based tracks).
+      &.four-equal,
+      &.five-equal {
+        column-gap: 16px;
+      }
     }
   }
 }
@@ -78,6 +134,12 @@
 }
 .normal ~ .normal ~ .normal {
   grid-area: normal3;
+}
+.normal ~ .normal ~ .normal ~ .normal {
+  grid-area: normal4;
+}
+.normal ~ .normal ~ .normal ~ .normal ~ .normal {
+  grid-area: normal5;
 }
 
 .sidebars {

--- a/src/assets/scss/debug.scss
+++ b/src/assets/scss/debug.scss
@@ -31,6 +31,12 @@
     &.three-with-sidebars {
       background-color: rgb(174, 220, 238);
     }
+    &.four-equal {
+      background-color: rgb(196, 181, 253);
+    }
+    &.five-equal {
+      background-color: rgb(245, 194, 231);
+    }
   }
 
   .aside {

--- a/src/assets/scss/iadc/_content-layout.scss
+++ b/src/assets/scss/iadc/_content-layout.scss
@@ -56,6 +56,10 @@
           width: 100%;
           max-width: 100%;
 
+          &[data-layout='center'] {
+            width: auto;
+          }
+
           td.confluenceTd img,
           td.confluenceTd .confluence-embedded-file-wrapper img,
           th.confluenceTh .confluence-embedded-file-wrapper img {

--- a/src/assets/scss/iadc/_content-layout.scss
+++ b/src/assets/scss/iadc/_content-layout.scss
@@ -29,6 +29,42 @@
         flex-direction: column;
       }
 
+      // Keep every column's content (images, tables, ...) inside its own
+      // column instead of overflowing and overlapping the neighbouring column.
+      // Content is scaled down to fit the column width so the cell never needs
+      // a horizontal scrollbar.
+      > .cell {
+        min-width: 0;
+      }
+
+      .innerCell {
+        .confluence-embedded-file-wrapper {
+          max-width: 100%;
+        }
+
+        img,
+        video {
+          max-width: 100%;
+          height: auto;
+        }
+
+        // Tables must fill - but never exceed - the column. Images inside
+        // table cells keep their natural width by default (see _tables.scss
+        // `max-width: auto`), which would overflow a narrow column and force a
+        // horizontal scrollbar, so we constrain them here as well.
+        table.confluenceTable {
+          width: 100%;
+          max-width: 100%;
+
+          td.confluenceTd img,
+          td.confluenceTd .confluence-embedded-file-wrapper img,
+          th.confluenceTh .confluence-embedded-file-wrapper img {
+            max-width: 100%;
+            height: auto;
+          }
+        }
+      }
+
       // 2 columns layout with smaller in the left
       &.two-left-sidebar {
         grid-template-columns: 30% 70%;
@@ -58,6 +94,26 @@
         grid-template-columns: 25% 50% 25%;
         grid-template-areas: 'sidebars normal sidebars2';
       }
+
+      // 4 equal columns layout
+      &.four-equal {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-template-areas: 'normal normal2 normal3 normal4';
+      }
+
+      // 5 equal columns layout
+      &.five-equal {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        grid-template-areas: 'normal normal2 normal3 normal4 normal5';
+      }
+
+      // The 4 and 5 column layouts are narrow enough to need extra spacing
+      // between columns. Their tracks use `minmax(0, 1fr)` so the gap is taken
+      // into account without overflowing (unlike the percentage based tracks).
+      &.four-equal,
+      &.five-equal {
+        column-gap: 16px;
+      }
     }
   }
 }
@@ -78,6 +134,12 @@
 }
 .normal ~ .normal ~ .normal {
   grid-area: normal3;
+}
+.normal ~ .normal ~ .normal ~ .normal {
+  grid-area: normal4;
+}
+.normal ~ .normal ~ .normal ~ .normal ~ .normal {
+  grid-area: normal5;
 }
 
 .sidebars {

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -15,6 +15,7 @@ import fixToc from './steps/fixToc';
 import fixHtmlHead from './steps/fixHtmlHead';
 import fixUserProfile from './steps/fixUserProfile';
 import fixContentWidth from './steps/fixContentWidth';
+import fixMultiColumnLayout from './steps/fixMultiColumnLayout';
 import fixVideo from './steps/fixVideo';
 import fixEmptyLineIncludePage from './steps/fixEmptyLineIncludePage';
 import fixCode from './steps/fixCode';
@@ -114,6 +115,7 @@ export class ProxyPageService {
     await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);
     fixHtmlHead(this.config)(this.context);
     fixContentWidth()(this.context);
+    fixMultiColumnLayout()(this.context);
     fixUserProfile()(this.context);
     fixProfilePicture()(this.context);
     await fixConfluenceSpace(this.config, this.confluence)(this.context);

--- a/src/proxy-page/steps/fixMultiColumnLayout.ts
+++ b/src/proxy-page/steps/fixMultiColumnLayout.ts
@@ -61,6 +61,15 @@ export default (): Step => (context: ContextService): void => {
         }
 
         const $viewLayout = $(viewLayouts[index]);
+
+        // Confluence collapses 4/5 column layouts specifically into a
+        // `three-equal` layout. Other 3-cell layouts (e.g.
+        // `three-with-sidebars`) share the same cell count but a different
+        // structure, so we must never rewrite them.
+        if (!$viewLayout.hasClass('three-equal') || $viewLayout.attr('data-layout') !== 'three-equal') {
+          return;
+        }
+
         const viewCells = $viewLayout.children('.cell').toArray();
 
         // Confluence always collapses the extra columns into exactly 3 cells.

--- a/src/proxy-page/steps/fixMultiColumnLayout.ts
+++ b/src/proxy-page/steps/fixMultiColumnLayout.ts
@@ -1,0 +1,120 @@
+import * as cheerio from 'cheerio';
+import { Logger } from '@nestjs/common';
+import { ContextService } from '../../context/context.service';
+import { Step } from '../proxy-page.step';
+
+/**
+ * ### Proxy page step to fix layouts with more than 3 columns
+ *
+ * Confluence's HTML "view" API (the format konviw renders) does not support
+ * layouts with 4 or 5 columns. It collapses them into a 3-column
+ * `columnLayout three-equal` and concatenates the content of columns 3..N
+ * into the 3rd rendered cell, which makes columns 4 and 5 stack below the
+ * third column (WEB-2894).
+ *
+ * The storage format, however, preserves the real structure via
+ * `<ac:layout-section ac:type="four_equal|five_equal">` with one
+ * `<ac:layout-cell>` per column. This step uses the storage format to rebuild
+ * the missing columns: it splits the merged 3rd cell back into the original
+ * columns (using the per-cell block counts as boundaries) and relabels the
+ * layout so the CSS grid renders them side by side
+ * (see `_content-layout.scss` `.four-equal` / `.five-equal`).
+ *
+ * The transformation is only applied when the storage and view structures line
+ * up exactly (same number of layout sections, and block counts that add up),
+ * so it never corrupts content it cannot confidently reconstruct.
+ *
+ * @returns Step
+ */
+
+// Map the number of columns that Confluence collapses to the layout class that
+// the konviw CSS grid understands. Only 4 and 5 column layouts are collapsed.
+const LAYOUT_CLASS_BY_COLUMN_COUNT: Record<number, string> = {
+  4: 'four-equal',
+  5: 'five-equal',
+};
+
+export default (): Step => (context: ContextService): void => {
+  context.setPerfMark('fixMultiColumnLayout');
+  const logger = new Logger('fixMultiColumnLayout');
+  const storage = context.getBodyStorage();
+
+  if (storage) {
+    const $ = context.getCheerioBody();
+    const $storage = cheerio.load(storage, { xmlMode: true });
+
+    const storageSections = $storage('ac\\:layout-section').toArray();
+    const viewLayouts = $('.columnLayout').toArray();
+
+    // Pair storage sections with rendered layouts by document order. If the two
+    // structures don't match one-to-one (e.g. layouts injected by included
+    // pages) we skip the whole page to avoid misaligned reconstruction.
+    if (storageSections.length > 0 && storageSections.length === viewLayouts.length) {
+      storageSections.forEach((section: cheerio.Element, index: number) => {
+        const storageCells = $storage(section).children('ac\\:layout-cell').toArray();
+        const columnCount = storageCells.length;
+        const targetClass = LAYOUT_CLASS_BY_COLUMN_COUNT[columnCount];
+
+        // Only 4 and 5 column layouts are collapsed by Confluence's view API.
+        if (!targetClass) {
+          return;
+        }
+
+        const $viewLayout = $(viewLayouts[index]);
+        const viewCells = $viewLayout.children('.cell').toArray();
+
+        // Confluence always collapses the extra columns into exactly 3 cells.
+        if (viewCells.length !== 3) {
+          return;
+        }
+
+        // Number of top-level blocks Confluence rendered for each storage cell.
+        // Storage block counts map 1:1 to the rendered blocks in the view.
+        const storageBlockCounts = storageCells.map(
+          (cell: cheerio.Element) => $storage(cell).children().length,
+        );
+
+        const viewInnerCells = viewCells.map((cell: cheerio.Element) =>
+          $(cell).children('.innerCell'));
+        const mergedChildren = viewInnerCells[2].children().toArray();
+        const expectedMergedCount = storageBlockCounts
+          .slice(2)
+          .reduce((sum: number, count: number) => sum + count, 0);
+
+        // Safety: only rebuild when every cell's block count matches what the
+        // storage format describes, so we never split content incorrectly.
+        const firstTwoMatch = viewInnerCells[0].children().length === storageBlockCounts[0]
+          && viewInnerCells[1].children().length === storageBlockCounts[1];
+        if (!firstTwoMatch || mergedChildren.length !== expectedMergedCount) {
+          logger.warn(
+            `Skipping ${targetClass} layout reconstruction: `
+            + 'view and storage block counts do not match',
+          );
+          return;
+        }
+
+        // Rebuild the columns 3..N from the merged 3rd cell by slicing its
+        // children according to the storage block counts.
+        let offset = 0;
+        const rebuiltCells = storageBlockCounts.slice(2).map((count: number) => {
+          const innerHtml = mergedChildren
+            .slice(offset, offset + count)
+            .map((element: cheerio.Element) => $.html(element))
+            .join('');
+          offset += count;
+          return `<div class="cell normal" data-type="normal"><div class="innerCell">${innerHtml}</div></div>`;
+        });
+
+        $(viewCells[2]).replaceWith(rebuiltCells.join(''));
+        $viewLayout
+          .removeClass('three-equal')
+          .addClass(targetClass)
+          .attr('data-layout', targetClass);
+
+        logger.log(`Rebuilt a ${columnCount}-column layout collapsed by Confluence into 3 columns`);
+      });
+    }
+  }
+
+  context.getPerfMeasure('fixMultiColumnLayout');
+};

--- a/tests/unit/steps/fixMultiColumnLayout.spec.ts
+++ b/tests/unit/steps/fixMultiColumnLayout.spec.ts
@@ -238,6 +238,47 @@ describe('ConfluenceProxy / fixMultiColumnLayout', () => {
     expect(cellTexts).toEqual(['C1', 'C2', 'C3', 'C4']);
   });
 
+  it('leaves other 3-cell layouts (e.g. three-with-sidebars) untouched', () => {
+    // A `three-with-sidebars` layout also renders 3 cells, but it is NOT the
+    // collapsed form of a 4/5-column layout. Even if the storage section has
+    // 4 cells, the step must not rewrite a layout that is not `three-equal`.
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(
+      '<div class="contentLayout2">'
+      + viewLayout('three-with-sidebars', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p><p>C4</p>'])
+      + '</div>',
+    );
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('three-with-sidebars')).toBe(true);
+    expect($('.columnLayout').hasClass('four-equal')).toBe(false);
+    expect($('.columnLayout > .cell').length).toBe(3);
+  });
+
+  it('does not modify a three-equal layout that does not have exactly 3 cells', () => {
+    // Defensive guard: even a `three-equal` layout is only rebuilt when it has
+    // the expected 3 collapsed cells. An unexpected cell count is left as-is.
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(
+      '<div class="contentLayout2">'
+      + viewLayout('three-equal', ['<p>C1</p>', '<p>C2</p>'])
+      + '</div>',
+    );
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('three-equal')).toBe(true);
+    expect($('.columnLayout').hasClass('four-equal')).toBe(false);
+    expect($('.columnLayout > .cell').length).toBe(2);
+  });
+
   it('rebuilt columns keep the expected cell / innerCell structure', () => {
     context.setBodyStorage(
       layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),

--- a/tests/unit/steps/fixMultiColumnLayout.spec.ts
+++ b/tests/unit/steps/fixMultiColumnLayout.spec.ts
@@ -1,0 +1,261 @@
+import * as cheerio from 'cheerio';
+import { ContextService } from '../../../src/context/context.service';
+import fixMultiColumnLayout from '../../../src/proxy-page/steps/fixMultiColumnLayout';
+import { createModuleRefForStep } from './utils';
+
+// Confluence's HTML "view" API collapses 4/5 column layouts into a 3-column
+// `three-equal`, merging the content of columns 3..N into the 3rd cell. These
+// tests feed the collapsed view HTML plus the matching storage format and check
+// that fixMultiColumnLayout rebuilds the original columns.
+
+const layoutView = (thirdCellInner: string): string =>
+  '<div class="contentLayout2">'
+  + '<div class="columnLayout three-equal" data-layout="three-equal">'
+  + '<div class="cell normal" data-type="normal"><div class="innerCell"><p>C1</p></div></div>'
+  + '<div class="cell normal" data-type="normal"><div class="innerCell"><p>C2</p></div></div>'
+  + `<div class="cell normal" data-type="normal"><div class="innerCell">${thirdCellInner}</div></div>`
+  + '</div>'
+  + '</div>';
+
+const layoutStorage = (type: string, cells: string[]): string =>
+  `<ac:layout><ac:layout-section ac:type="${type}">`
+  + cells.map((cell) => `<ac:layout-cell>${cell}</ac:layout-cell>`).join('')
+  + '</ac:layout-section></ac:layout>';
+
+// Composable builders for pages that contain several layout sections.
+const viewCell = (inner: string): string =>
+  `<div class="cell normal" data-type="normal"><div class="innerCell">${inner}</div></div>`;
+
+const viewLayout = (layoutClass: string, cellInners: string[]): string =>
+  `<div class="columnLayout ${layoutClass}" data-layout="${layoutClass}">`
+  + cellInners.map(viewCell).join('')
+  + '</div>';
+
+const storageSection = (type: string, cells: string[]): string =>
+  `<ac:layout-section ac:type="${type}">`
+  + cells.map((cell) => `<ac:layout-cell>${cell}</ac:layout-cell>`).join('')
+  + '</ac:layout-section>';
+
+describe('ConfluenceProxy / fixMultiColumnLayout', () => {
+  let context: ContextService;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'XXX', '123456', 'dark');
+  });
+
+  const countCells = (): number => {
+    const $ = cheerio.load(context.getHtmlBody());
+    return $('.columnLayout > .cell').length;
+  };
+
+  it('rebuilds a four-column layout collapsed into three columns', () => {
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(layoutView('<p>C3</p><p>C4</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('four-equal')).toBe(true);
+    expect($('.columnLayout').hasClass('three-equal')).toBe(false);
+    expect($('.columnLayout').attr('data-layout')).toBe('four-equal');
+    expect($('.columnLayout > .cell').length).toBe(4);
+    // Each column ends up isolated in its own cell, in order and without loss.
+    const cellTexts = $('.columnLayout > .cell').map((_i, el) => $(el).text()).get();
+    expect(cellTexts).toEqual(['C1', 'C2', 'C3', 'C4']);
+  });
+
+  it('rebuilds a five-column layout collapsed into three columns', () => {
+    context.setBodyStorage(
+      layoutStorage('five_equal', [
+        '<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>', '<p>C5</p>',
+      ]),
+    );
+    context.setHtmlBody(layoutView('<p>C3</p><p>C4</p><p>C5</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('five-equal')).toBe(true);
+    expect($('.columnLayout').attr('data-layout')).toBe('five-equal');
+    expect($('.columnLayout > .cell').length).toBe(5);
+    const cellTexts = $('.columnLayout > .cell').map((_i, el) => $(el).text()).get();
+    expect(cellTexts).toEqual(['C1', 'C2', 'C3', 'C4', 'C5']);
+  });
+
+  it('preserves multi-block columns using the storage block counts as boundaries', () => {
+    // Column 3 has two blocks (a heading + a table) and column 4 has two blocks.
+    context.setBodyStorage(
+      layoutStorage('four_equal', [
+        '<p>C1</p>',
+        '<p>C2</p>',
+        '<h3>Third</h3><table><tbody><tr><td>t</td></tr></tbody></table>',
+        '<h3>Fourth</h3><p>C4</p>',
+      ]),
+    );
+    context.setHtmlBody(
+      layoutView(
+        '<h3>Third</h3><div class="table-wrap"><table><tbody><tr><td>t</td></tr></tbody></table></div>'
+        + '<h3>Fourth</h3><p>C4</p>',
+      ),
+    );
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout > .cell').length).toBe(4);
+    const thirdCell = $('.columnLayout > .cell').eq(2);
+    const fourthCell = $('.columnLayout > .cell').eq(3);
+    expect(thirdCell.find('h3').text()).toBe('Third');
+    expect(thirdCell.find('table').length).toBe(1);
+    expect(fourthCell.find('h3').text()).toBe('Fourth');
+    expect(fourthCell.find('table').length).toBe(0);
+  });
+
+  it('leaves a genuine three-column layout untouched', () => {
+    context.setBodyStorage(
+      layoutStorage('three_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>']),
+    );
+    context.setHtmlBody(layoutView('<p>C3</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('three-equal')).toBe(true);
+    expect($('.columnLayout > .cell').length).toBe(3);
+  });
+
+  it('does not modify the layout when block counts do not match (safety)', () => {
+    // Storage says column 3 has 1 block and column 4 has 1 block (merged = 2),
+    // but the view's merged cell only has 1 block. The counts disagree so the
+    // step must leave the content untouched to avoid corrupting it.
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(layoutView('<p>C3 only</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    expect(countCells()).toBe(3);
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').hasClass('four-equal')).toBe(false);
+    expect($('.columnLayout').hasClass('three-equal')).toBe(true);
+  });
+
+  it('does nothing when there is no storage format available', () => {
+    context.setBodyStorage('');
+    context.setHtmlBody(layoutView('<p>C3</p><p>C4</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    expect(countCells()).toBe(3);
+  });
+
+  it('rebuilds several collapsed layouts on the same page, paired by document order', () => {
+    // A single-column section, then a 4-column and a 5-column section, all of
+    // which Confluence renders one after another. The step must pair each
+    // rendered layout with the matching storage section by order.
+    context.setBodyStorage(
+      '<ac:layout>'
+      + storageSection('fixed-width', ['<p>F</p>'])
+      + storageSection('four_equal', ['<p>A1</p>', '<p>A2</p>', '<p>A3</p>', '<p>A4</p>'])
+      + storageSection('five_equal', [
+        '<p>B1</p>', '<p>B2</p>', '<p>B3</p>', '<p>B4</p>', '<p>B5</p>',
+      ])
+      + '</ac:layout>',
+    );
+    context.setHtmlBody(
+      '<div class="contentLayout2">'
+      + viewLayout('fixed-width', ['<p>F</p>'])
+      + viewLayout('three-equal', ['<p>A1</p>', '<p>A2</p>', '<p>A3</p><p>A4</p>'])
+      + viewLayout('three-equal', ['<p>B1</p>', '<p>B2</p>', '<p>B3</p><p>B4</p><p>B5</p>'])
+      + '</div>',
+    );
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    const layouts = $('.columnLayout');
+    expect(layouts.length).toBe(3);
+    // The fixed-width single column section stays untouched.
+    expect(layouts.eq(0).hasClass('fixed-width')).toBe(true);
+    expect(layouts.eq(0).children('.cell').length).toBe(1);
+    // The 4 and 5 column sections are rebuilt in place.
+    expect(layouts.eq(1).hasClass('four-equal')).toBe(true);
+    expect(layouts.eq(1).children('.cell').length).toBe(4);
+    expect(
+      layouts.eq(1).children('.cell').map((_i, el) => $(el).text()).get(),
+    ).toEqual(['A1', 'A2', 'A3', 'A4']);
+    expect(layouts.eq(2).hasClass('five-equal')).toBe(true);
+    expect(layouts.eq(2).children('.cell').length).toBe(5);
+    expect(
+      layouts.eq(2).children('.cell').map((_i, el) => $(el).text()).get(),
+    ).toEqual(['B1', 'B2', 'B3', 'B4', 'B5']);
+  });
+
+  it('does not modify anything when section counts differ between storage and view', () => {
+    // Storage describes a single 4-column section, but the rendered body has an
+    // extra columnLayout (e.g. injected by an included page). Since the two
+    // structures cannot be aligned one-to-one, the step leaves everything as-is.
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(
+      '<div class="contentLayout2">'
+      + viewLayout('three-equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p><p>C4</p>'])
+      + viewLayout('two-equal', ['<p>X1</p>', '<p>X2</p>'])
+      + '</div>',
+    );
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    expect($('.columnLayout').eq(0).hasClass('four-equal')).toBe(false);
+    expect($('.columnLayout').eq(0).hasClass('three-equal')).toBe(true);
+    expect($('.columnLayout').eq(0).children('.cell').length).toBe(3);
+  });
+
+  it('leaves the layout untouched when the rendered form is not the collapsed 3-cell shape', () => {
+    // Storage describes 4 columns and the rendered layout already has 4 cells
+    // (not Confluence's collapsed 3-cell form), so there is nothing to rebuild.
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(
+      '<div class="contentLayout2">'
+      + viewLayout('four-equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>'])
+      + '</div>',
+    );
+
+    fixMultiColumnLayout()(context);
+
+    expect(countCells()).toBe(4);
+    const $ = cheerio.load(context.getHtmlBody());
+    const cellTexts = $('.columnLayout > .cell').map((_i, el) => $(el).text()).get();
+    expect(cellTexts).toEqual(['C1', 'C2', 'C3', 'C4']);
+  });
+
+  it('rebuilt columns keep the expected cell / innerCell structure', () => {
+    context.setBodyStorage(
+      layoutStorage('four_equal', ['<p>C1</p>', '<p>C2</p>', '<p>C3</p>', '<p>C4</p>']),
+    );
+    context.setHtmlBody(layoutView('<p>C3</p><p>C4</p>'));
+
+    fixMultiColumnLayout()(context);
+
+    const $ = cheerio.load(context.getHtmlBody());
+    const cells = $('.columnLayout > .cell');
+    expect(cells.length).toBe(4);
+    cells.each((_i, el) => {
+      const cell = $(el);
+      expect(cell.hasClass('cell')).toBe(true);
+      expect(cell.hasClass('normal')).toBe(true);
+      expect(cell.attr('data-type')).toBe('normal');
+      // Each cell wraps its content in a single innerCell div.
+      expect(cell.children('.innerCell').length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Confluence's HTML **view** API (the format konviw renders) does not support layouts with 4 or 5 columns. It collapses them into a 3-column `columnLayout three-equal` and concatenates the content of columns 3..N into the 3rd rendered cell, so columns 4 and 5 stack **below** column 3 instead of rendering side by side (WEB-2894).

This PR fixes the rendering in two complementary parts:

- **New proxy step `fixMultiColumnLayout`** — uses the Confluence **storage** format (which preserves the true structure via `<ac:layout-section ac:type="four_equal|five_equal">`) to rebuild the missing columns. It splits the merged 3rd cell back into the original columns using the per-cell block counts as boundaries, then relabels the layout (`four-equal` / `five-equal`). The transform only runs when storage and view line up exactly (same number of sections, matching block counts), so it never corrupts content it cannot confidently reconstruct. Registered after `fixContentWidth` in the render pipeline.
- **CSS grid rules** for `.four-equal` / `.five-equal` (`repeat(N, minmax(0, 1fr))` + `column-gap`) plus content-constraining rules on `.columnLayout > .cell` / `.innerCell` so images, videos and tables scale down to fit their column and never force a horizontal scrollbar. Applied to both the default and `iadc` themes, with matching debug-mode background colors.

### Screenshots

1. Four Layout
<img width="1352" height="683" alt="Screenshot 2026-07-13 at 3 35 34 PM" src="https://github.com/user-attachments/assets/827584b0-30d8-4839-8663-83a7f66082f6" />

2. Five Layout
<img width="1341" height="796" alt="Screenshot 2026-07-13 at 3 35 41 PM" src="https://github.com/user-attachments/assets/bbd263bc-f7e3-4c9d-a342-7019842ba836" />


## Test plan

- [x] `npm run test:unit:cov` — 170/170 pass; `fixMultiColumnLayout.ts` at 100% coverage (10 dedicated tests)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds (JS + compiled SCSS artifacts produced)
- [x] `npm run test:e2e` — the 2 failing suites (`proxy-api` 404s from Confluence, `health` `jest.useFakeTimers('legacy')` TS error) are pre-existing/environmental; verified they fail identically on the clean base with these changes stashed
- [x] Manually verified against the WEB-2894 demo page in a local dev server: 4- and 5-column layouts render side by side with content contained inside each column