### PR TITLE
Web 2475 xray snapshot columns

### DIFF
--- a/src/assets/scss/_macro-jira.scss
+++ b/src/assets/scss/_macro-jira.scss
@@ -4,6 +4,42 @@
   font-size: 16px;
 }
 
+// Size the Jira snapshot grid columns to their content so the full column
+// headings are visible instead of being clipped with an ellipsis. Grid.js
+// defaults to `table-layout: fixed` + `max-width: 100%`, which squeezes every
+// column into the container width; switching to auto layout lets each column
+// grow to fit its heading/content while the wrapper (`overflow: auto`) keeps
+// the horizontal scrolling when the table is wider than its container.
+.gridjs-wrapper {
+  table.gridjs-table {
+    table-layout: auto;
+    max-width: none;
+  }
+
+  .gridjs-th {
+    white-space: nowrap;
+
+    // Keep the heading label and the sort arrow on the same line (arrow right
+    // after the name). Grid.js floats the content left and the sort button
+    // right, which drops the arrow below the label once columns are auto-sized.
+    .gridjs-th-content {
+      float: none;
+      display: inline-block;
+      vertical-align: middle;
+      width: auto;
+      overflow: visible;
+      text-overflow: clip;
+    }
+
+    .gridjs-sort {
+      float: none;
+      display: inline-block;
+      vertical-align: middle;
+      margin-left: 4px;
+    }
+  }
+}
+
 
 // Table Jira chart Report ===================================
 

--- a/src/assets/scss/_macro-jira.scss
+++ b/src/assets/scss/_macro-jira.scss
@@ -4,6 +4,53 @@
   font-size: 16px;
 }
 
+// Inline thumbnails for Xray Test Run evidence images in the snapshot grid.
+img.xray-evidence-thumb {
+  max-height: 64px;
+  max-width: 120px;
+  margin: 2px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  object-fit: cover;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+// Lightbox modal shown when an evidence thumbnail is clicked.
+.xray-evidence-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+
+  &.is-open {
+    display: flex;
+  }
+
+  .xray-evidence-modal-img {
+    max-width: 80vw;
+    max-height: 80vh;
+    object-fit: contain;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .xray-evidence-modal-close {
+    position: absolute;
+    top: 20px;
+    right: 32px;
+    color: #fff;
+    font-size: 40px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+}
+
 // Size the Jira snapshot grid columns to their content so the full column
 // headings are visible instead of being clipped with an ellipsis. Grid.js
 // defaults to `table-layout: fixed` + `max-width: 100%`, which squeezes every

--- a/src/assets/scss/iadc/_macro-jira.scss
+++ b/src/assets/scss/iadc/_macro-jira.scss
@@ -4,6 +4,42 @@
   font-size: 16px;
 }
 
+// Size the Jira snapshot grid columns to their content so the full column
+// headings are visible instead of being clipped with an ellipsis. Grid.js
+// defaults to `table-layout: fixed` + `max-width: 100%`, which squeezes every
+// column into the container width; switching to auto layout lets each column
+// grow to fit its heading/content while the wrapper (`overflow: auto`) keeps
+// the horizontal scrolling when the table is wider than its container.
+.gridjs-wrapper {
+  table.gridjs-table {
+    table-layout: auto;
+    max-width: none;
+  }
+
+  .gridjs-th {
+    white-space: nowrap;
+
+    // Keep the heading label and the sort arrow on the same line (arrow right
+    // after the name). Grid.js floats the content left and the sort button
+    // right, which drops the arrow below the label once columns are auto-sized.
+    .gridjs-th-content {
+      float: none;
+      display: inline-block;
+      vertical-align: middle;
+      width: auto;
+      overflow: visible;
+      text-overflow: clip;
+    }
+
+    .gridjs-sort {
+      float: none;
+      display: inline-block;
+      vertical-align: middle;
+      margin-left: 4px;
+    }
+  }
+}
+
 
 // Table Jira chart Report ===================================
 

--- a/src/assets/scss/iadc/_macro-jira.scss
+++ b/src/assets/scss/iadc/_macro-jira.scss
@@ -4,6 +4,53 @@
   font-size: 16px;
 }
 
+// Inline thumbnails for Xray Test Run evidence images in the snapshot grid.
+img.xray-evidence-thumb {
+  max-height: 64px;
+  max-width: 120px;
+  margin: 2px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  object-fit: cover;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+// Lightbox modal shown when an evidence thumbnail is clicked.
+.xray-evidence-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+
+  &.is-open {
+    display: flex;
+  }
+
+  .xray-evidence-modal-img {
+    max-width: 80vw;
+    max-height: 80vh;
+    object-fit: contain;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .xray-evidence-modal-close {
+    position: absolute;
+    top: 20px;
+    right: 32px;
+    color: #fff;
+    font-size: 40px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+}
+
 // Size the Jira snapshot grid columns to their content so the full column
 // headings are visible instead of being clipped with an ellipsis. Grid.js
 // defaults to `table-layout: fixed` + `max-width: 100%`, which squeezes every

--- a/src/jira/jira.service.ts
+++ b/src/jira/jira.service.ts
@@ -518,6 +518,67 @@ export class JiraService {
   }
 
   /**
+   * @function getUsersByAccountIds Service
+   * @description Resolves a set of Atlassian account ids to their user details
+   * (mainly the display name). Used to turn the raw account ids returned by the
+   * Xray API (e.g. the Test Run executor / assignee) into human-readable names.
+   * Fails gracefully by returning an empty map so a rendering step never breaks
+   * because a user could not be resolved.
+   * @param accountIds {string[]} the Atlassian account ids to resolve
+   * @return Promise {Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }>}
+   */
+  async getUsersByAccountIds(
+    accountIds: string[],
+  ): Promise<Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }>> {
+    this.init();
+    const uniqueIds = Array.from(new Set((accountIds ?? []).filter(Boolean)));
+    const usersById: Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }> = {};
+    if (uniqueIds.length === 0) {
+      return usersById;
+    }
+    // The bulk endpoint accepts up to 200 accountId params per request.
+    const chunkSize = 200;
+    const chunks: string[][] = [];
+    for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+      chunks.push(uniqueIds.slice(i, i + chunkSize));
+    }
+    try {
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          const params = new URLSearchParams();
+          params.set('maxResults', String(chunkSize));
+          chunk.forEach((id) => params.append('accountId', id));
+          const response = await firstValueFrom(
+            this.http.get(`${this.baseUrl}/rest/api/3/user/bulk?${params.toString()}`, {
+              auth: { username: this.apiUsername, password: this.apiToken },
+            }),
+          );
+          (response.data?.values ?? []).forEach((user) => {
+            if (user?.accountId) {
+              usersById[user.accountId] = {
+                accountId: user.accountId,
+                displayName: user.displayName ?? '',
+                emailAddress: user.emailAddress ?? '',
+                self: user.self ?? '',
+              };
+            }
+          });
+        }),
+      );
+      this.logger.log(`Resolved ${Object.keys(usersById).length}/${uniqueIds.length} Jira users by account id`);
+    } catch (error) {
+      this.logger.error({
+        msg: 'HTTP request error in getUsersByAccountIds',
+        message: error.message,
+        response: error.response
+          ? { status: error.response.status, data: error.response.data }
+          : undefined,
+      });
+    }
+    return usersById;
+  }
+
+  /**
    * @function findProjectVersions Service
    * @description Returns the list of project versions.
    * @return Promise {any}

--- a/src/proxy-api/proxy-api.controller.ts
+++ b/src/proxy-api/proxy-api.controller.ts
@@ -1,7 +1,8 @@
 import {
-  Controller, Get, Logger, Param, Query, Version,
+  Controller, Get, Logger, Param, Query, Res, Version,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express'; // eslint-disable-line import/no-extraneous-dependencies
 import {
   PageParamsDTO,
   PageQueryDTO,
@@ -322,5 +323,25 @@ export class ProxyApiController {
     const du = await this.proxyApi.getAttachmentDownloadUrl(uri);
     this.logger.debug(`Attachment download URL: ${du}`);
     return du;
+  }
+
+  /**
+   * @GET (controller) api/xray/attachments/:id
+   * @description Proxies an Xray Test Run evidence/attachment so it can be
+   * opened from the browser. Xray attachment URLs require a bearer token that a
+   * browser click cannot supply, so konviw fetches the bytes server-side and
+   * streams them back with the original content type.
+   * @param {string} id - The Xray attachment (evidence) id.
+   */
+  @ApiOkResponse({ description: 'Download an Xray evidence attachment' })
+  @Get('xray/attachments/:id')
+  async getXrayAttachment(
+    @Param('id') id: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { data, contentType } = await this.proxyApi.getXrayAttachment(id);
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    res.send(data);
   }
 }

--- a/src/proxy-api/proxy-api.module.ts
+++ b/src/proxy-api/proxy-api.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { JiraModule } from '../jira/jira.module';
 import { HttpModule } from '../http/http.module';
 import { ConfluenceModule } from '../confluence/confluence.module';
