### PR TITLE
 fix(jira-snapshot): resolve Xray defect keys and merge step-level defects/evidence (WEB-2475)

### DIFF
--- a/src/jira/jira.service.ts
+++ b/src/jira/jira.service.ts
@@ -579,6 +579,62 @@ export class JiraService {
   }
 
   /**
+   * @function getIssueKeysByIds Service
+   * @description Resolves a set of numeric Jira issue ids to their issue keys.
+   * The Xray API returns defects as raw Jira issue ids; this turns them into the
+   * human-readable keys (e.g. ARM-3926) expected in the "Defects" column. Fails
+   * gracefully by returning an empty map so a rendering step never breaks because
+   * an id could not be resolved.
+   * @param issueIds {string[]} the numeric Jira issue ids to resolve
+   * @return Promise {Record<string, string>} a map of issue id -> issue key
+   */
+  async getIssueKeysByIds(issueIds: string[]): Promise<Record<string, string>> {
+    this.init();
+    const uniqueIds = Array.from(new Set((issueIds ?? []).map((id) => String(id ?? '')).filter(Boolean)));
+    const keysById: Record<string, string> = {};
+    if (uniqueIds.length === 0) {
+      return keysById;
+    }
+    // The bulk fetch endpoint accepts up to 100 issues per request.
+    const chunkSize = 100;
+    const chunks: string[][] = [];
+    for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+      chunks.push(uniqueIds.slice(i, i + chunkSize));
+    }
+    try {
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          const response = await firstValueFrom(
+            this.http.post(
+              `${this.baseUrl}/rest/api/3/issue/bulkfetch`,
+              { fields: ['key'], issueIdsOrKeys: chunk },
+              {
+                auth: { username: this.apiUsername, password: this.apiToken },
+                headers: { 'Content-Type': 'application/json' },
+              },
+            ),
+          );
+          (response.data?.issues ?? []).forEach((issue) => {
+            if (issue?.id && issue?.key) {
+              keysById[String(issue.id)] = issue.key;
+            }
+          });
+        }),
+      );
+      this.logger.log(`Resolved ${Object.keys(keysById).length}/${uniqueIds.length} Jira issue keys by id`);
+    } catch (error) {
+      this.logger.error({
+        msg: 'HTTP request error in getIssueKeysByIds',
+        message: error.message,
+        response: error.response
+          ? { status: error.response.status, data: error.response.data }
+          : undefined,
+      });
+    }
+    return keysById;
+  }
+
+  /**
    * @function findProjectVersions Service
    * @description Returns the list of project versions.
    * @return Promise {any}

--- a/src/proxy-page/steps/addJiraSnapshot.ts
+++ b/src/proxy-page/steps/addJiraSnapshot.ts
@@ -172,12 +172,20 @@ export default (
         const usersById = await jiraService
           .getUsersByAccountIds(accountIds)
           .catch(() => ({}));
+        // Xray returns defects as raw Jira issue ids (at the run and/or step
+        // level); resolve them to issue keys in a single batched call so the
+        // "Defects" column shows keys (e.g. ARM-3926) instead of numeric ids.
+        const defectIds = filteredRuns.flatMap((run) => collectDefectIds(run));
+        // eslint-disable-next-line no-await-in-loop
+        const defectsById = await jiraService
+          .getIssueKeysByIds(defectIds)
+          .catch(() => ({}));
         parentTests.forEach((test) => {
           const testRuns = runsByTest[test?.id] ?? [];
           jiraIssues.push({
             issues: {
               issues: Promise.resolve(
-                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain, usersById, basePath),
+                mapTestRunsToIssues(testRuns, test?.key, confluenceDomain, usersById, basePath, defectsById),
               ),
             },
           });
@@ -377,12 +385,38 @@ function filterTestRunsByEnvironment(runs: XrayTestRun[], levelJql: string): Xra
 // keyed by the macro's XRAY column ids (see XRAY_TESTRUN_FIELDS) so they render
 // through the same fieldFunctions / columnConfig as Jira issues. All supported
 // columns are populated; the grid only renders the ones the macro configured.
+// Collects the defect Jira issue ids attached to a run, from both the run level
+// and the individual test steps (deduplicated). Xray attaches defects at either
+// level depending on how the test was executed.
+function collectDefectIds(run: XrayTestRun): string[] {
+  const runDefects = run?.defects ?? [];
+  const stepDefects = (run?.steps ?? []).flatMap((step) => step?.defects ?? []);
+  return Array.from(new Set([...runDefects, ...stepDefects].filter(Boolean)));
+}
+
+// Collects the evidence attached to a run, from both the run level and the
+// individual test steps, deduplicated by evidence id (falling back to filename).
+function collectEvidence(run: XrayTestRun): { id?: string; filename?: string; downloadLink?: string }[] {
+  const runEvidence = run?.evidence ?? [];
+  const stepEvidence = (run?.steps ?? []).flatMap((step) => step?.evidence ?? []);
+  const seen = new Set<string>();
+  return [...runEvidence, ...stepEvidence].filter((evidence) => {
+    const dedupeKey = evidence?.id || evidence?.downloadLink || evidence?.filename;
+    if (!dedupeKey || seen.has(dedupeKey)) {
+      return false;
+    }
+    seen.add(dedupeKey);
+    return true;
+  });
+}
+
 function mapTestRunsToIssues(
   runs: XrayTestRun[],
   testKeyFallback: string,
   baseUrl: string,
   usersById: Record<string, { accountId: string; displayName: string; emailAddress: string; self: string }> = {},
   webBasePath = '',
+  defectsById: Record<string, string> = {},
 ) {
   // Builds the `user`-typed data (an array of User objects) expected by
   // formatUser. Falls back to showing the raw account id when the user could
@@ -441,7 +475,13 @@ function mapTestRunsToIssues(
           }]
           : [],
         fixversions: fixVersions,
-        defects: (run?.defects ?? []).map((defect) => ({ id: '', key: defect, self: `${baseUrl}/browse/${defect}` })),
+        // Defects come from the run and/or its steps and are returned by Xray as
+        // Jira issue ids; show the resolved key (e.g. ARM-3926) and link to it,
+        // falling back to the id when it could not be resolved.
+        defects: collectDefectIds(run).map((defectId) => {
+          const defectKey = defectsById?.[defectId] || defectId;
+          return { id: defectId, key: defectKey, self: `${baseUrl}/browse/${defectKey}` };
+        }),
         // Xray Test Runs are not Jira issues and have no public deep link, so we
         // link to the Test Execution issue that contains the run.
         testrunlinkcloud: execKey ? [{ name: execKey, link: `${baseUrl}/browse/${execKey}?src=confmacro` }] : [],
@@ -458,7 +498,7 @@ function mapTestRunsToIssues(
         // Xray attachment URLs (`evidence.downloadLink`) require a bearer token
         // and are not browsable directly, so we point at konviw's proxy route
         // (`/api/xray/attachments/:id`) which fetches the bytes server-side.
-        evidences: (run?.evidence ?? []).map((evidence) => ({
+        evidences: collectEvidence(run).map((evidence) => ({
           name: evidence?.filename ?? evidence?.id ?? 'evidence',
           link: evidence?.id
             ? `${webBasePath}/api/xray/attachments/${evidence.id}`

--- a/src/xray/xray.service.ts
+++ b/src/xray/xray.service.ts
@@ -17,6 +17,14 @@ export interface XrayEvidence {
   downloadLink?: string;
 }
 
+export interface XrayTestRunStep {
+  id?: string;
+  // Defects (Jira issue ids) and evidence can be attached at the step level
+  // rather than the run level (e.g. manual tests), so we collect both.
+  defects?: string[];
+  evidence?: XrayEvidence[];
+}
+
 export interface XrayTestRun {
   id: string;
   status?: { name?: string; color?: string; description?: string };
@@ -42,11 +50,15 @@ export interface XrayTestRun {
   // Account ids of the executor / assignee; resolved to display names later.
   executedById?: string;
   assigneeId?: string;
+  // Run-level defects (Jira issue ids). Defects may also live on the steps.
   defects?: string[];
   comment?: string;
   gherkin?: string;
   unstructured?: string;
+  // Run-level evidence. Evidence may also live on the steps.
   evidence?: XrayEvidence[];
+  // Manual test steps, each of which can carry its own defects and evidence.
+  steps?: XrayTestRunStep[];
 }
 
 // Xray caps the `limit` argument of GraphQL connections at 100.
@@ -271,6 +283,10 @@ export class XrayService {
           gherkin
           unstructured
           evidence { id filename downloadLink }
+          steps {
+            defects
+            evidence { id filename downloadLink }
+          }
         }
       }
     }`;

--- a/tests/unit/jira/jira.service.spec.ts
+++ b/tests/unit/jira/jira.service.spec.ts
@@ -81,3 +81,76 @@ describe('jira.service / getUsersByAccountIds', () => {
     expect(users).toEqual({});
   });
 });
+
+describe('jira.service / getIssueKeysByIds', () => {
+  let jiraService: JiraService;
+  let httpService: { get: jest.Mock; post: jest.Mock };
+
+  const buildService = async () => {
+    httpService = { get: jest.fn(), post: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ load: [configuration] })],
+      providers: [
+        JiraService,
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+    jiraService = module.get<JiraService>(JiraService);
+  };
+
+  const issuesResponse = (issues: any[]) => of({ data: { issues } });
+
+  it('resolves numeric issue ids to a map keyed by id', async () => {
+    await buildService();
+    httpService.post.mockReturnValueOnce(issuesResponse([
+      { id: '9535271', key: 'ARM-3951' },
+      { id: '9556906', key: 'ARM-3969' },
+    ]));
+
+    const keys = await jiraService.getIssueKeysByIds(['9535271', '9556906']);
+
+    expect(keys['9535271']).toBe('ARM-3951');
+    expect(keys['9556906']).toBe('ARM-3969');
+    const [url, body] = httpService.post.mock.calls[0];
+    expect(String(url)).toContain('/rest/api/3/issue/bulkfetch');
+    expect(body.issueIdsOrKeys).toEqual(['9535271', '9556906']);
+    expect(body.fields).toEqual(['key']);
+  });
+
+  it('dedupes duplicate ids and ignores falsy values', async () => {
+    await buildService();
+    httpService.post.mockReturnValueOnce(issuesResponse([{ id: '1', key: 'ARM-1' }]));
+
+    await jiraService.getIssueKeysByIds(['1', '1', '', null as any, undefined as any]);
+
+    expect(httpService.post).toHaveBeenCalledTimes(1);
+    expect(httpService.post.mock.calls[0][1].issueIdsOrKeys).toEqual(['1']);
+  });
+
+  it('returns an empty map without calling the API when there are no ids', async () => {
+    await buildService();
+    const keys = await jiraService.getIssueKeysByIds([]);
+    expect(keys).toEqual({});
+    expect(httpService.post).not.toHaveBeenCalled();
+  });
+
+  it('splits requests into chunks of 100 issue ids', async () => {
+    await buildService();
+    httpService.post.mockReturnValue(issuesResponse([]));
+    const ids = Array.from({ length: 101 }, (_, i) => `${i}`);
+
+    await jiraService.getIssueKeysByIds(ids);
+
+    // 101 unique ids -> two chunks (100 + 1).
+    expect(httpService.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades gracefully to an empty map when the API fails', async () => {
+    await buildService();
+    httpService.post.mockReturnValueOnce(throwError(() => new Error('boom')));
+
+    const keys = await jiraService.getIssueKeysByIds(['1']);
+
+    expect(keys).toEqual({});
+  });
+});

--- a/tests/unit/steps/addJiraSnapshot.edge.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.edge.spec.ts
@@ -35,6 +35,15 @@ class ConfigurableJiraServiceMock {
       return acc;
     }, {} as Record<string, any>);
   }
+
+  // Resolves defect Jira issue ids to keys via the same `directory` map (values
+  // that are strings are treated as keys); unknown ids are left unresolved.
+  async getIssueKeysByIds(issueIds: string[]) {
+    return (issueIds ?? []).reduce((acc, id) => {
+      if (typeof this.directory[id] === 'string') acc[id] = this.directory[id];
+      return acc;
+    }, {} as Record<string, string>);
+  }
 }
 
 class ConfigurableXrayServiceMock {

--- a/tests/unit/steps/addJiraSnapshot.spec.ts
+++ b/tests/unit/steps/addJiraSnapshot.spec.ts
@@ -41,6 +41,18 @@ class JiraServiceMock {
       return acc;
     }, {} as Record<string, any>);
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getIssueKeysByIds(issueIds: string[]) {
+    const directory = {
+      '90001': 'TRACK4-BUG-1',
+      '90002': 'TRACK4-BUG-2',
+    };
+    return (issueIds ?? []).reduce((acc, id) => {
+      if (directory[id]) acc[id] = directory[id];
+      return acc;
+    }, {} as Record<string, string>);
+  }
 }
 
 class XrayServiceMock {
@@ -66,11 +78,21 @@ class XrayServiceMock {
         testVersion: { id: 2, name: 'v2' },
         executedById: 'account-executor',
         assigneeId: 'account-assignee',
-        defects: ['TRACK4-BUG-1'],
+        // Xray returns defects as raw Jira issue ids at the run level ...
+        defects: ['90001'],
         comment: 'run comment',
         gherkin: 'Given a step',
         unstructured: 'do the thing',
         evidence: [{ id: 'ev1', filename: 'screenshot.png', downloadLink: 'https://files/screenshot.png' }],
+        // ... and can also attach defects / evidence at the step level, which
+        // must be merged into the run's Defects / Evidences columns.
+        steps: [
+          {
+            id: 'step-1',
+            defects: ['90002'],
+            evidence: [{ id: 'ev2', filename: 'step-evidence.png', downloadLink: 'https://files/step.png' }],
+          },
+        ],
       },
     ];
   }
@@ -152,7 +174,12 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     expect(html).toContain('PASSED');
     expect(html).toContain('TRACK4-EXEC-1');
     expect(html).toContain('Track4 2.0.1');
-    expect(html).toContain('TRACK4-BUG-1');
+    // Defects: raw Jira issue ids returned by Xray must be resolved to keys ...
+    expect(html).toContain('TRACK4-BUG-1'); // run-level defect id 90001 -> key
+    expect(html).toContain('TRACK4-BUG-2'); // step-level defect id 90002 -> key (merged)
+    // ... and the raw numeric ids must not be shown.
+    expect(html).not.toContain('90001');
+    expect(html).not.toContain('90002');
     expect(html).toContain('Test Environments');
     expect(html).toContain('Staging');
     // New columns fixed as part of WEB-2475 Kevin feedback.
@@ -161,10 +188,12 @@ describe('Confluence Proxy / addJiraSnapshot', () => {
     expect(html).toContain('Bob Assignee'); // assignee resolved to name
     expect(html).toContain('v2'); // testversion
     expect(html).toContain('run comment'); // comment via synthetic string field
-    expect(html).toContain('screenshot.png'); // evidences
+    expect(html).toContain('screenshot.png'); // run-level evidence
+    expect(html).toContain('step-evidence.png'); // step-level evidence (merged)
     // Evidence links must go through konviw's Xray attachment proxy, not the
     // raw (unauthenticated, 404-ing) Xray downloadLink.
     expect(html).toContain('/api/xray/attachments/ev1');
+    expect(html).toContain('/api/xray/attachments/ev2'); // step-level evidence proxied too
     expect(html).not.toContain('https://files/screenshot.png');
     // Image evidence is displayed inline as a thumbnail: the evidences column
     // uses the image formatter (the grid renders the <img> client-side from the

--- a/tests/unit/xray/xray.service.spec.ts
+++ b/tests/unit/xray/xray.service.spec.ts
@@ -59,6 +59,10 @@ describe('xray.service', () => {
     expect(graphqlCall[0]).toContain('/graphql');
     expect(graphqlCall[2].headers.Authorization).toBe('Bearer a-bearer-token');
     expect(graphqlCall[1].query).toContain('testIssueIds: ["20001", "20002"]');
+    // Defects / evidence can live on the steps, so the query must fetch them
+    // (WEB-2475 Kevin feedback: missing defects / evidences on some runs).
+    expect(graphqlCall[1].query).toContain('steps');
+    expect(graphqlCall[1].query).toMatch(/steps\s*{[\s\S]*defects[\s\S]*evidence/);
   });
 
   it('paginates beyond the 100-item page limit', async () => {


### PR DESCRIPTION
## Summary

Follow-up fixes for the Xray Test Run columns (WEB-2475), addressing review feedback from Kevin:

- **Defects show issue key, not id** — Xray returns defects as raw Jira issue ids (e.g. `9535271`). A new `JiraService.getIssueKeysByIds()` bulk-resolves ids → keys via the Jira `bulkfetch` endpoint, so the Defects column now shows keys (e.g. `ARM-3951`) and links to them.
- **Missing defects on some runs** — defects can be attached at the test **step** level, not just the run level. The GraphQL query now also fetches `steps { defects }`, and the mapper merges run- and step-level defects (deduplicated).
- **Missing evidences on some runs** — same root cause: evidence lives on `steps[].evidence`. The query now fetches `steps { evidence }`, and the mapper merges run- and step-level evidence (deduplicated by id).

## Changes

- `src/xray/xray.service.ts` — add `steps { defects evidence }` to the `getTestRuns` query; new `XrayTestRunStep` type.
- `src/jira/jira.service.ts` — new `getIssueKeysByIds()` (chunked `bulkfetch`, graceful fallback).
- `src/proxy-page/steps/addJiraSnapshot.ts` — `collectDefectIds` / `collectEvidence` helpers, defect id→key resolution, run+step merging.
- Tests: `tests/unit/{jira,xray}/*.spec.ts`, `tests/unit/steps/addJiraSnapshot*.spec.ts`.

## Verification

- Verified live against production Xray/Jira: `ARM-3926`→defect `ARM-3951`, `ARM-3948`→step defect `ARM-3969`; step-level evidence now included (383 unique evidence links on the test page); no raw numeric ids leak.
- Type-check ✅, lint ✅, unit tests **208/208** ✅, build ✅.

## Test plan

- [ ] Re-test on DEV: Defects column shows keys; ARM-3948 shows its defect and multiple evidences.