### PR TITLE
Isolate ContextService and avoid theme flicker effect

### DIFF
--- a/src/proxy-page/proxy-page.module.ts
+++ b/src/proxy-page/proxy-page.module.ts
@@ -3,13 +3,12 @@ import { JiraModule } from '../jira/jira.module';
 import { XrayModule } from '../xray/xray.module';
 import { HttpModule } from '../http/http.module';
 import { ConfluenceModule } from '../confluence/confluence.module';
-import { ContextService } from '../context/context.service';
 import { ProxyPageService } from './proxy-page.service';
 import { ProxyPageController } from './proxy-page.controller';
 
 @Module({
   imports: [ConfluenceModule, JiraModule, XrayModule, HttpModule],
-  providers: [ProxyPageService, ContextService],
+  providers: [ProxyPageService],
   controllers: [ProxyPageController],
   exports: [],
 })

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -62,7 +62,6 @@ export class ProxyPageService {
 
   constructor(
     private config: ConfigService,
-    private context: ContextService,
     private confluence: ConfluenceService,
     private jira: JiraService,
     private xray: XrayService,
@@ -98,7 +97,8 @@ export class ProxyPageService {
       version,
       status,
     );
-    this.context.initPageContext(
+    const context = new ContextService(this.config);
+    context.initPageContext(
       'v2',
       spaceKey,
       pageId,
@@ -109,62 +109,62 @@ export class ProxyPageService {
       true, // loadAsDocument
       view,
     );
-    const contextType = this.context.getType();
-    const addJiraPromise = addJira(this.config, this.jira)(this.context);
-    const addJiraSnapshotPromise = addJiraSnapshot(this.config, this.jira, this.xray)(this.context);
-    await getExcerptAndHeaderImage(this.config, this.confluence)(this.context);
-    fixHtmlHead(this.config)(this.context);
-    fixContentWidth()(this.context);
-    fixMultiColumnLayout()(this.context);
-    fixUserProfile()(this.context);
-    fixProfilePicture()(this.context);
-    await fixConfluenceSpace(this.config, this.confluence)(this.context);
-    await fixLinks(this.config, this.http, this.jira)(this.context);
+    const contextType = context.getType();
+    const addJiraPromise = addJira(this.config, this.jira)(context);
+    const addJiraSnapshotPromise = addJiraSnapshot(this.config, this.jira, this.xray)(context);
+    await getExcerptAndHeaderImage(this.config, this.confluence)(context);
+    fixHtmlHead(this.config)(context);
+    fixContentWidth()(context);
+    fixMultiColumnLayout()(context);
+    fixUserProfile()(context);
+    fixProfilePicture()(context);
+    await fixConfluenceSpace(this.config, this.confluence)(context);
+    await fixLinks(this.config, this.http, this.jira)(context);
     if (view !== 'iframe-resizer') {
-      fixToc()(this.context);
+      fixToc()(context);
     }
-    await fixEmojis(this.config, this.confluence)(this.context);
-    fixDrawioMacro(this.config)(this.context);
-    fixChartMacro(this.config)(this.context);
-    fixExpander()(this.context);
-    fixVideo()(this.context);
+    await fixEmojis(this.config, this.confluence)(context);
+    fixDrawioMacro(this.config)(context);
+    fixChartMacro(this.config)(context);
+    fixExpander()(context);
+    fixVideo()(context);
     // fixEmptyLineIncludePage()(this.context);
-    fixRoadmap(this.config)(this.context);
-    fixCode()(this.context);
-    fixFrameAllowFullscreen()(this.context);
-    fixCaptionImage()(this.context);
-    fixImageSize()(this.context);
-    fixColGroupWidth()(this.context);
+    fixRoadmap(this.config)(context);
+    fixCode()(context);
+    fixFrameAllowFullscreen()(context);
+    fixCaptionImage()(context);
+    fixImageSize()(context);
+    fixColGroupWidth()(context);
     if (contextType.includes('blog')) {
-      await addHeaderBlog()(this.context);
+      await addHeaderBlog()(context);
     } else if (!contextType.includes('notitle')) {
-      await addHeaderTitle(this.confluence)(this.context);
+      await addHeaderTitle(this.confluence)(context);
     }
-    fixSVG(this.config)(this.context);
-    fixEmbeddedFile()(this.context);
-    fixTableBackground()(this.context);
-    fixTableSize()(this.context);
-    fixRecentlyUpdated()(this.context);
-    addTableResponsive()(this.context);
-    addAuthorVersion()(this.context);
-    delUnnecessaryCode()(this.context);
-    addCustomCss(this.config, style)(this.context);
-    addLibrariesCSS()(this.context);
-    addZoom()(this.context);
-    addTheme()(this.context);
+    fixSVG(this.config)(context);
+    fixEmbeddedFile()(context);
+    fixTableBackground()(context);
+    fixTableSize()(context);
+    fixRecentlyUpdated()(context);
+    addTableResponsive()(context);
+    addAuthorVersion()(context);
+    delUnnecessaryCode()(context);
+    addCustomCss(this.config, style)(context);
+    addLibrariesCSS()(context);
+    addZoom()(context);
+    addTheme()(context);
     if (view !== 'iframe-resizer') {
-      addScrollToTop()(this.context);
-      addReadingProgressBar()(this.context);
+      addScrollToTop()(context);
+      addReadingProgressBar()(context);
     }
-    addCopyLinks()(this.context);
-    addWebStatsTracker(this.config)(this.context);
+    addCopyLinks()(context);
+    addWebStatsTracker(this.config)(context);
     await addJiraPromise;
     await addJiraSnapshotPromise;
-    addLibrariesJS()(this.context);
-    addUnsupportedMacroIndicator()(this.context);
-    await addPDF(this.confluence)(this.context);
-    this.context.Close();
-    return this.context.getHtmlBody();
+    addLibrariesJS()(context);
+    addUnsupportedMacroIndicator()(context);
+    await addPDF(this.confluence)(context);
+    context.Close();
+    return context.getHtmlBody();
   }
 
   /**
@@ -186,46 +186,47 @@ export class ProxyPageService {
     status: string,
   ): Promise<string> {
     const content: Content = await this.confluence.getPage(spaceKey, pageId, version, status);
+    const context = new ContextService(this.config);
     addSlideContextByStrategy(
-      this.context,
+      context,
       spaceKey,
       pageId,
       style,
       content,
     );
-    const addJiraPromise = addJira(this.config, this.jira)(this.context);
-    const addJiraSnapshotPromise = addJiraSnapshot(this.config, this.jira, this.xray)(this.context);
-    addSlidesCSS(this.config)(this.context);
-    fixHtmlHead(this.config)(this.context);
-    fixUserProfile()(this.context);
-    fixProfilePicture()(this.context);
-    fixEmbeddedFile()(this.context);
-    await fixConfluenceSpace(this.config, this.confluence)(this.context);
-    await fixLinks(this.config, this.http, this.jira)(this.context);
-    fixToc()(this.context);
-    await fixEmojis(this.config, this.confluence)(this.context);
-    fixDrawioMacro(this.config)(this.context);
-    fixChartMacro(this.config)(this.context);
-    fixExpander()(this.context);
-    fixVideo()(this.context);
-    fixEmptyLineIncludePage()(this.context);
-    fixRoadmap(this.config)(this.context);
-    fixCaptionImage()(this.context);
-    fixImageSize()(this.context);
-    fixFrameAllowFullscreen()(this.context);
-    fixSVG(this.config)(this.context);
-    fixTableBackground()(this.context);
+    const addJiraPromise = addJira(this.config, this.jira)(context);
+    const addJiraSnapshotPromise = addJiraSnapshot(this.config, this.jira, this.xray)(context);
+    addSlidesCSS(this.config)(context);
+    fixHtmlHead(this.config)(context);
+    fixUserProfile()(context);
+    fixProfilePicture()(context);
+    fixEmbeddedFile()(context);
+    await fixConfluenceSpace(this.config, this.confluence)(context);
+    await fixLinks(this.config, this.http, this.jira)(context);
+    fixToc()(context);
+    await fixEmojis(this.config, this.confluence)(context);
+    fixDrawioMacro(this.config)(context);
+    fixChartMacro(this.config)(context);
+    fixExpander()(context);
+    fixVideo()(context);
+    fixEmptyLineIncludePage()(context);
+    fixRoadmap(this.config)(context);
+    fixCaptionImage()(context);
+    fixImageSize()(context);
+    fixFrameAllowFullscreen()(context);
+    fixSVG(this.config)(context);
+    fixTableBackground()(context);
     // addTableResponsive()(this.context);
-    delUnnecessaryCode()(this.context);
+    delUnnecessaryCode()(context);
     await addJiraPromise;
     await addJiraSnapshotPromise;
-    addSlideTypeByStrategy(this.config)(this.context);
-    addSlidesJS(this.config)(this.context);
-    addMessageLastSlide()(this.context);
-    addWebStatsTracker(this.config)(this.context);
-    await addPDF(this.confluence)(this.context);
-    this.context.Close();
-    return this.context.getHtmlBody();
+    addSlideTypeByStrategy(this.config)(context);
+    addSlidesJS(this.config)(context);
+    addMessageLastSlide()(context);
+    addWebStatsTracker(this.config)(context);
+    await addPDF(this.confluence)(context);
+    context.Close();
+    return context.getHtmlBody();
   }
 
   /**

--- a/src/proxy-page/steps/addTheme.ts
+++ b/src/proxy-page/steps/addTheme.ts
@@ -10,29 +10,31 @@ export default (): Step => (context: ContextService): void => {
   switch (theme) {
     case 'dark':
     case 'light':
-      // When the DOM content is loaded set the theme and save the preference
-      $('body').append(
-        `<script type="module">
-            document.addEventListener('DOMContentLoaded', function () {
-              document.documentElement.setAttribute('data-theme', '${theme}');
-              localStorage.setItem('theme', '${theme}');
-            })
-          </script>`,
+      // The theme is known server-side, so render it straight onto <html>. The
+      // attribute is present at parse time, CSS matches on first paint and there
+      // is no light->dark flash. A tiny synchronous script only persists the
+      // preference for later param-less loads (no DOMContentLoaded / no defer).
+      $('html').attr('data-theme', theme);
+      $('head').prepend(
+        `<script>try{localStorage.setItem('theme','${theme}')}catch(e){}</script>`,
       );
       break;
     default:
-      $('body').append(
-        `<script type="module">
-            document.addEventListener('DOMContentLoaded', function () {
-              const currentTheme = localStorage.getItem('theme');
-              if (currentTheme) {
-                document.documentElement.setAttribute('data-theme', currentTheme);
-              } else {
-                document.documentElement.setAttribute('data-theme', 'light');
-                localStorage.setItem('theme', 'light');
-              }
-            })
-          </script>`,
+      // No theme param: we cannot know the stored preference server-side, so run
+      // a blocking inline script as the first <head> node. It sets data-theme
+      // synchronously, before the stylesheet paints the body -> no flash.
+      $('head').prepend(
+        `<script>
+          (function () {
+            var theme = null;
+            try { theme = localStorage.getItem('theme'); } catch (e) { theme = null; }
+            if (!theme) {
+              theme = 'light';
+              try { localStorage.setItem('theme', 'light'); } catch (e) { /* ignore */ }
+            }
+            document.documentElement.setAttribute('data-theme', theme);
+          })();
+        </script>`,
       );
   }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,2 +1,3 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.performance = require('perf_hooks').performance;

--- a/tests/unit/proxy-page/proxy-page.service.spec.ts
+++ b/tests/unit/proxy-page/proxy-page.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { ProxyPageService } from '../../../src/proxy-page/proxy-page.service';
+import { ContextService } from '../../../src/context/context.service';
+import { ConfluenceService } from '../../../src/confluence/confluence.service';
+import { JiraService } from '../../../src/jira/jira.service';
+import { XrayService } from '../../../src/xray/xray.service';
+import { HttpModule } from '../../../src/http/http.module';
+import { Content } from '../../../src/confluence/confluence.interface';
+import configuration from '../../../src/config/configuration.test';
+
+jest.mock('../../../src/confluence/confluence.service');
+jest.mock('../../../src/jira/jira.service');
+
+type DeepPartial<T> = T extends object
+  ? { [P in keyof T]?: DeepPartial<T[P]> }
+  : T;
+
+// A v2-shaped Confluence page with a plain body. The minimal DOM keeps every
+// content-driven step (jira macros, emojis, space links, PDFs, attachments) on
+// its no-op branch, so renderPage completes without hitting external services.
+class ConfluenceServiceMock {
+  // eslint-disable-next-line class-methods-use-this
+  getPage(): DeepPartial<Content> {
+    return {
+      pageContent: {
+        title: 'Page title',
+        body: {
+          view: { value: '<p>plain body content</p>' },
+          storage: { value: '<p>plain body content</p>' },
+        },
+        version: { number: 21, createdAt: '2021-01-19T01:30:00.000' },
+        createdAt: '2020-01-01T01:30:00.000',
+      },
+      authorContent: {
+        email: 'email@somewhere.com',
+        publicName: 'Author name',
+        profilePicture: { path: '//profilepic' },
+      },
+      versionAuthorContent: {
+        email: 'email@somewhere.com',
+        publicName: 'Author name',
+        profilePicture: { path: '//profilepic' },
+      },
+      spaceContent: { key: 'MySpace' },
+      labelsContent: { results: [{ name: 'one' }] },
+      propertiesContent: {},
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getAttachments() {
+    return [];
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getSpecialAtlassianIcons() {
+    return '';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getSpecialUploadedIcons() {
+    return '';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getSpaceMetadata() {
+    return { data: {} };
+  }
+}
+
+describe('proxy-page.service', () => {
+  let app: TestingModule;
+  let proxyPageService: ProxyPageService;
+
+  const renderOnce = () =>
+    proxyPageService.renderPage(
+      'MySpace',
+      '1234',
+      '', // version
+      'light', // theme
+      'page', // type
+      'konviw', // style
+      'fullpage', // view (enables reading-progress bar)
+      'current', // status
+    );
+
+  const countOccurrences = (haystack: string, needle: string): number =>
+    haystack.split(needle).length - 1;
+
+  beforeAll(async () => {
+    app = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ load: [configuration] }), HttpModule],
+      providers: [
+        ProxyPageService,
+        ContextService,
+        { provide: ConfluenceService, useClass: ConfluenceServiceMock },
+        {
+          provide: JiraService,
+          useValue: { getFields: jest.fn().mockResolvedValue([]) },
+        },
+        { provide: XrayService, useValue: { getAttachment: jest.fn() } },
+      ],
+    }).compile();
+    proxyPageService = app.get<ProxyPageService>(ProxyPageService);
+  });
+
+  it('renders a single title and reading-progress bar for a sequential request', async () => {
+    const html = await renderOnce();
+    expect(countOccurrences(html, '<h1 class="titlePage">')).toBe(1);
+    expect(countOccurrences(html, 'id="reading-progress"')).toBe(1);
+  });
+
+  it('does not duplicate the title or reading-progress bar under concurrent requests', async () => {
+    // Regression: the render buffer used to live on a shared singleton
+    // ContextService, so overlapping renderPage calls accumulated copies of the
+    // <h1 class="titlePage"> and <div id="reading-progress"> nodes. Each call
+    // must now own an isolated context.
+    const results = await Promise.all(Array.from({ length: 6 }, renderOnce));
+
+    results.forEach((html) => {
+      expect(countOccurrences(html, '<h1 class="titlePage">')).toBe(1);
+      expect(countOccurrences(html, 'id="reading-progress"')).toBe(1);
+    });
+  });
+});

--- a/tests/unit/steps/addTheme.spec.ts
+++ b/tests/unit/steps/addTheme.spec.ts
@@ -13,29 +13,33 @@ describe('Confluence Proxy / addTheme', () => {
     context = moduleRef.get<ContextService>(ContextService);
   });
 
-  it('should add dark theme', () => {
+  it('should set data-theme=dark on <html> for zero-flash paint', () => {
     context.initPageContext('v2', 'XXX', '123456', 'dark');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())
-      .toEqual(`<html><head></head><body><div id="Content">BODY CONTENT</div><script type="module">
-            document.addEventListener('DOMContentLoaded', function () {
-              document.documentElement.setAttribute('data-theme', 'dark');
-              localStorage.setItem('theme', 'dark');
-            })
-          </script></body></html>`);
+      .toEqual('<html data-theme="dark"><head><script>try{localStorage.setItem(\'theme\',\'dark\')}catch(e){}</script></head><body><div id="Content">BODY CONTENT</div></body></html>');
   });
 
-  it('should add light theme', () => {
+  it('should set data-theme=light on <html> for zero-flash paint', () => {
     context.initPageContext('v2', 'XXX', '123456', 'light');
     context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
     step(context);
     expect(context.getHtmlBody())
-      .toEqual(`<html><head></head><body><div id="Content">BODY CONTENT</div><script type="module">
-            document.addEventListener('DOMContentLoaded', function () {
-              document.documentElement.setAttribute('data-theme', 'light');
-              localStorage.setItem('theme', 'light');
-            })
-          </script></body></html>`);
+      .toEqual('<html data-theme="light"><head><script>try{localStorage.setItem(\'theme\',\'light\')}catch(e){}</script></head><body><div id="Content">BODY CONTENT</div></body></html>');
+  });
+
+  it('should inject a blocking head script resolving the theme when none is given', () => {
+    context.initPageContext('v2', 'XXX', '123456', undefined as any);
+    context.setHtmlBody('<html><head></head><body>BODY CONTENT</body></html>');
+    step(context);
+    const html = context.getHtmlBody();
+    // No server-side attribute on <html> (preference is only known client-side)
+    expect(html).not.toContain('data-theme="');
+    // Blocking, non-deferred head script that resolves the theme before paint
+    expect(html).toContain("localStorage.getItem('theme')");
+    expect(html).toContain("document.documentElement.setAttribute('data-theme', theme)");
+    expect(html).not.toContain('DOMContentLoaded');
+    expect(html).not.toContain('type="module"');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "dist", "docs", "tests"]
+  "exclude": ["node_modules", "dist", "docs", "tests/e2e"]
 }


### PR DESCRIPTION
The ContextService was a singleton, so its cheerio render buffer
   (cheerioBody, title, ...) was shared across all concurrent renderPage /
   renderSlides calls. Because rendering is async with multiple await points,
   overlapping requests for the same page interleaved on the one shared DOM and
   each continuation prepended its own `<h1 class="titlePage">` and
   `<div id="reading-progress">` node -> N concurrent requests produced up to N
   duplicated titles and progress bars in a single response.
   
addTheme applied the theme via a DOMContentLoaded-gated, deferred module
   script appended at the end of <body>. The page painted with the light :root
   defaults first and only flipped to dark after full parse -> a visible
   light->dark flash on every load (and on each theme switch, which reloads the
   iframe).

   - Known theme (dark/light): set data-theme directly on <html> server-side so
     CSS matches on the first paint; a tiny synchronous script only persists the
     preference to localStorage.
   - No theme param: emit a blocking inline <head> script that resolves the
     stored theme before the body paints.
   - Drop the DOMContentLoaded wrapper and type="module" deferral.

   Also make jest globals resolve in the editor: include tests/unit in the root
   tsconfig (previously the whole tests dir was excluded, so VS Code used an
   inferred project without @types/jest) and add "node" to types; add the
   matching eslint-disable in tests/setup.ts. Build is unaffected — nest build
   uses tsconfig.build.json, which still excludes tests and specs.