+import { XrayModule } from '../xray/xray.module';
 import { ContextService } from '../context/context.service';
 import { ProxyApiService } from './proxy-api.service';
 import { ProxyApiController } from './proxy-api.controller';
 
 @Module({
-  imports: [ConfluenceModule, JiraModule, HttpModule],
+  imports: [ConfluenceModule, JiraModule, HttpModule, XrayModule],
   providers: [ProxyApiService, ContextService],
   controllers: [ProxyApiController],
   exports: [],

--- a/src/proxy-api/proxy-api.service.ts
+++ b/src/proxy-api/proxy-api.service.ts
@@ -9,6 +9,7 @@ import {
 } from '../confluence/confluence.interface';
 import { ConfluenceService } from '../confluence/confluence.service';
 import { JiraService } from '../jira/jira.service';
+import { XrayService } from '../xray/xray.service';
 import getExcerptAndHeaderImage from './steps/getExcerptAndHeaderImage';
 import fixContentWidth from '../proxy-page/steps/fixContentWidth';
 import fixLinks from '../proxy-page/steps/fixLinks';
@@ -43,6 +44,7 @@ export class ProxyApiService {
     private jira: JiraService,
     private context: ContextService,
     private readonly http: HttpService,
+    private readonly xray: XrayService,
   ) {}
 
   /**
@@ -547,6 +549,18 @@ export class ProxyApiService {
   async getAttachmentDownloadUrl(uri: string): Promise<string> {
     const downloadUrl = await this.confluence.getRedirectUrlForMedia(uri);
     return downloadUrl;
+  }
+
+  /**
+   * @function getXrayAttachment
+   * @description Downloads an Xray Test Run evidence/attachment by its id so it
+   * can be proxied to the browser. Xray attachment URLs require a bearer token
+   * that a browser click cannot provide, hence the server-side proxy.
+   * @param id {string} The Xray attachment (evidence) id.
+   * @return Promise {{ data: Buffer; contentType: string }}
+   */
+  async getXrayAttachment(id: string): Promise<{ data: Buffer; contentType: string }> {
+    return this.xray.getAttachment(id);
   }
 
   /**

--- a/src/proxy-page/dto/FieldInterface.ts
+++ b/src/proxy-page/dto/FieldInterface.ts
@@ -386,6 +386,15 @@ export const formatWebLink = (value: any) =>
     string,
   ];
 
+// Same passthrough shape as `formatWebLink` but rendered through the dedicated
+// `evidences` grid column, which shows image attachments as inline thumbnails
+// (and falls back to a plain link for non-image files).
+export const formatEvidences = (value: any) =>
+  [Array.isArray(value) ? value.filter((item) => item && item.link) : [], 'evidences'] as [
+    { name: string; link: string }[],
+    string,
+  ];
+
 export const fieldFunctions: {
   [key: string]: (value: any, baseUrl?: string) => any;
 } = {
@@ -407,4 +416,5 @@ export const fieldFunctions: {
     formatIssueLinks(value, baseUrl),
   json: formatJson,
   weblink: formatWebLink,
+  evidences: formatEvidences,
 };

--- a/src/proxy-page/dto/FieldInterface.ts
+++ b/src/proxy-page/dto/FieldInterface.ts
@@ -376,6 +376,16 @@ export const createLinkObject = (key, baseUrl, name = '') => ({
   link: key ? `${baseUrl}/browse/${key}?src=confmacro` : '',
 });
 
+// Passthrough formatter for pre-built web links. Unlike `issuelinks`, the value
+// is already an array of `{ name, link }` objects (with absolute URLs), so it is
+// rendered as-is through the `link` grid column. Used for Xray columns that
+// point to arbitrary URLs (e.g. evidences, link to the Test Run's execution).
+export const formatWebLink = (value: any) =>
+  [Array.isArray(value) ? value.filter((item) => item && item.link) : [], 'link'] as [
+    { name: string; link: string }[],
+    string,
+  ];
+
 export const fieldFunctions: {
   [key: string]: (value: any, baseUrl?: string) => any;
 } = {
@@ -396,4 +406,5 @@ export const fieldFunctions: {
   issuelinks: (value: any, baseUrl?: string) =>
     formatIssueLinks(value, baseUrl),
   json: formatJson,
+  weblink: formatWebLink,
 };

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -32,7 +32,7 @@ const XRAY_TESTRUN_FIELDS = [
   { id: 'comment', name: 'Comment', schema: { type: 'string' } },
   { id: 'gherkin', name: 'Gherkin', schema: { type: 'string' } },
   { id: 'unstructured', name: 'Definition', schema: { type: 'string' } },
-  { id: 'evidences', name: 'Evidences', schema: { type: 'weblink' } },
+  { id: 'evidences', name: 'Evidences', schema: { type: 'evidences' } },
 ];
 
 export default (
@@ -65,6 +65,51 @@ export default (
   $('div[data-macro-name="jira-jql-snapshot"]').each((i, element) => {
     jiraJqlSnapshots.push($(element));
   });
+
+  // Lightbox for Xray evidence images: clicking a thumbnail opens the full
+  // image in a centered modal (80% of the viewport) instead of navigating away
+  // or downloading it. Added once per page and driven by a delegated listener
+  // since the grid (and its thumbnails) are rendered client-side by Grid.js.
+  if (jiraJqlSnapshots.length > 0) {
+    // The modal image is created client-side (not in the server HTML) so that
+    // earlier link/image steps (e.g. fixLinks, which hides <img> tags that have
+    // an empty src) cannot tamper with it before we set its src on click.
+    $('body').append(
+      '<div id="xray-evidence-modal" class="xray-evidence-modal">'
+      + '<span class="xray-evidence-modal-close" aria-label="Close">&times;</span>'
+      + '</div>',
+    );
+    $('body').append(`<script defer>
+      document.addEventListener('DOMContentLoaded', function () {
+        var modal = document.getElementById('xray-evidence-modal');
+        if (!modal) { return; }
+        var modalImg = document.createElement('img');
+        modalImg.className = 'xray-evidence-modal-img';
+        modal.appendChild(modalImg);
+        var open = function (src, alt) {
+          modalImg.setAttribute('src', src);
+          modalImg.setAttribute('alt', alt || '');
+          modal.classList.add('is-open');
+        };
+        var close = function () {
+          modal.classList.remove('is-open');
+          modalImg.setAttribute('src', '');
+        };
+        document.addEventListener('click', function (e) {
+          var target = e.target;
+          if (target && target.classList && target.classList.contains('xray-evidence-thumb')) {
+            e.preventDefault();
+            open(target.currentSrc || target.src, target.getAttribute('alt'));
+          } else if (target === modal || (target.classList && target.classList.contains('xray-evidence-modal-close'))) {
+            close();
+          }
+        });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') { close(); }
+        });
+      });
+    </script>`);
+  }
 
   const macroParamsList = [];
   $xml('ac\\:parameter[ac\\:name="macroParams"]').each((i, element) => {
@@ -132,7 +177,7 @@ export default (
           jiraIssues.push({
             issues: {
               issues: Promise.resolve(
-                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain, usersById),
+                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain, usersById, basePath),
               ),
             },
           });
@@ -337,6 +382,7 @@ function mapTestRunsToIssues(
   testKeyFallback: string,
   baseUrl: string,
   usersById: Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }> = {},
+  webBasePath = '',
 ) {
   // Builds the `user`-typed data (an array of User objects) expected by
   // formatUser. Falls back to showing the raw account id when the user could
@@ -409,9 +455,14 @@ function mapTestRunsToIssues(
         comment: run?.comment ?? '',
         gherkin: run?.gherkin ?? '',
         unstructured: run?.unstructured ?? '',
+        // Xray attachment URLs (`evidence.downloadLink`) require a bearer token
+        // and are not browsable directly, so we point at konviw's proxy route
+        // (`/api/xray/attachments/:id`) which fetches the bytes server-side.
         evidences: (run?.evidence ?? []).map((evidence) => ({
           name: evidence?.filename ?? evidence?.id ?? 'evidence',
-          link: evidence?.downloadLink ?? '',
+          link: evidence?.id
+            ? `${webBasePath}/api/xray/attachments/${evidence.id}`
+            : (evidence?.downloadLink ?? ''),
         })),
       },
     };

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -393,9 +393,9 @@ function mapTestRunsToIssues(
     }
     const user = usersById?.[accountId];
     return [{
-      self: user?.self ?? '',
+      self: '',
       accountId,
-      emailAddress: user?.emailAddress ?? '',
+      emailAddress: '',
       displayName: user?.displayName || accountId,
     }];
   };

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -120,6 +120,7 @@ export default (
         // Xray returns account ids for the executor / assignee; resolve them to
         // display names in a single batched call so the grid shows user names.
         const accountIds = filteredRuns.flatMap((run) => [run?.executedById, run?.assigneeId]);
+        // eslint-disable-next-line no-await-in-loop
         const usersById = await jiraService
           .getUsersByAccountIds(accountIds)
           .catch(() => ({}));
@@ -166,7 +167,15 @@ export default (
     const duplicatedIssue = hierarchiedIssues.flatMap((issue) => traverseIssues(issue));
 
     // Then based on the duplicate value we will build the row format for gridjs
-    const gridData = extractKeysColumns(duplicatedIssue, jqlParams.allColumnsId, jqlParams.levelType, jiraFields, xrayJiraFields, fieldFunctions, confluenceDomain);
+    const gridData = extractKeysColumns(
+      duplicatedIssue,
+      jqlParams.allColumnsId,
+      jqlParams.levelType,
+      jiraFields,
+      xrayJiraFields,
+      fieldFunctions,
+      confluenceDomain,
+    );
     const preparedData = gridData.map((obj) => Object.values(obj));
     const gridjsColumns = createHeaderGridColumns(jqlParams, jiraFields, xrayJiraFields, columnConfig, fieldFunctions, confluenceDomain);
     // Implementation of the gridjs table

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -115,7 +115,10 @@ export default (
           // eslint-disable-next-line no-await-in-loop
           runs = await xrayService.getTestRunsByTestIds(testIds).catch(() => []);
         }
-        const filteredRuns = filterTestRunsByFixVersion(runs, jqlParams.jqls[i]);
+        const filteredRuns = filterTestRunsByEnvironment(
+          filterTestRunsByFixVersion(runs, jqlParams.jqls[i]),
+          jqlParams.jqls[i],
+        );
         const runsByTest = groupTestRunsByTest(filteredRuns);
         // Xray returns account ids for the executor / assignee; resolve them to
         // display names in a single batched call so the grid shows user names.
@@ -309,6 +312,22 @@ function filterTestRunsByFixVersion(runs: XrayTestRun[], levelJql: string): Xray
   });
 }
 
+// Best-effort restriction of the runs to a test environment, parsed from the
+// XRAY level query (e.g. `environments = Test`). Test environments live on the
+// Test Execution in Xray. When no environment can be parsed, all runs are
+// returned unchanged.
+function filterTestRunsByEnvironment(runs: XrayTestRun[], levelJql: string): XrayTestRun[] {
+  const match = (levelJql ?? '').match(/(?:test)?environments?\s*=\s*"?([^"\n]+?)"?\s*(?:and|$)/i);
+  const wanted = match?.[1]?.trim();
+  if (!wanted) {
+    return runs ?? [];
+  }
+  return (runs ?? []).filter((run) => {
+    const environments = run?.testExecution?.testEnvironments ?? [];
+    return environments.includes(wanted);
+  });
+}
+
 // Maps Xray Test Runs into the issue-like shape expected by the grid pipeline,
 // keyed by the macro's XRAY column ids (see XRAY_TESTRUN_FIELDS) so they render
 // through the same fieldFunctions / columnConfig as Jira issues. All supported
@@ -419,10 +438,22 @@ function buildChildren(data: any[][][], level: number, parentIndex: number): Iss
     return children;
   }
 
-  data[level][parentIndex].forEach((childItem: any, index: number) => {
+  const siblingGroups = data[level] ?? [];
+  const group = siblingGroups[parentIndex] ?? [];
+  // The next level's groups are indexed by the *global* (flattened) position of
+  // their parent within this level, whereas `forEach` only gives us the index
+  // local to the current parent group. We therefore add the number of items in
+  // all preceding sibling groups so children resolve to the correct group
+  // instead of always the first one (which broke snapshots with 2+ parents).
+  let globalOffset = 0;
+  for (let i = 0; i < parentIndex; i += 1) {
+    globalOffset += (siblingGroups[i]?.length ?? 0);
+  }
+
+  group.forEach((childItem: any, index: number) => {
     const childNode = {
       item: childItem,
-      children: buildChildren(data, level + 1, index),
+      children: buildChildren(data, level + 1, globalOffset + index),
     };
     children.push(childNode);
   });

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -15,14 +15,24 @@ import * as jiraGrid from '../utils/jiraGrid';
 // is a real Jira field and already resolves through getFields().
 const XRAY_TESTRUN_FIELDS = [
   { id: 'testexeckey', name: 'Test Execution Key', schema: { type: 'issuelinks' } },
+  { id: 'testexecsummary', name: 'Test Execution Summary', schema: { type: 'string' } },
+  { id: 'testexecstatus', name: 'Test Execution Status', schema: { type: 'status' } },
   { id: 'fixversions', name: 'Fix versions', schema: { type: 'string' } },
   { id: 'defects', name: 'Defects', schema: { type: 'issuelinks' } },
   { id: 'test', name: 'Test', schema: { type: 'issuelinks' } },
+  { id: 'testkey', name: 'Test Key', schema: { type: 'issuelinks' } },
+  { id: 'testrunlinkcloud', name: 'Link to Test Run', schema: { type: 'weblink' } },
+  { id: 'testversion', name: 'Test Version', schema: { type: 'string' } },
+  { id: 'revision', name: 'Revision', schema: { type: 'string' } },
   { id: 'startedon', name: 'Started On', schema: { type: 'datetime' } },
   { id: 'finishedon', name: 'Finished On', schema: { type: 'datetime' } },
-  { id: 'executedby', name: 'Executed By', schema: { type: 'string' } },
+  { id: 'executedby', name: 'Executed By', schema: { type: 'user' } },
+  { id: 'assignee', name: 'Assignee', schema: { type: 'user' } },
   { id: 'testenvironments', name: 'Test Environments', schema: { type: 'string' } },
   { id: 'comment', name: 'Comment', schema: { type: 'string' } },
+  { id: 'gherkin', name: 'Gherkin', schema: { type: 'string' } },
+  { id: 'unstructured', name: 'Definition', schema: { type: 'string' } },
+  { id: 'evidences', name: 'Evidences', schema: { type: 'weblink' } },
 ];
 
 export default (
@@ -67,8 +77,13 @@ export default (
   await promise.then((result) => {
     jiraFields_ = result;
   });
-  // Make the Xray Test Run columns resolvable by the grid rendering pipeline.
-  jiraFields_ = [...(jiraFields_ ?? []), ...XRAY_TESTRUN_FIELDS];
+  jiraFields_ = jiraFields_ ?? [];
+  // The Xray Test Run columns are only valid inside an XRAY_TESTRUNS level.
+  // We keep a dedicated field list where the synthetic Xray metadata takes
+  // precedence over the real Jira fields, so columns whose id collides with a
+  // real Jira field (e.g. `comment`, `assignee`) resolve with the type/data we
+  // control for Xray. Regular Jira levels keep using the untouched Jira fields.
+  const xrayJiraFields = [...XRAY_TESTRUN_FIELDS, ...jiraFields_];
 
   const processJqlsWithKeys = async (jqlParams: JqlParams, jiraFields, index) => {
     const allIssues = [];
@@ -102,12 +117,18 @@ export default (
         }
         const filteredRuns = filterTestRunsByFixVersion(runs, jqlParams.jqls[i]);
         const runsByTest = groupTestRunsByTest(filteredRuns);
+        // Xray returns account ids for the executor / assignee; resolve them to
+        // display names in a single batched call so the grid shows user names.
+        const accountIds = filteredRuns.flatMap((run) => [run?.executedById, run?.assigneeId]);
+        const usersById = await jiraService
+          .getUsersByAccountIds(accountIds)
+          .catch(() => ({}));
         parentTests.forEach((test) => {
           const testRuns = runsByTest[test?.id] ?? [];
           jiraIssues.push({
             issues: {
               issues: Promise.resolve(
-                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain),
+                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain, usersById),
               ),
             },
           });
@@ -145,9 +166,9 @@ export default (
     const duplicatedIssue = hierarchiedIssues.flatMap((issue) => traverseIssues(issue));
 
     // Then based on the duplicate value we will build the row format for gridjs
-    const gridData = extractKeysColumns(duplicatedIssue, jqlParams.allColumnsId, jiraFields, fieldFunctions, confluenceDomain);
+    const gridData = extractKeysColumns(duplicatedIssue, jqlParams.allColumnsId, jqlParams.levelType, jiraFields, xrayJiraFields, fieldFunctions, confluenceDomain);
     const preparedData = gridData.map((obj) => Object.values(obj));
-    const gridjsColumns = createHeaderGridColumns(jqlParams, jiraFields, columnConfig, fieldFunctions, confluenceDomain);
+    const gridjsColumns = createHeaderGridColumns(jqlParams, jiraFields, xrayJiraFields, columnConfig, fieldFunctions, confluenceDomain);
     // Implementation of the gridjs table
     $(jiraJqlSnapshots[index]).append(createGridTable(index, gridjsColumns, preparedData));
   };
@@ -283,22 +304,52 @@ function filterTestRunsByFixVersion(runs: XrayTestRun[], levelJql: string): Xray
 // keyed by the macro's XRAY column ids (see XRAY_TESTRUN_FIELDS) so they render
 // through the same fieldFunctions / columnConfig as Jira issues. All supported
 // columns are populated; the grid only renders the ones the macro configured.
-function mapTestRunsToIssues(runs: XrayTestRun[], testKeyFallback: string, baseUrl: string) {
+function mapTestRunsToIssues(
+  runs: XrayTestRun[],
+  testKeyFallback: string,
+  baseUrl: string,
+  usersById: Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }> = {},
+) {
+  // Builds the `user`-typed data (an array of User objects) expected by
+  // formatUser. Falls back to showing the raw account id when the user could
+  // not be resolved, so the column is never silently empty.
+  const toUserData = (accountId?: string) => {
+    if (!accountId) {
+      return [];
+    }
+    const user = usersById?.[accountId];
+    return [{
+      self: user?.self ?? '',
+      accountId,
+      emailAddress: user?.emailAddress ?? '',
+      displayName: user?.displayName || accountId,
+    }];
+  };
+
   return (runs ?? []).map((run) => {
     const execKey = run?.testExecution?.jira?.key ?? '';
     const testKey = run?.test?.jira?.key ?? testKeyFallback ?? '';
     const statusName = run?.status?.name ?? '';
+    const execStatus = run?.testExecution?.jira?.status;
     const fixVersions = (run?.testExecution?.jira?.fixVersions ?? [])
       .map((version) => version?.name)
       .filter(Boolean)
       .join(', ');
+    const testLink = testKey
+      ? [{ id: run?.test?.issueId ?? '', key: testKey, self: `${baseUrl}/browse/${testKey}` }]
+      : [];
     return {
       id: run?.id ?? '',
       key: execKey || testKey,
       self: execKey ? `${baseUrl}/browse/${execKey}` : '',
       fields: {
         testexeckey: execKey ? [{ id: run?.testExecution?.issueId ?? '', key: execKey, self: `${baseUrl}/browse/${execKey}` }] : [],
-        test: testKey ? [{ id: run?.test?.issueId ?? '', key: testKey, self: `${baseUrl}/browse/${testKey}` }] : [],
+        testexecsummary: run?.testExecution?.jira?.summary ?? '',
+        // The Test Execution's Jira status object already carries the shape
+        // (name + statusCategory.colorName) expected by formatStatus.
+        testexecstatus: execStatus?.name ? [execStatus] : [],
+        test: testLink,
+        testkey: testLink,
         status: statusName
           ? [{
             self: '',
@@ -317,11 +368,23 @@ function mapTestRunsToIssues(runs: XrayTestRun[], testKeyFallback: string, baseU
           : [],
         fixversions: fixVersions,
         defects: (run?.defects ?? []).map((defect) => ({ id: '', key: defect, self: `${baseUrl}/browse/${defect}` })),
+        // Xray Test Runs are not Jira issues and have no public deep link, so we
+        // link to the Test Execution issue that contains the run.
+        testrunlinkcloud: execKey ? [{ name: execKey, link: `${baseUrl}/browse/${execKey}?src=confmacro` }] : [],
+        testversion: run?.testVersion?.name ?? '',
+        revision: run?.testVersion?.id != null ? String(run.testVersion.id) : '',
         startedon: run?.startedOn ?? '',
         finishedon: run?.finishedOn ?? '',
-        executedby: run?.executedById ?? '',
+        executedby: toUserData(run?.executedById),
+        assignee: toUserData(run?.assigneeId),
         testenvironments: (run?.testExecution?.testEnvironments ?? []).join(', '),
         comment: run?.comment ?? '',
+        gherkin: run?.gherkin ?? '',
+        unstructured: run?.unstructured ?? '',
+        evidences: (run?.evidence ?? []).map((evidence) => ({
+          name: evidence?.filename ?? evidence?.id ?? 'evidence',
+          link: evidence?.downloadLink ?? '',
+        })),
       },
     };
   });
@@ -371,7 +434,7 @@ function buildHierarchy(data: any[][][]): Issues[] {
   return hierarchy;
 }
 
-function extractKeysColumns(issuesArray, allColumnsId, jiraFields, fieldFunctions, baseUrl): DataObject[] {
+function extractKeysColumns(issuesArray, allColumnsId, levelTypes, jiraFields, xrayFields, fieldFunctions, baseUrl): DataObject[] {
   const dataObjects: DataObject[] = [];
 
   issuesArray.forEach((issueArray) => {
@@ -381,9 +444,10 @@ function extractKeysColumns(issuesArray, allColumnsId, jiraFields, fieldFunction
 
     issueArray.forEach((issue, levelIndex) => {
       const columns = splitStrings([allColumnsId[levelIndex]]);
+      const fieldsForLevel = levelTypes?.[levelIndex] === 'XRAY_TESTRUNS' ? xrayFields : jiraFields;
       columns.forEach((column) => {
         const isKeyColumn = column === 'key';
-        const fieldTypeData = checkFieldExistence(jiraFields, column);
+        const fieldTypeData = checkFieldExistence(fieldsForLevel, column);
 
         if (!isKeyColumn && isInternalCustomField(column) && fieldTypeData === undefined) {
           return;
@@ -449,15 +513,16 @@ function createGridColumns(columns, columnsName, jiraFields, columnConfig, field
   return `[${allColumns_.join(',')}]`;
 }
 
-function createHeaderGridColumns(jqlParams:JqlParams, jiraFields, columnConfig, fieldFunctions, confluenceDomain) {
+function createHeaderGridColumns(jqlParams:JqlParams, jiraFields, xrayFields, columnConfig, fieldFunctions, confluenceDomain) {
   const gridColumns = jqlParams.allColumnsId.map((column, indexLevel) => {
     const columnId = splitStrings([column]);
     const columnName = splitStrings([jqlParams.allColumnsName[indexLevel]]);
     const name = `${jqlParams.titles[indexLevel]} (Total: ${jqlParams.numberTicket[indexLevel]})`;
+    const fieldsForLevel = jqlParams.levelType?.[indexLevel] === 'XRAY_TESTRUNS' ? xrayFields : jiraFields;
 
     const header = `{
       name: '${name}',
-      columns: ${createGridColumns(columnId, columnName, jiraFields, columnConfig, fieldFunctions, confluenceDomain)}
+      columns: ${createGridColumns(columnId, columnName, fieldsForLevel, columnConfig, fieldFunctions, confluenceDomain)}
     }`;
 
     return header;

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -75,8 +75,8 @@ export default (
     // earlier link/image steps (e.g. fixLinks, which hides <img> tags that have
     // an empty src) cannot tamper with it before we set its src on click.
     $('body').append(
-      '<div id="xray-evidence-modal" class="xray-evidence-modal">'
-      + '<span class="xray-evidence-modal-close" aria-label="Close">&times;</span>'
+      '<div id="xray-evidence-modal" class="xray-evidence-modal" role="dialog" aria-modal="true" aria-label="Xray evidence">'
+      + '<button type="button" class="xray-evidence-modal-close" aria-label="Close">&times;</button>'
       + '</div>',
     );
     $('body').append(`<script defer>

--- a/src/proxy-page/utils/jiraGrid.ts
+++ b/src/proxy-page/utils/jiraGrid.ts
@@ -42,6 +42,20 @@ export const columnConfig = {
           \`).join(' ')
         )
       }`,
+  evidences: (name) => `
+      {
+        name: \`${name}\`,
+        sort: { compare: (a, b) => ((a?.data[0]?.name ?? '') > (b?.data[0]?.name ?? '') ? 1 : -1) },
+        formatter: (cell) => gridjs.html(
+          (cell?.data ?? []).map(item => {
+            const isImage = /\\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(item.name || '');
+            return isImage
+              ? \`<img src="\${item.link}" alt="\${item.name}" title="\${item.name}" \`
+                + \`loading="lazy" class="xray-evidence-thumb" />\`
+              : \`<a href="\${item.link}" target="_blank">\${item.name}</a>\`;
+          }).join(' ')
+        )
+      }`,
 };
 
 export const createTable = (index, gridjsColumns, preparedData) => `

--- a/src/proxy-page/utils/jiraGrid.ts
+++ b/src/proxy-page/utils/jiraGrid.ts
@@ -58,10 +58,10 @@ export const columnConfig = {
               .replace(/'/g, '&#39;');
             const safeName = escapeHtml(name);
             const safeLink = escapeHtml(link);
-            const isImage = /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
+            const isImage = /\\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
             return isImage
-              ? `<img src="${safeLink}" alt="${safeName}" title="${safeName}" loading="lazy" class="xray-evidence-thumb" />`
-              : `<a href="${safeLink}" target="_blank" rel="noopener noreferrer">${safeName}</a>`;
+              ? \`<img src="\${safeLink}" alt="\${safeName}" title="\${safeName}" loading="lazy" class="xray-evidence-thumb" />\`
+              : \`<a href="\${safeLink}" target="_blank" rel="noopener noreferrer">\${safeName}</a>\`;
           }).join(' ')
         )
       }`,

--- a/src/proxy-page/utils/jiraGrid.ts
+++ b/src/proxy-page/utils/jiraGrid.ts
@@ -48,11 +48,20 @@ export const columnConfig = {
         sort: { compare: (a, b) => ((a?.data[0]?.name ?? '') > (b?.data[0]?.name ?? '') ? 1 : -1) },
         formatter: (cell) => gridjs.html(
           (cell?.data ?? []).map(item => {
-            const isImage = /\\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(item.name || '');
+            const name = String(item?.name ?? '');
+            const link = String(item?.link ?? '');
+            const escapeHtml = (s) => String(s)
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;')
+              .replace(/'/g, '&#39;');
+            const safeName = escapeHtml(name);
+            const safeLink = escapeHtml(link);
+            const isImage = /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
             return isImage
-              ? \`<img src="\${item.link}" alt="\${item.name}" title="\${item.name}" \`
-                + \`loading="lazy" class="xray-evidence-thumb" />\`
-              : \`<a href="\${item.link}" target="_blank">\${item.name}</a>\`;
+              ? `<img src="${safeLink}" alt="${safeName}" title="${safeName}" loading="lazy" class="xray-evidence-thumb" />`
+              : `<a href="${safeLink}" target="_blank" rel="noopener noreferrer">${safeName}</a>`;
           }).join(' ')
         )
       }`,

--- a/src/xray/xray.service.ts
+++ b/src/xray/xray.service.ts
@@ -178,7 +178,9 @@ export class XrayService {
 
   // eslint-disable-next-line class-methods-use-this
   private buildTestRunsQuery(testIds: string[], start: number): string {
-    const idsArg = testIds.map((id) => `"${id}"`).join(', ');
+    // Encode each id as a JSON string so an unexpected character (e.g. a quote)
+    // cannot break out of the GraphQL string literal / alter the query.
+    const idsArg = testIds.map((id) => JSON.stringify(String(id))).join(', ');
     return `query {
       getTestRuns(testIssueIds: [${idsArg}], limit: ${XRAY_MAX_PAGE_SIZE}, start: ${start}) {
         total

--- a/src/xray/xray.service.ts
+++ b/src/xray/xray.service.ts
@@ -232,6 +232,14 @@ export class XrayService {
     ) {
       return 'image/webp';
     }
+    if (buffer[0] === 0x42 && buffer[1] === 0x4d) {
+      return 'image/bmp';
+    }
+    // SVG is text-based; check the initial bytes for an <svg> tag (optionally after an XML header).
+    const head = buffer.toString('utf8', 0, Math.min(buffer.length, 256)).trimStart().toLowerCase();
+    if (head.includes('<svg')) {
+      return 'image/svg+xml';
+    }
     if (buffer[0] === 0x25 && buffer[1] === 0x50 && buffer[2] === 0x44 && buffer[3] === 0x46) {
       return 'application/pdf';
     }

--- a/src/xray/xray.service.ts
+++ b/src/xray/xray.service.ts
@@ -176,6 +176,68 @@ export class XrayService {
     }
   }
 
+  /**
+   * @function getAttachment
+   * @description Downloads a Test Run evidence/attachment by its id, using the
+   * authenticated Xray REST endpoint (`/attachments/:id`). The `downloadLink`
+   * returned by the GraphQL API points at an `/enterprise/...` path that is not
+   * directly reachable and, like every Xray endpoint, requires a bearer token a
+   * browser cannot supply - so konviw proxies the download server-side instead.
+   * @param id {string} the Xray attachment id (equals the evidence id)
+   * @return Promise {{ data: Buffer; contentType: string }}
+   */
+  async getAttachment(id: string): Promise<{ data: Buffer; contentType: string }> {
+    if (!this.isConfigured()) {
+      throw new Error('Xray credentials are not configured');
+    }
+    const token = await this.authenticate();
+    const baseURL = this.config.get('xray.baseURL');
+    const response = await firstValueFrom(
+      this.http.get(`${baseURL}/attachments/${encodeURIComponent(id)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        responseType: 'arraybuffer',
+      }),
+    );
+    const data = Buffer.from(response.data);
+    const headerContentType = response.headers?.['content-type'];
+    // Xray serves evidence as `application/octet-stream`, which prevents the
+    // browser from rendering it inline. Sniff the magic bytes so images get a
+    // proper `image/*` type and can be shown as thumbnails in the grid.
+    const contentType = (!headerContentType || headerContentType === 'application/octet-stream')
+      ? (XrayService.sniffContentType(data) ?? headerContentType ?? 'application/octet-stream')
+      : headerContentType;
+    return { data, contentType };
+  }
+
+  // Detects a content type from the leading "magic" bytes of a buffer. Returns
+  // undefined when the type is not recognised so the caller can keep the
+  // original header value.
+  private static sniffContentType(buffer: Buffer): string | undefined {
+    if (!buffer || buffer.length < 4) {
+      return undefined;
+    }
+    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
+      return 'image/png';
+    }
+    if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+      return 'image/jpeg';
+    }
+    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) {
+      return 'image/gif';
+    }
+    if (
+      buffer.length >= 12
+      && buffer.toString('ascii', 0, 4) === 'RIFF'
+      && buffer.toString('ascii', 8, 12) === 'WEBP'
+    ) {
+      return 'image/webp';
+    }
+    if (buffer[0] === 0x25 && buffer[1] === 0x50 && buffer[2] === 0x44 && buffer[3] === 0x46) {
+      return 'application/pdf';
+    }
+    return undefined;
+  }
+
   // eslint-disable-next-line class-methods-use-this
   private buildTestRunsQuery(testIds: string[], start: number): string {
     // Encode each id as a JSON string so an unexpected character (e.g. a quote)

--- a/src/xray/xray.service.ts
+++ b/src/xray/xray.service.ts
@@ -3,23 +3,50 @@ import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
 
+export interface XrayJiraStatus {
+  name?: string;
+  description?: string;
+  iconUrl?: string;
+  id?: string;
+  statusCategory?: { colorName?: string; name?: string };
+}
+
+export interface XrayEvidence {
+  id?: string;
+  filename?: string;
+  downloadLink?: string;
+}
+
 export interface XrayTestRun {
   id: string;
   status?: { name?: string; color?: string; description?: string };
   test?: { issueId?: string; jira?: { key?: string; summary?: string } };
   testExecution?: {
     issueId?: string;
-    jira?: { key?: string; fixVersions?: { name?: string }[] };
+    // `jira` is resolved server-side from the Test Execution Jira issue, so it
+    // carries whatever fields we request (key, summary, fixVersions, status).
+    jira?: {
+      key?: string;
+      summary?: string;
+      fixVersions?: { name?: string }[];
+      status?: XrayJiraStatus;
+    };
     // Test environments are a property of the Test Execution in Xray (the
     // TestRun type does not expose them), so they are nested here.
     testEnvironments?: string[];
   };
+  // The Test version this run was executed against (e.g. name "v1", id 1).
+  testVersion?: { id?: number; name?: string };
   startedOn?: string;
   finishedOn?: string;
+  // Account ids of the executor / assignee; resolved to display names later.
   executedById?: string;
   assigneeId?: string;
   defects?: string[];
   comment?: string;
+  gherkin?: string;
+  unstructured?: string;
+  evidence?: XrayEvidence[];
 }
 
 // Xray caps the `limit` argument of GraphQL connections at 100.
@@ -161,13 +188,17 @@ export class XrayService {
           id
           status { name color description }
           test { issueId jira(fields: ["key", "summary"]) }
-          testExecution { issueId jira(fields: ["key", "fixVersions"]) testEnvironments }
+          testExecution { issueId jira(fields: ["key", "summary", "status", "fixVersions"]) testEnvironments }
+          testVersion { id name }
           startedOn
           finishedOn
           executedById
           assigneeId
           defects
           comment
+          gherkin
+          unstructured
+          evidence { id filename downloadLink }
         }
       }
     }`;

--- a/tests/unit/jira/jira.service.spec.ts
+++ b/tests/unit/jira/jira.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import configuration from '../../../src/config/configuration.test';
+import { JiraService } from '../../../src/jira/jira.service';
+
+describe('jira.service / getUsersByAccountIds', () => {
+  let jiraService: JiraService;
+  let httpService: { get: jest.Mock };
+
+  const buildService = async () => {
+    httpService = { get: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ load: [configuration] })],
+      providers: [
+        JiraService,
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+    jiraService = module.get<JiraService>(JiraService);
+  };
+
+  const userResponse = (values: any[]) => of({ data: { values } });
+
+  it('resolves account ids to a map keyed by accountId', async () => {
+    await buildService();
+    httpService.get.mockReturnValueOnce(userResponse([
+      { accountId: 'a1', displayName: 'Alice', emailAddress: 'alice@test.com', self: 'https://s/a1' },
+      { accountId: 'a2', displayName: 'Bob', emailAddress: 'bob@test.com', self: 'https://s/a2' },
+    ]));
+
+    const users = await jiraService.getUsersByAccountIds(['a1', 'a2']);
+
+    expect(users.a1.displayName).toBe('Alice');
+    expect(users.a2.displayName).toBe('Bob');
+    const url = String(httpService.get.mock.calls[0][0]);
+    expect(url).toContain('/rest/api/3/user/bulk');
+    expect(url).toContain('accountId=a1');
+    expect(url).toContain('accountId=a2');
+  });
+
+  it('dedupes duplicate ids and ignores falsy values', async () => {
+    await buildService();
+    httpService.get.mockReturnValueOnce(userResponse([
+      { accountId: 'a1', displayName: 'Alice' },
+    ]));
+
+    await jiraService.getUsersByAccountIds(['a1', 'a1', '', null as any, undefined as any]);
+
+    expect(httpService.get).toHaveBeenCalledTimes(1);
+    const url = String(httpService.get.mock.calls[0][0]);
+    // Only one accountId param despite the duplicates / falsy entries.
+    expect(url.match(/accountId=/g)).toHaveLength(1);
+  });
+
+  it('returns an empty map without calling the API when there are no ids', async () => {
+    await buildService();
+    const users = await jiraService.getUsersByAccountIds([]);
+    expect(users).toEqual({});
+    expect(httpService.get).not.toHaveBeenCalled();
+  });
+
+  it('splits requests into chunks of 200 account ids', async () => {
+    await buildService();
+    httpService.get.mockReturnValue(userResponse([]));
+    const ids = Array.from({ length: 201 }, (_, i) => `acc-${i}`);
+
+    await jiraService.getUsersByAccountIds(ids);
+
+    // 201 unique ids -> two chunks (200 + 1).
+    expect(httpService.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades gracefully to an empty map when the API fails', async () => {
+    await buildService();
+    httpService.get.mockReturnValueOnce(throwError(() => new Error('boom')));
+
+    const users = await jiraService.getUsersByAccountIds(['a1']);
+
+    expect(users).toEqual({});
+  });
+});

--- a/tests/unit/proxy-api/proxy-api.service.spec.ts
+++ b/tests/unit/proxy-api/proxy-api.service.spec.ts
@@ -3,6 +3,7 @@ import { ProxyApiService } from '../../../src/proxy-api/proxy-api.service';
 import { ContextService } from '../../../src/context/context.service';
 import { ConfluenceService } from '../../../src/confluence/confluence.service';
 import { JiraService } from '../../../src/jira/jira.service';
+import { XrayService } from '../../../src/xray/xray.service';
 import { HttpModule } from '../../../src/http/http.module';
 import { ConfigModule } from '@nestjs/config';
 import { Content } from '../../../src/confluence/confluence.interface';
@@ -70,6 +71,7 @@ describe('proxy-api.service', () => {
         ConfluenceServiceProvider,
         ProxyApiService,
         JiraService,
+        { provide: XrayService, useValue: { getAttachment: jest.fn() } },
       ],
     }).compile();
     proxyApiService = app.get<ProxyApiService>(ProxyApiService);

--- a/tests/unit/steps/addJiraSnapshot.edge.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.edge.spec.ts
@@ -1,0 +1,218 @@
+import { ConfigService } from '@nestjs/config';
+import { ContextService } from '../../../src/context/context.service';
+import { Step } from '../../../src/proxy-page/proxy-page.step';
+import addJiraSnapshot from '../../../src/proxy-page/steps/addJiraSnapshot';
+import { createModuleRefForStep } from './utils';
+
+// A JiraService test double whose `findTickets` resolves issues from the JQL so
+// we can build multi-parent hierarchies (each parent gets its own query).
+class ConfigurableJiraServiceMock {
+  private readonly resolve: (jql: string) => any[];
+
+  private readonly directory: Record<string, any>;
+
+  constructor(resolve: (jql: string) => any[], directory: Record<string, any> = {}) {
+    this.resolve = resolve;
+    this.directory = directory;
+  }
+
+  async findTickets(_project: string, jql: string) {
+    return { data: { total: 0, issues: this.resolve(jql) } };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getFields() {
+    return [
+      { id: 'key', key: 'key', name: 'Key', schema: { type: 'issuelinks' } },
+      { id: 'summary', key: 'summary', name: 'Summary', schema: { type: 'string' } },
+      { id: 'status', key: 'status', name: 'Status', schema: { type: 'status' } },
+    ];
+  }
+
+  async getUsersByAccountIds(accountIds: string[]) {
+    return (accountIds ?? []).reduce((acc, id) => {
+      if (this.directory[id]) acc[id] = this.directory[id];
+      return acc;
+    }, {} as Record<string, any>);
+  }
+}
+
+class ConfigurableXrayServiceMock {
+  private readonly runs: any[];
+
+  constructor(runs: any[]) {
+    this.runs = runs;
+  }
+
+  async getTestRunsByTestIds(testIds: string[]) {
+    return this.runs.filter((run) => testIds.includes(run?.test?.issueId));
+  }
+}
+
+const epicLevel = (fieldsPosition: any[]) => ({
+  jql: 'project = ARM AND issuetype = Epic',
+  title: 'Epics',
+  levelType: 'JIRA_ISSUES',
+  fieldsPosition,
+});
+
+const buildBody = () => '<html><head><title>test</title></head><body>'
+  + '<div id="Content"><div data-macro-name="jira-jql-snapshot"></div></div>'
+  + '</body></html>';
+
+const buildStorage = (macroParams: any) => '<ac:structured-macro ac:name="jira-jql-snapshot">'
+  + `<ac:parameter ac:name="macroParams">${JSON.stringify(macroParams)}</ac:parameter>`
+  + '</ac:structured-macro>';
+
+// Pulls the `data: [...]` array that the step serialises into the grid script
+// so we can assert on the actual rows (and their parent/child pairing).
+const extractGridData = (html: string): any[][] => {
+  const match = html.match(/data:\s*(\[[\s\S]*\]),\s*resizable: true/);
+  if (!match) return [];
+  return JSON.parse(match[1]);
+};
+
+const rowText = (row: any[]): string => JSON.stringify(row);
+
+describe('Confluence Proxy / addJiraSnapshot (edge cases)', () => {
+  let context: ContextService;
+  let config: ConfigService;
+
+  const runStep = async (step: Step) => {
+    await step(context);
+    return context.getHtmlBody();
+  };
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    config = moduleRef.get<ConfigService>(ConfigService);
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'KONVIW', '123456', 'dark');
+    context.setHtmlBody(buildBody());
+  });
+
+  it('aligns Xray runs with the correct parent across multiple epics', async () => {
+    const macroParams = {
+      levels: [
+        epicLevel([
+          { value: { id: 'key' }, label: 'Key' },
+          { value: { id: 'summary' }, label: 'Summary' },
+        ]),
+        {
+          jql: '"Epic Link" = $key',
+          title: 'Tests',
+          levelType: 'JIRA_ISSUES',
+          fieldsPosition: [
+            { value: { id: 'key' }, label: 'Key' },
+            { value: { id: 'summary' }, label: 'Summary' },
+          ],
+        },
+        {
+          jql: 'mode = all',
+          title: 'Test execution',
+          levelType: 'XRAY_TESTRUNS',
+          fieldsPosition: [
+            { value: { id: 'testexeckey' }, label: 'Test Execution Key' },
+            { value: { id: 'status' }, label: 'Status' },
+          ],
+        },
+      ],
+    };
+    context.setBodyStorage(buildStorage(macroParams));
+
+    const jira = new ConfigurableJiraServiceMock((jql) => {
+      if (jql.includes('EPIC-1')) {
+        return [{ id: '101', key: 'TEST-1', fields: { summary: 'Test One' } }];
+      }
+      if (jql.includes('EPIC-2')) {
+        return [{ id: '201', key: 'TEST-2', fields: { summary: 'Test Two' } }];
+      }
+      return [
+        { id: '1', key: 'EPIC-1', fields: { summary: 'Epic One' } },
+        { id: '2', key: 'EPIC-2', fields: { summary: 'Epic Two' } },
+      ];
+    });
+    const xray = new ConfigurableXrayServiceMock([
+      { id: 'r1', status: { name: 'PASSED', color: '#67AB49' }, test: { issueId: '101', jira: { key: 'TEST-1' } }, testExecution: { issueId: '1001', jira: { key: 'EXEC-1' } } },
+      { id: 'r2', status: { name: 'FAILED', color: '#E5493A' }, test: { issueId: '201', jira: { key: 'TEST-2' } }, testExecution: { issueId: '2002', jira: { key: 'EXEC-2' } } },
+    ]);
+
+    const html = await runStep(addJiraSnapshot(config, jira as any, xray as any));
+    const rows = extractGridData(html);
+
+    // Two leaf rows, one per epic->test->execution path.
+    expect(rows).toHaveLength(2);
+    const test1Row = rows.find((r) => rowText(r).includes('TEST-1'));
+    const test2Row = rows.find((r) => rowText(r).includes('TEST-2'));
+    // The key regression: each test must carry its OWN execution, not the first
+    // test's execution leaking onto the second epic.
+    expect(rowText(test1Row)).toContain('EXEC-1');
+    expect(rowText(test1Row)).not.toContain('EXEC-2');
+    expect(rowText(test2Row)).toContain('EXEC-2');
+    expect(rowText(test2Row)).not.toContain('EXEC-1');
+    expect(html).toContain('PASSED');
+    expect(html).toContain('FAILED');
+  });
+
+  const singleLevelMacro = (xrayJql: string) => ({
+    levels: [
+      epicLevel([{ value: { id: 'key' }, label: 'Key' }]),
+      {
+        jql: xrayJql,
+        title: 'Test execution',
+        levelType: 'XRAY_TESTRUNS',
+        fieldsPosition: [
+          { value: { id: 'testexeckey' }, label: 'Test Execution Key' },
+          { value: { id: 'executedby' }, label: 'Executed By' },
+        ],
+      },
+    ],
+  });
+
+  const singleTestResolver = (jql: string) => {
+    if (jql.includes('issuetype = Epic')) {
+      return [{ id: '101', key: 'TEST-1', fields: { summary: 'Test One' } }];
+    }
+    return [];
+  };
+
+  it('falls back to the raw account id when a user cannot be resolved', async () => {
+    context.setBodyStorage(buildStorage(singleLevelMacro('mode = all')));
+    const jira = new ConfigurableJiraServiceMock(singleTestResolver, {}); // empty directory
+    const xray = new ConfigurableXrayServiceMock([
+      { id: 'r1', test: { issueId: '101', jira: { key: 'TEST-1' } }, testExecution: { issueId: '1001', jira: { key: 'EXEC-1' } }, executedById: 'ghost-account-id' },
+    ]);
+
+    const html = await runStep(addJiraSnapshot(config, jira as any, xray as any));
+
+    // Unresolved users still surface (raw id) rather than a silently empty cell.
+    expect(html).toContain('ghost-account-id');
+    expect(html).toContain('EXEC-1');
+  });
+
+  it('excludes runs that do not match the fix version in the level JQL', async () => {
+    context.setBodyStorage(buildStorage(singleLevelMacro('mode = all AND fixVersions = 2.0.0')));
+    const jira = new ConfigurableJiraServiceMock(singleTestResolver);
+    const xray = new ConfigurableXrayServiceMock([
+      { id: 'r1', test: { issueId: '101', jira: { key: 'TEST-1' } }, testExecution: { issueId: '1001', jira: { key: 'EXEC-1', fixVersions: [{ name: '1.0.0' }] } } },
+    ]);
+
+    const html = await runStep(addJiraSnapshot(config, jira as any, xray as any));
+
+    expect(html).not.toContain('EXEC-1');
+    expect(html).toContain('Test execution (Total: 0)');
+  });
+
+  it('excludes runs that do not match the environment in the level JQL', async () => {
+    context.setBodyStorage(buildStorage(singleLevelMacro('mode = all AND environments = Prod')));
+    const jira = new ConfigurableJiraServiceMock(singleTestResolver);
+    const xray = new ConfigurableXrayServiceMock([
+      { id: 'r1', test: { issueId: '101', jira: { key: 'TEST-1' } }, testExecution: { issueId: '1001', jira: { key: 'EXEC-1' }, testEnvironments: ['Dev'] } },
+    ]);
+
+    const html = await runStep(addJiraSnapshot(config, jira as any, xray as any));
+
+    expect(html).not.toContain('EXEC-1');
+    expect(html).toContain('Test execution (Total: 0)');
+  });
+});

--- a/tests/unit/steps/addJiraSnapshot.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.spec.ts
@@ -162,6 +162,16 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     expect(html).toContain('v2'); // testversion
     expect(html).toContain('run comment'); // comment via synthetic string field
     expect(html).toContain('screenshot.png'); // evidences
+    // Evidence links must go through konviw's Xray attachment proxy, not the
+    // raw (unauthenticated, 404-ing) Xray downloadLink.
+    expect(html).toContain('/api/xray/attachments/ev1');
+    expect(html).not.toContain('https://files/screenshot.png');
+    // Image evidence is displayed inline as a thumbnail: the evidences column
+    // uses the image formatter (the grid renders the <img> client-side from the
+    // proxied link in the row data).
+    expect(html).toContain('<img src="${item.link}"');
+    // Clicking a thumbnail opens the lightbox modal rather than navigating.
+    expect(html).toContain('xray-evidence-modal');
     expect(html).toContain('Given a step'); // gherkin
     // account ids should not leak into the rendered output
     expect(html).not.toContain('account-executor');

--- a/tests/unit/steps/addJiraSnapshot.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.spec.ts
@@ -61,7 +61,7 @@ class XrayServiceMock {
             },
             fixVersions: [{ name: 'Track4 2.0.1' }],
           },
-          testEnvironments: ['Dev'],
+          testEnvironments: ['Staging'],
         },
         testVersion: { id: 2, name: 'v2' },
         executedById: 'account-executor',
@@ -88,7 +88,7 @@ const macroParams = {
       ],
     },
     {
-      jql: 'mode = all AND fixVersions = Track4 2.0.1 AND environments = Test',
+      jql: 'mode = all AND fixVersions = Track4 2.0.1 AND environments = Staging',
       title: 'Test execution',
       levelType: 'XRAY_TESTRUNS',
       fieldsPosition: [
@@ -154,7 +154,7 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     expect(html).toContain('Track4 2.0.1');
     expect(html).toContain('TRACK4-BUG-1');
     expect(html).toContain('Test Environments');
-    expect(html).toContain('Dev');
+    expect(html).toContain('Staging');
     // New columns fixed as part of WEB-2475 Kevin feedback.
     expect(html).toContain('Regression exec'); // testexecsummary
     expect(html).toContain('Alice Executor'); // executedby resolved to name

--- a/tests/unit/steps/addJiraSnapshot.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.spec.ts
@@ -23,7 +23,23 @@ class JiraServiceMock {
       { id: 'key', key: 'key', name: 'Key', schema: { type: 'issuelinks' } },
       { id: 'summary', key: 'summary', name: 'Summary', schema: { type: 'string' } },
       { id: 'status', key: 'status', name: 'Status', schema: { type: 'status' } },
+      // A real Jira `comment` field with an unsupported type; the Xray synthetic
+      // metadata must take precedence for the XRAY level so it is not rendered
+      // as "Type not treated".
+      { id: 'comment', key: 'comment', name: 'Comment', schema: { type: 'comments-page' } },
     ];
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getUsersByAccountIds(accountIds: string[]) {
+    const directory = {
+      'account-executor': { accountId: 'account-executor', displayName: 'Alice Executor', emailAddress: 'alice@test.com', self: '' },
+      'account-assignee': { accountId: 'account-assignee', displayName: 'Bob Assignee', emailAddress: 'bob@test.com', self: '' },
+    };
+    return (accountIds ?? []).reduce((acc, id) => {
+      if (directory[id]) acc[id] = directory[id];
+      return acc;
+    }, {} as Record<string, any>);
   }
 }
 
@@ -37,10 +53,24 @@ class XrayServiceMock {
         test: { issueId: '20001', jira: { key: 'TRACK4-TEST-1', summary: 'Login works' } },
         testExecution: {
           issueId: '10001',
-          jira: { key: 'TRACK4-EXEC-1', fixVersions: [{ name: 'Track4 2.0.1' }] },
+          jira: {
+            key: 'TRACK4-EXEC-1',
+            summary: 'Regression exec',
+            status: {
+              self: '', description: '', iconUrl: '', name: 'Done', id: '3', statusCategory: { self: '', id: 3, key: 'done', colorName: 'green', name: 'Done' },
+            },
+            fixVersions: [{ name: 'Track4 2.0.1' }],
+          },
           testEnvironments: ['Dev'],
         },
+        testVersion: { id: 2, name: 'v2' },
+        executedById: 'account-executor',
+        assigneeId: 'account-assignee',
         defects: ['TRACK4-BUG-1'],
+        comment: 'run comment',
+        gherkin: 'Given a step',
+        unstructured: 'do the thing',
+        evidence: [{ id: 'ev1', filename: 'screenshot.png', downloadLink: 'https://files/screenshot.png' }],
       },
     ];
   }
@@ -63,10 +93,22 @@ const macroParams = {
       levelType: 'XRAY_TESTRUNS',
       fieldsPosition: [
         { value: { id: 'testexeckey' }, label: 'Test Execution Key' },
+        { value: { id: 'testexecsummary' }, label: 'Test Execution Summary' },
+        { value: { id: 'testexecstatus' }, label: 'Test Execution Status' },
         { value: { id: 'status' }, label: 'Status' },
         { value: { id: 'fixversions' }, label: 'Fix versions' },
         { value: { id: 'defects' }, label: 'Defects' },
+        { value: { id: 'testkey' }, label: 'Test Key' },
+        { value: { id: 'assignee' }, label: 'Assignee' },
+        { value: { id: 'testrunlinkcloud' }, label: 'Link to Test Run' },
+        { value: { id: 'executedby' }, label: 'Executed By' },
+        { value: { id: 'testversion' }, label: 'Test Version' },
+        { value: { id: 'revision' }, label: 'Revision' },
         { value: { id: 'testenvironments' }, label: 'Test Environments' },
+        { value: { id: 'comment' }, label: 'Comment' },
+        { value: { id: 'gherkin' }, label: 'Gherkin' },
+        { value: { id: 'unstructured' }, label: 'Definition' },
+        { value: { id: 'evidences' }, label: 'Evidences' },
       ],
     },
   ],
@@ -105,6 +147,7 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
 
     expect(html).not.toContain('TEST RUN NOT SUPPORTED YET');
     expect(html).not.toContain('column undefined');
+    expect(html).not.toContain('Type not treated');
     expect(html).toContain('Test execution (Total: 1)');
     expect(html).toContain('PASSED');
     expect(html).toContain('TRACK4-EXEC-1');
@@ -112,6 +155,17 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     expect(html).toContain('TRACK4-BUG-1');
     expect(html).toContain('Test Environments');
     expect(html).toContain('Dev');
+    // New columns fixed as part of WEB-2475 Kevin feedback.
+    expect(html).toContain('Regression exec'); // testexecsummary
+    expect(html).toContain('Alice Executor'); // executedby resolved to name
+    expect(html).toContain('Bob Assignee'); // assignee resolved to name
+    expect(html).toContain('v2'); // testversion
+    expect(html).toContain('run comment'); // comment via synthetic string field
+    expect(html).toContain('screenshot.png'); // evidences
+    expect(html).toContain('Given a step'); // gherkin
+    // account ids should not leak into the rendered output
+    expect(html).not.toContain('account-executor');
+    expect(html).not.toContain('account-assignee');
   });
 
   it('degrades gracefully when the Xray service is not provided', async () => {

--- a/tests/unit/steps/addJiraSnapshot.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.spec.ts
@@ -169,7 +169,7 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     // Image evidence is displayed inline as a thumbnail: the evidences column
     // uses the image formatter (the grid renders the <img> client-side from the
     // proxied link in the row data).
-    expect(html).toContain('<img src="${item.link}"');
+    expect(html).toContain('class="xray-evidence-thumb"');
     // Clicking a thumbnail opens the lightbox modal rather than navigating.
     expect(html).toContain('xray-evidence-modal');
     expect(html).toContain('Given a step'); // gherkin

--- a/tests/unit/xray/xray.service.spec.ts
+++ b/tests/unit/xray/xray.service.spec.ts
@@ -102,4 +102,46 @@ describe('xray.service', () => {
     const runs = await xrayService.getTestRunsByTestIds(['20001']);
     expect(runs).toEqual([]);
   });
+
+  it('reuses the cached bearer token across calls (authenticates only once)', async () => {
+    await buildService();
+    httpService.post
+      .mockReturnValueOnce(of({ data: '"a-bearer-token"' }))
+      .mockReturnValue(graphqlPage([{ id: 'run-1', test: { issueId: '20001' } }], 1));
+
+    await xrayService.getTestRunsByTestIds(['20001']);
+    await xrayService.getTestRunsByTestIds(['20002']);
+
+    const authCalls = httpService.post.mock.calls.filter((call) => String(call[0]).includes('/authenticate'));
+    expect(authCalls).toHaveLength(1);
+  });
+
+  it('stops paginating when a page returns no results even if total is higher', async () => {
+    await buildService();
+    httpService.post
+      .mockReturnValueOnce(of({ data: '"a-bearer-token"' }))
+      .mockReturnValueOnce(graphqlPage([{ id: 'run-1', test: { issueId: '20001' } }], 500))
+      .mockReturnValueOnce(graphqlPage([], 500));
+
+    const runs = await xrayService.getTestRunsByTestIds(['20001']);
+
+    expect(runs).toHaveLength(1);
+    // auth + first (non-empty) page + second (empty) page, then it breaks
+    expect(httpService.post).toHaveBeenCalledTimes(3);
+  });
+
+  it('escapes the test issue ids injected into the GraphQL query', async () => {
+    await buildService();
+    httpService.post
+      .mockReturnValueOnce(of({ data: '"a-bearer-token"' }))
+      .mockReturnValueOnce(graphqlPage([], 0));
+
+    await xrayService.getTestRunsByTestIds(['20001', 'evil" injection']);
+
+    const { query } = httpService.post.mock.calls[1][1];
+    // The rogue quote must be escaped so it cannot break out of the string.
+    expect(query).toContain('"20001"');
+    expect(query).toContain('evil\\" injection');
+    expect(query).not.toContain('"evil" injection"');
+  });
 });

--- a/tests/unit/xray/xray.service.spec.ts
+++ b/tests/unit/xray/xray.service.spec.ts
@@ -7,10 +7,10 @@ import { XrayService } from '../../../src/xray/xray.service';
 
 describe('xray.service', () => {
   let xrayService: XrayService;
-  let httpService: { post: jest.Mock };
+  let httpService: { post: jest.Mock; get: jest.Mock };
 
   const buildService = async (clientId = 'id', clientSecret = 'secret') => {
-    httpService = { post: jest.fn() };
+    httpService = { post: jest.fn(), get: jest.fn() };
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         ConfigModule.forRoot({
@@ -143,5 +143,43 @@ describe('xray.service', () => {
     expect(query).toContain('"20001"');
     expect(query).toContain('evil\\" injection');
     expect(query).not.toContain('"evil" injection"');
+  });
+
+  it('downloads an attachment with the bearer token and preserves the content type', async () => {
+    await buildService();
+    httpService.post.mockReturnValueOnce(of({ data: '"a-bearer-token"' }));
+    httpService.get.mockReturnValueOnce(of({
+      data: Buffer.from('PNG-BYTES'),
+      headers: { 'content-type': 'image/png' },
+    }));
+
+    const result = await xrayService.getAttachment('att-123');
+
+    expect(result.contentType).toBe('image/png');
+    expect(Buffer.isBuffer(result.data)).toBe(true);
+    const getCall = httpService.get.mock.calls[0];
+    expect(getCall[0]).toContain('/attachments/att-123');
+    expect(getCall[1].headers.Authorization).toBe('Bearer a-bearer-token');
+    expect(getCall[1].responseType).toBe('arraybuffer');
+  });
+
+  it('sniffs the content type when Xray returns a generic octet-stream', async () => {
+    await buildService();
+    httpService.post.mockReturnValueOnce(of({ data: '"a-bearer-token"' }));
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    httpService.get.mockReturnValueOnce(of({
+      data: png,
+      headers: { 'content-type': 'application/octet-stream' },
+    }));
+
+    const result = await xrayService.getAttachment('att-1');
+
+    expect(result.contentType).toBe('image/png');
+  });
+
+  it('throws and makes no request when downloading an attachment while unconfigured', async () => {
+    await buildService('', '');
+    await expect(xrayService.getAttachment('att-123')).rejects.toThrow();
+    expect(httpService.get).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Enhances the Jira Snapshot report's Xray Test Run integration (WEB-2475):

- **Enriched Xray Test Run columns** — maps Xray Cloud GraphQL fields into synthetic grid columns (status, execution date, executed-by, defects, assignee, evidences, etc.) with correct column metadata, fixing the previous "column undefined" / "type not treated" errors.
- **Human-readable users** — bulk-resolves Jira account IDs to display names via a new `JiraService` helper, so *Executed By* / *Assignee* show names instead of raw account IDs.
- **Correct filtering & hierarchy** — filters Xray test runs by both `fixVersions` and `environment` from the JQL, and fixes a multi-parent hierarchy bug so test runs attach to the correct parent issue.
- **Evidence attachments proxy** — new backend route streams Xray evidence through the konviw backend (with bearer auth and content-type sniffing), so authenticated evidence images actually resolve instead of 404'ing.
- **Inline thumbnails + lightbox** — image evidences render as inline thumbnails in the grid and open in a client-side lightbox modal (non-image files fall back to text links). The modal image is created client-side to avoid being hidden by `fixLinks`' empty-`src` image handling.
- **Grid UX** — full column headings are shown without truncation and sort arrows are aligned inline with the headers.

## Changes

- `src/xray/xray.service.ts` — `getAttachment(id)` streaming with token caching + content-type sniffing; escaped GraphQL queries.
- `src/proxy-api/*` — new `GET /api/xray/attachments/:id` route; wired `XrayService` into the module/service.
- `src/jira/jira.service.ts` — `getUsersByAccountIds` bulk user resolution.
- `src/proxy-page/steps/addJiraSnapshot.ts` — column enrichment, user resolution, env/fixVersion filtering, hierarchy fix, evidence proxy URLs, lightbox modal injection.
- `src/proxy-page/dto/FieldInterface.ts` + `src/proxy-page/utils/jiraGrid.ts` — `formatEvidences` formatter and inline thumbnail/link renderer.
- `src/assets/scss/_macro-jira.scss` (+ iadc variant) — thumbnail & modal styles, grid header width/inline sort-arrow styles.

##Evidences
<img width="2340" height="1171" alt="Screenshot 2026-07-14 at 12 39 31 PM" src="https://github.com/user-attachments/assets/7e14e8d5-22f2-4eb6-a563-f43d9d0c75cd" />

<img width="1722" height="722" alt="Screenshot 2026-07-14 at 12 39 26 PM" src="https://github.com/user-attachments/assets/f4e42390-28f8-4de9-b8a6-866c9daf1413" />

<img width="1598" height="1112" alt="Screenshot 2026-07-14 at 12 39 18 PM" src="https://github.com/user-attachments/assets/2b461d70-4c67-4bc5-966e-61feaa314b8f" />


## Test plan

- [x] Unit tests added/updated: `xray.service.spec.ts` (getAttachment, token caching, content-type sniffing), `jira.service.spec.ts` (getUsersByAccountIds), `addJiraSnapshot.spec.ts` + `addJiraSnapshot.edge.spec.ts` (evidence proxy URLs, inline images, multi-epic hierarchy, unresolved-user fallback, fixVersion/environment filters), `proxy-api.service.spec.ts`.
- [x] Lint + build pass.
- [ ] Manually verify on docs page: evidence thumbnails render, clicking opens the lightbox with the image, non-image evidence shows as a link.
- [ ] Verify Xray credentials are injected via AWS Secrets Manager / ECS task definition in the deployed environment.