### PR TITLE
test: fix flaky fixLinks specs (live HTTP fetch causing CI timeouts)

### DIFF
--- a/tests/unit/steps/fixLinks.spec.ts
+++ b/tests/unit/steps/fixLinks.spec.ts
@@ -1,6 +1,8 @@
 import { ConfigService } from '@nestjs/config';
-import { ContextService } from '../../../src/context/context.service';
 import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { ContextService } from '../../../src/context/context.service';
 import fixLinks from '../../../src/proxy-page/steps/fixLinks';
 import { jiraMockServiceFactory } from '../mocks/jiraService';
 import { createModuleRefForStep } from './utils';
@@ -20,6 +22,17 @@ describe('ConfluenceProxy / fixLinks', () => {
 
     context.initPageContext('v2', 'XXX', '123456', 'dark');
   });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Stub the external metadata fetch so smart-link tests never hit the network.
+  const mockSmartLinkFetch = (html: string) => {
+    jest
+      .spyOn(http, 'get')
+      .mockReturnValue(of({ data: html } as AxiosResponse));
+  };
 
   it('should replace page absolute URLs', async () => {
     const step = fixLinks(config, http, jiraMockServiceFactory);
@@ -235,6 +248,7 @@ describe('ConfluenceProxy / fixLinks', () => {
   });
 
   it('should display data-appearance=inline links with a favicon', async () => {
+    mockSmartLinkFetch('<html><head><link rel="icon" href="/favicon.ico"><title>Example</title></head></html>');
     const step = fixLinks(config, http, jiraMockServiceFactory);
     const example =
     '<html><head></head><body>' +
@@ -247,6 +261,7 @@ describe('ConfluenceProxy / fixLinks', () => {
   });
 
   it('should display data-appearance=inline links without a favicon', async () => {
+    mockSmartLinkFetch('<html><head><link rel="icon" href="/favicon.ico"><title>Example</title></head></html>');
     const step = fixLinks(config, http, jiraMockServiceFactory);
     const example =
     '<html><head></head><body>' +
@@ -259,6 +274,7 @@ describe('ConfluenceProxy / fixLinks', () => {
   });
 
   it('should display data-appearance=card links as a card', async () => {
+    mockSmartLinkFetch('<html><head><link rel="icon" href="/favicon.ico"><title>Example</title><meta name="description" content="Example description"></head></html>');
     const step = fixLinks(config, http, jiraMockServiceFactory);
     const example =
     '<html><head></head><body>' +


### PR DESCRIPTION
## Summary

Follow-up to #687. The `fixLinks` unit tests for smart-link favicons/cards performed **real HTTP requests** to `github.com` and `google.com` to fetch page metadata. On CI these intermittently exceeded Jest's 5s timeout, failing the `Quality` check flakily:

```
● ConfluenceProxy / fixLinks › should display data-appearance=inline links with a favicon
  thrown: "Exceeded timeout of 5000 ms for a test."
```

This mocks `HttpService.get` in the three affected tests so they are deterministic and never touch the network.

## Changes

`tests/unit/steps/fixLinks.spec.ts`:
- Add a `mockSmartLinkFetch(html)` helper that stubs `HttpService.get` with a canned response (`jest.spyOn` + `of(...)`), and `afterEach(jest.restoreAllMocks)`.
- Apply it to the three tests that previously hit the network: inline-with-favicon, inline-without-favicon, and block card.

## Why not in #687

#687 was merged before this test fix landed on the branch, so `main` still carries the flaky test. This PR brings only that test change into `main`.

## Test plan

- [x] `tests/unit/steps/fixLinks.spec.ts` → 16/16 pass, offline
- [x] Full unit suite → 217/217 pass
- [x] `npm run lint` passes

Made with [Cursor](https://cursor.com)