### PR TITLE
fix (WEB-2452) : Render "Table Filters and Charts" macro (tables & charts) in Konviw

### DIFF
--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -31,6 +31,7 @@ import addJira from './steps/addJira';
 import addWebStatsTracker from './steps/addWebStatsTracker';
 import fixDrawioMacro from './steps/fixDrawio';
 import fixChartMacro from './steps/fixChart';
+import fixTableChartMacro from './steps/fixTableChart';
 import fixRoadmap from './steps/fixRoadmap';
 import fixFrameAllowFullscreen from './steps/fixFrameAllowFullscreen';
 import fixImageSize from './steps/fixImageSize';
@@ -126,6 +127,7 @@ export class ProxyPageService {
     await fixEmojis(this.config, this.confluence)(context);
     fixDrawioMacro(this.config)(context);
     fixChartMacro(this.config)(context);
+    fixTableChartMacro()(context);
     fixExpander()(context);
     fixVideo()(context);
     // fixEmptyLineIncludePage()(this.context);
@@ -207,6 +209,7 @@ export class ProxyPageService {
     await fixEmojis(this.config, this.confluence)(context);
     fixDrawioMacro(this.config)(context);
     fixChartMacro(this.config)(context);
+    fixTableChartMacro()(context);
     fixExpander()(context);
     fixVideo()(context);
     fixEmptyLineIncludePage()(context);

--- a/src/proxy-page/steps/addUnsupportedMacroIndicator.ts
+++ b/src/proxy-page/steps/addUnsupportedMacroIndicator.ts
@@ -15,7 +15,6 @@ export default (): Step => (context: ContextService): void => {
   $(
     /* List of unsupported macros */
     `[data-macro-name="pagetree"],
-      [data-macro-name="table-chart"],
       [data-macro-name="pagetreesearch"]`,
   ).each((_: number, element: cheerio.Element) => {
     const thisBlock = $(element).html();

--- a/src/proxy-page/steps/fixTableChart.ts
+++ b/src/proxy-page/steps/fixTableChart.ts
@@ -35,6 +35,16 @@ type TableChartMacro = {
 };
 
 /**
+ * Decode HTML entities left untouched by cheerio's XML mode. Stiltsoft stores
+ * the aggregation/pieKeys separator as the named entity `&sbquo;` (U+201A), so
+ * without decoding the multi-column selections cannot be split correctly.
+ */
+const decodeEntities = (value: string): string => {
+  if (!value || value.indexOf('&') === -1) return value;
+  return cheerio.load(`<x>${value}</x>`, null, false)('x').text();
+};
+
+/**
  * Walk the storage XML and collect every `table-chart` macro in document order.
  * Confluence serializes `com.atlassian.confluence.macro.core` extensions as
  * classic `<ac:structured-macro ac:name="table-chart">` nodes whose parameters
@@ -54,7 +64,7 @@ const collectStorageTableChartMacros = (storageBody: string): TableChartMacro[] 
       .children(String.raw`ac\:parameter`)
       .each((_j, param) => {
         const name = $xml(param).attr('ac:name');
-        if (name) params[name] = $xml(param).text();
+        if (name) params[name] = decodeEntities($xml(param).text());
       });
 
     const tableHtml = $xml.html($el.find(String.raw`ac\:rich-text-body table`).first());

--- a/src/proxy-page/steps/fixTableChart.ts
+++ b/src/proxy-page/steps/fixTableChart.ts
@@ -1,0 +1,269 @@
+import * as cheerio from 'cheerio';
+import { Tabletojson } from 'tabletojson';
+import { Step } from '../proxy-page.step';
+import { ContextService } from '../../context/context.service';
+
+/**
+ * ### Proxy page step to render the "Table Filters and Charts for Confluence"
+ * (Stiltsoft) macro family, whose macros are stored under the `table-chart`
+ * extension key (`com.atlassian.confluence.macro.core`).
+ *
+ * These macros are Atlassian Connect *dynamic content macros*: Confluence only
+ * returns an empty iframe placeholder (`[data-macro-name="table-chart"]`) in the
+ * `body.view` format, so neither the source table nor the chart are visible in a
+ * Konviw rendition. The macro data (parameters + the source table) does live in
+ * the `body.storage` format though, so — exactly like the API v2 fallback in
+ * {@link fixDrawio} — we parse the storage body, correlate the macros to the
+ * view placeholders by document order and rebuild the output ourselves:
+ *
+ * - "Chart from Table" (a `type` parameter is present) is rendered as an
+ *   interactive ApexCharts chart. The source table is appended below the chart
+ *   unless the macro is configured to hide it (`hide=true`).
+ * - Any other variant (Table Filter, Pivot Table, ...) is rendered as its plain
+ *   source table so at least the tabular data is displayed.
+ *
+ * @returns void
+ */
+
+// Stiltsoft joins the selected aggregation columns / pie keys with a
+// SINGLE LOW-9 QUOTATION MARK (U+201A) instead of a regular comma.
+const AGGREGATION_SEPARATOR = '\u201A';
+
+type TableChartMacro = {
+  params: Record<string, string>;
+  tableHtml: string;
+};
+
+/**
+ * Walk the storage XML and collect every `table-chart` macro in document order.
+ * Confluence serializes `com.atlassian.confluence.macro.core` extensions as
+ * classic `<ac:structured-macro ac:name="table-chart">` nodes whose parameters
+ * live in `<ac:parameter>` children and whose data table lives in the
+ * `<ac:rich-text-body>`.
+ */
+const collectStorageTableChartMacros = (storageBody: string): TableChartMacro[] => {
+  if (!storageBody) return [];
+  const $xml = cheerio.load(storageBody, { xmlMode: true });
+  const macros: TableChartMacro[] = [];
+
+  $xml(String.raw`ac\:structured-macro[ac\:name="table-chart"]`).each((_i, el) => {
+    const $el = $xml(el);
+
+    const params: Record<string, string> = {};
+    $el
+      .children(String.raw`ac\:parameter`)
+      .each((_j, param) => {
+        const name = $xml(param).attr('ac:name');
+        if (name) params[name] = $xml(param).text();
+      });
+
+    const tableHtml = $xml.html($el.find(String.raw`ac\:rich-text-body table`).first());
+
+    macros.push({ params, tableHtml });
+  });
+
+  return macros;
+};
+
+/**
+ * Map the Stiltsoft chart `type` parameter to an ApexCharts type plus the
+ * horizontal/stacked modifiers.
+ */
+const resolveChartType = (
+  type: string,
+): { apexType: string; horizontal: boolean; stacked: boolean } => {
+  const value = (type ?? '').toLowerCase();
+  const stacked = value.startsWith('stacked');
+  if (value.includes('pie')) return { apexType: 'pie', horizontal: false, stacked: false };
+  if (value.includes('donut') || value.includes('doughnut')) {
+    return { apexType: 'donut', horizontal: false, stacked: false };
+  }
+  if (value.includes('area')) return { apexType: 'area', horizontal: false, stacked };
+  if (value.includes('line')) return { apexType: 'line', horizontal: false, stacked: false };
+  if (value.includes('bar')) return { apexType: 'bar', horizontal: true, stacked };
+  // "Column" / "Stacked Column" and anything unknown default to vertical bars
+  return { apexType: 'bar', horizontal: false, stacked };
+};
+
+const parseNumber = (raw: string): number => {
+  if (raw === undefined || raw === null) return 0;
+  // strip everything but digits, sign, decimal point and exponent markers
+  const cleaned = String(raw).replace(/[^0-9.eE+-]/g, '');
+  const value = Number.parseFloat(cleaned);
+  return Number.isFinite(value) ? value : 0;
+};
+
+const splitList = (raw: string): string[] => {
+  if (!raw) return [];
+  return raw
+    .split(new RegExp(`[${AGGREGATION_SEPARATOR},]`))
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+const legendOption = (legend: string): string => {
+  const value = (legend ?? '').toLowerCase();
+  if (value === 'false' || value === 'none' || value === 'off') {
+    return 'legend: { show: false },';
+  }
+  const position = ['top', 'right', 'bottom', 'left'].includes(value) ? value : 'bottom';
+  return `legend: { show: true, position: '${position}' },`;
+};
+
+/**
+ * Build the ApexCharts `<div>` + `<script>` for a chart macro from its already
+ * parsed data table. Returns an empty string when there is no usable data so the
+ * caller can fall back to rendering the plain table.
+ */
+const buildChart = (macro: TableChartMacro, index: number): string => {
+  const tables = Tabletojson.convert(macro.tableHtml);
+  const rows: Record<string, string>[] = tables[0] ?? [];
+  if (rows.length === 0) return '';
+
+  const headers = Object.keys(rows[0]);
+  if (headers.length < 2) return '';
+
+  const { params } = macro;
+  const { apexType, horizontal, stacked } = resolveChartType(params.type);
+  const isCircular = apexType === 'pie' || apexType === 'donut';
+  // Stiltsoft prints the value inside each bar segment / pie slice. Keep labels
+  // off for line charts only, where they would clutter the plot.
+  const showDataLabels = apexType !== 'line';
+
+  // The category column (X axis). Default to the first column.
+  const categoryColumn = headers.includes(params.column) ? params.column : headers[0];
+
+  // The value columns (series). Prefer the explicit aggregation selection and
+  // fall back to every column that is not the category column.
+  const requestedSeries = splitList(params.aggregation).filter((col) => headers.includes(col));
+  const seriesColumns = requestedSeries.length > 0
+    ? requestedSeries
+    : headers.filter((header) => header !== categoryColumn);
+  if (seriesColumns.length === 0) return '';
+
+  const categories = rows.map((row) => row[categoryColumn]);
+
+  const colors = splitList(params.colors);
+  const colorsOption = colors.length > 0 ? `colors: ${JSON.stringify(colors)},` : '';
+  const titleOption = params.title
+    ? `title: { text: ${JSON.stringify(params.title)}, align: 'center' },`
+    : '';
+
+  let seriesOption: string;
+  let labelsOrXaxis: string;
+
+  if (isCircular) {
+    const valueColumn = seriesColumns[0];
+    seriesOption = `series: ${JSON.stringify(rows.map((row) => parseNumber(row[valueColumn])))},`;
+    labelsOrXaxis = `labels: ${JSON.stringify(categories)},`;
+  } else {
+    const series = seriesColumns.map((column) => ({
+      name: column,
+      data: rows.map((row) => parseNumber(row[column])),
+    }));
+    seriesOption = `series: ${JSON.stringify(series)},`;
+    labelsOrXaxis = `xaxis: { categories: ${JSON.stringify(categories)} },`;
+  }
+
+  const options = `{
+    chart: { type: '${apexType}', height: 400, stacked: ${stacked}, toolbar: { show: false } },
+    plotOptions: { bar: { horizontal: ${horizontal}, borderRadius: 4, dataLabels: { position: 'center' } } },
+    ${colorsOption}
+    ${titleOption}
+    ${legendOption(params.legend)}
+    dataLabels: {
+      enabled: ${showDataLabels},
+      formatter: function (val) { return val === 0 ? '' : String(val); },
+      style: { fontSize: '12px', fontWeight: 600, colors: ['#172b4d'] },
+      background: { enabled: true, foreColor: '#ffffff', opacity: 0.7, borderWidth: 0, borderRadius: 2 },
+      dropShadow: { enabled: false },
+    },
+    ${seriesOption}
+    ${labelsOrXaxis}
+  }`;
+
+  return `<div class="konviw-table-chart" id="konviw-table-chart-${index}"></div>
+    <script type="module">
+      document.addEventListener('DOMContentLoaded', function () {
+        var chart${index} = new ApexCharts(
+          document.querySelector('#konviw-table-chart-${index}'),
+          ${options}
+        );
+        chart${index}.render();
+      });
+    </script>`;
+};
+
+/**
+ * Render the plain source table so at least the tabular data is displayed.
+ * Adds the Confluence table classes so the later table-related steps
+ * (addTableResponsive, fixTableSize, ...) pick it up.
+ */
+const buildTable = (macro: TableChartMacro): string => {
+  if (!macro.tableHtml) return '';
+  const $table = cheerio.load(macro.tableHtml, null, false);
+  $table('table').addClass('confluenceTable');
+  $table('th').addClass('confluenceTh');
+  $table('td').addClass('confluenceTd');
+  return `<div class="table-wrap">${$table.html()}</div>`;
+};
+
+export default (): Step => (context: ContextService): void => {
+  context.setPerfMark('fixTableChart');
+  const $ = context.getCheerioBody();
+
+  const placeholders = $('[data-macro-name="table-chart"]');
+  if (placeholders.length === 0) {
+    context.getPerfMeasure('fixTableChart');
+    return;
+  }
+
+  const macros = collectStorageTableChartMacros(context.getBodyStorage());
+  let needsApexCharts = false;
+
+  placeholders.each((index: number, element: cheerio.Element) => {
+    const macro = macros[index];
+    if (!macro) {
+      // No matching storage data: drop the empty placeholder to avoid leaking
+      // the unusable iframe stub into the rendition.
+      $(element).remove();
+      return;
+    }
+
+    const isChart = Boolean(macro.params.type);
+    let output = '';
+
+    if (isChart) {
+      const chart = buildChart(macro, index);
+      if (chart) {
+        needsApexCharts = true;
+        output = chart;
+        // The source table is a data source hidden by default; only show it
+        // when the macro is explicitly configured to keep it visible.
+        if (macro.params.hide !== 'true') {
+          output += buildTable(macro);
+        }
+      }
+    }
+
+    if (!output) {
+      // Table Filter / Pivot Table variants (or a chart without usable data):
+      // fall back to the plain source table.
+      output = buildTable(macro);
+    }
+
+    if (output) {
+      $(element).replaceWith(output);
+    } else {
+      $(element).remove();
+    }
+  });
+
+  if (needsApexCharts && $('script[data-konviw-apexcharts]').length === 0) {
+    $('body').append(
+      '<script defer data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>',
+    );
+  }
+
+  context.getPerfMeasure('fixTableChart');
+};

--- a/tests/unit/steps/fixTableChart.spec.ts
+++ b/tests/unit/steps/fixTableChart.spec.ts
@@ -216,9 +216,9 @@ describe('ConfluenceProxy / fixTableChart', () => {
 
   // Helper to render a single chart macro of a given type and return the
   // generated HTML (including the ApexCharts options script).
-  const renderChart = (type: string, extraParams = '', tableRows?: string): string => {
+  const renderChart = (type: string, extraParams = '', tableRows = ''): string => {
     const rows = tableRows
-      ?? `<tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th></tr>
+      || `<tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th></tr>
           <tr><td><p>May</p></td><td><p>2300</p></td><td><p>2900</p></td></tr>
           <tr><td><p>June</p></td><td><p>2400</p></td><td><p>3000</p></td></tr>`;
     const storage = `
@@ -333,6 +333,39 @@ describe('ConfluenceProxy / fixTableChart', () => {
 
     it('omits the title block when no title parameter is set', () => {
       expect(renderChart('Column')).not.toContain('title: { text:');
+    });
+  });
+
+  describe('Aggregation separator entity decoding (real storage regression)', () => {
+    // In the real body.storage the aggregation/pieKeys separator is stored as
+    // the HTML entity &sbquo; (U+201A), which cheerio's XML mode does NOT decode.
+    // The columns must still be split and kept in the configured order.
+    const stackedStorage = `
+      <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
+        <ac:parameter ac:name="type">Stacked Column</ac:parameter>
+        <ac:parameter ac:name="column">Month</ac:parameter>
+        <ac:parameter ac:name="aggregation">MCE&sbquo;Not Managed&sbquo;Central Jira</ac:parameter>
+        <ac:parameter ac:name="colors">#2484c1,#f6c342,#d04437</ac:parameter>
+        <ac:parameter ac:name="hide">true</ac:parameter>
+        <ac:rich-text-body>
+          <table>
+            <tbody>
+              <tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th><th><p>Central Jira</p></th></tr>
+              <tr><td><p>May</p></td><td><p>2300</p></td><td><p>2900</p></td><td><p>700</p></td></tr>
+            </tbody>
+          </table>
+        </ac:rich-text-body>
+      </ac:structured-macro>`;
+
+    it('splits the &sbquo; aggregation into the configured series order', () => {
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(stackedStorage);
+      fixTableChart()(context);
+
+      const html = context.getHtmlBody();
+      expect(html).toContain(
+        'series: [{"name":"MCE","data":[2900]},{"name":"Not Managed","data":[2300]},{"name":"Central Jira","data":[700]}]',
+      );
     });
   });
 

--- a/tests/unit/steps/fixTableChart.spec.ts
+++ b/tests/unit/steps/fixTableChart.spec.ts
@@ -1,0 +1,216 @@
+import { ContextService } from '../../../src/context/context.service';
+import fixTableChart from '../../../src/proxy-page/steps/fixTableChart';
+import { createModuleRefForStep } from './utils';
+
+// Stiltsoft joins the selected aggregation columns with U+201A (‚), not a comma.
+const SEP = '\u201A';
+
+// The view body Confluence returns for a Connect "Table Filters and Charts"
+// macro: only an empty iframe placeholder, no table nor chart.
+const viewHtml = `
+<html>
+  <body>
+    <div id="Content">
+      <h3>Chart from Table macro</h3>
+      <div class="conf-macro output-block ap-container" data-hasbody="true" data-macro-name="table-chart" data-macro-id="eb1c6cf8">
+        <iframe class="ap-iframe"></iframe>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+// The storage body holds the macro parameters and the source data table.
+const storageXml = `
+<ac:structured-macro ac:name="table-chart" ac:schema-version="1" ac:macro-id="eb1c6cf8">
+  <ac:parameter ac:name="type">Stacked Column</ac:parameter>
+  <ac:parameter ac:name="column">Month</ac:parameter>
+  <ac:parameter ac:name="aggregation">Not Managed${SEP}MCE${SEP}Central Jira</ac:parameter>
+  <ac:parameter ac:name="colors">#2484c1,#f6c342,#d04437</ac:parameter>
+  <ac:parameter ac:name="legend">right</ac:parameter>
+  <ac:parameter ac:name="hide">true</ac:parameter>
+  <ac:rich-text-body>
+    <table>
+      <tbody>
+        <tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th><th><p>Central Jira</p></th></tr>
+        <tr><td><p>May</p></td><td><p>2300</p></td><td><p>2900</p></td><td><p>700</p></td></tr>
+        <tr><td><p>June</p></td><td><p>2400</p></td><td><p>3000</p></td><td><p>750</p></td></tr>
+      </tbody>
+    </table>
+  </ac:rich-text-body>
+</ac:structured-macro>`;
+
+describe('ConfluenceProxy / fixTableChart', () => {
+  let context: ContextService;
+
+  beforeEach(async () => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    context.initPageContext('v2', 'XXX', '60616441914', 'dark');
+  });
+
+  describe('Chart from Table (hidden source table)', () => {
+    beforeEach(() => {
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(storageXml);
+      fixTableChart()(context);
+    });
+
+    it('replaces the placeholder iframe with an ApexCharts container', () => {
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(1);
+      expect($('iframe.ap-iframe').length).toBe(0);
+    });
+
+    it('builds a stacked bar chart with a series per aggregation column', () => {
+      const html = context.getHtmlBody();
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain('stacked: true');
+      expect(html).toContain('"name":"Not Managed"');
+      expect(html).toContain('"name":"MCE"');
+      expect(html).toContain('"name":"Central Jira"');
+      expect(html).toContain('"data":[2300,2400]');
+    });
+
+    it('uses the configured categories, colors and legend position', () => {
+      const html = context.getHtmlBody();
+      expect(html).toContain('categories: ["May","June"]');
+      expect(html).toContain('#2484c1');
+      expect(html).toContain("position: 'right'");
+    });
+
+    it('loads the ApexCharts library once', () => {
+      const $ = context.getCheerioBody();
+      expect($('script[data-konviw-apexcharts]').length).toBe(1);
+    });
+
+    it('hides the source table when hide=true', () => {
+      const $ = context.getCheerioBody();
+      expect($('table.confluenceTable').length).toBe(0);
+    });
+  });
+
+  describe('Chart from Table (visible source table)', () => {
+    it('renders both the chart and the source table when hide!=true', () => {
+      const storageVisible = storageXml.replace(
+        '<ac:parameter ac:name="hide">true</ac:parameter>',
+        '<ac:parameter ac:name="hide">false</ac:parameter>',
+      );
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(storageVisible);
+      fixTableChart()(context);
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(1);
+      expect($('table.confluenceTable').length).toBe(1);
+      expect($('table.confluenceTable').text()).toContain('May');
+    });
+  });
+
+  describe('Pie chart', () => {
+    it('emits labels and a flat series array for a pie chart', () => {
+      const pieStorage = `
+        <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
+          <ac:parameter ac:name="type">Pie</ac:parameter>
+          <ac:parameter ac:name="column">Instances</ac:parameter>
+          <ac:parameter ac:name="aggregation">Users</ac:parameter>
+          <ac:parameter ac:name="hide">true</ac:parameter>
+          <ac:rich-text-body>
+            <table>
+              <tbody>
+                <tr><th><p>Instances</p></th><th><p>Users</p></th></tr>
+                <tr><td><p>Not Managed</p></td><td><p>1500</p></td></tr>
+                <tr><td><p>MCE</p></td><td><p>2900</p></td></tr>
+                <tr><td><p>Central Jira</p></td><td><p>900</p></td></tr>
+              </tbody>
+            </table>
+          </ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(pieStorage);
+      fixTableChart()(context);
+
+      const html = context.getHtmlBody();
+      expect(html).toContain("type: 'pie'");
+      expect(html).toContain('series: [1500,2900,900]');
+      expect(html).toContain('labels: ["Not Managed","MCE","Central Jira"]');
+    });
+  });
+
+  describe('Table Filter / Pivot Table variants (no chart type)', () => {
+    it('renders the plain source table when the macro has no type', () => {
+      const filterStorage = `
+        <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
+          <ac:parameter ac:name="column">Month</ac:parameter>
+          <ac:rich-text-body>
+            <table>
+              <tbody>
+                <tr><th><p>Month</p></th><th><p>Value</p></th></tr>
+                <tr><td><p>May</p></td><td><p>2300</p></td></tr>
+              </tbody>
+            </table>
+          </ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(filterStorage);
+      fixTableChart()(context);
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect($('table.confluenceTable').length).toBe(1);
+      expect($('table.confluenceTable').text()).toContain('2300');
+      expect($('script[data-konviw-apexcharts]').length).toBe(0);
+    });
+  });
+
+  describe('Multiple macros correlated by document order', () => {
+    it('matches each placeholder with the storage macro at the same index', () => {
+      const twoPlaceholders = `
+        <html><body><div id="Content">
+          <div data-macro-name="table-chart"><iframe></iframe></div>
+          <p></p>
+          <div data-macro-name="table-chart"><iframe></iframe></div>
+        </div></body></html>`;
+      const twoMacros = `
+        <ac:structured-macro ac:name="table-chart">
+          <ac:parameter ac:name="type">Column</ac:parameter>
+          <ac:parameter ac:name="column">Month</ac:parameter>
+          <ac:parameter ac:name="aggregation">Value</ac:parameter>
+          <ac:parameter ac:name="hide">true</ac:parameter>
+          <ac:rich-text-body><table><tbody>
+            <tr><th><p>Month</p></th><th><p>Value</p></th></tr>
+            <tr><td><p>May</p></td><td><p>11</p></td></tr>
+          </tbody></table></ac:rich-text-body>
+        </ac:structured-macro>
+        <ac:structured-macro ac:name="table-chart">
+          <ac:parameter ac:name="type">Pie</ac:parameter>
+          <ac:parameter ac:name="column">City</ac:parameter>
+          <ac:parameter ac:name="aggregation">Sales</ac:parameter>
+          <ac:parameter ac:name="hide">true</ac:parameter>
+          <ac:rich-text-body><table><tbody>
+            <tr><th><p>City</p></th><th><p>Sales</p></th></tr>
+            <tr><td><p>Paris</p></td><td><p>42</p></td></tr>
+          </tbody></table></ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(twoPlaceholders);
+      context.setBodyStorage(twoMacros);
+      fixTableChart()(context);
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(2);
+      const html = context.getHtmlBody();
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain("type: 'pie'");
+    });
+  });
+
+  describe('No placeholders present', () => {
+    it('does nothing when the page has no table-chart macros', () => {
+      const plain = '<html><body><div id="Content"><p>hello</p></div></body></html>';
+      context.setHtmlBody(plain);
+      context.setBodyStorage('');
+      fixTableChart()(context);
+      expect(context.getHtmlBody()).toContain('hello');
+      expect(context.getCheerioBody()('script[data-konviw-apexcharts]').length).toBe(0);
+    });
+  });
+});

--- a/tests/unit/steps/fixTableChart.spec.ts
+++ b/tests/unit/steps/fixTableChart.spec.ts
@@ -213,4 +213,139 @@ describe('ConfluenceProxy / fixTableChart', () => {
       expect(context.getCheerioBody()('script[data-konviw-apexcharts]').length).toBe(0);
     });
   });
+
+  // Helper to render a single chart macro of a given type and return the
+  // generated HTML (including the ApexCharts options script).
+  const renderChart = (type: string, extraParams = '', tableRows?: string): string => {
+    const rows = tableRows
+      ?? `<tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th></tr>
+          <tr><td><p>May</p></td><td><p>2300</p></td><td><p>2900</p></td></tr>
+          <tr><td><p>June</p></td><td><p>2400</p></td><td><p>3000</p></td></tr>`;
+    const storage = `
+      <ac:structured-macro ac:name="table-chart">
+        <ac:parameter ac:name="type">${type}</ac:parameter>
+        <ac:parameter ac:name="column">Month</ac:parameter>
+        <ac:parameter ac:name="hide">true</ac:parameter>
+        ${extraParams}
+        <ac:rich-text-body><table><tbody>${rows}</tbody></table></ac:rich-text-body>
+      </ac:structured-macro>`;
+    context.setHtmlBody(viewHtml);
+    context.setBodyStorage(storage);
+    fixTableChart()(context);
+    return context.getHtmlBody();
+  };
+
+  describe('Data labels (WEB-2452 values on bars)', () => {
+    it('enables data labels for bar/column charts', () => {
+      expect(renderChart('Column')).toContain('enabled: true');
+    });
+
+    it('uses a readable dark label color with a background pill', () => {
+      const html = renderChart('Column');
+      expect(html).toContain("colors: ['#172b4d']");
+      expect(html).toContain('background: { enabled: true');
+    });
+
+    it('blanks out zero values so empty categories show no label', () => {
+      const html = renderChart('Column');
+      expect(html).toContain("return val === 0 ? '' : String(val);");
+    });
+
+    it('disables data labels for line charts to avoid clutter', () => {
+      expect(renderChart('Line')).toContain('enabled: false');
+    });
+
+    it('enables data labels for pie charts', () => {
+      const html = renderChart(
+        'Pie',
+        '',
+        `<tr><th><p>Month</p></th><th><p>Not Managed</p></th></tr>
+         <tr><td><p>May</p></td><td><p>2300</p></td></tr>`,
+      );
+      expect(html).toContain("type: 'pie'");
+      expect(html).toContain('enabled: true');
+    });
+  });
+
+  describe('Chart type mapping', () => {
+    it('renders "Bar" as a horizontal bar chart', () => {
+      const html = renderChart('Bar');
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain('horizontal: true');
+    });
+
+    it('renders "Column" as a vertical (non-horizontal) bar chart', () => {
+      const html = renderChart('Column');
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain('horizontal: false');
+      expect(html).toContain('stacked: false');
+    });
+
+    it('renders "Stacked Bar" as a horizontal stacked bar chart', () => {
+      const html = renderChart('Stacked Bar');
+      expect(html).toContain('horizontal: true');
+      expect(html).toContain('stacked: true');
+    });
+
+    it('renders "Area" as an area chart', () => {
+      expect(renderChart('Area')).toContain("type: 'area'");
+    });
+
+    it('renders "Donut" as a donut chart', () => {
+      const html = renderChart(
+        'Donut',
+        '',
+        `<tr><th><p>Month</p></th><th><p>Value</p></th></tr>
+         <tr><td><p>May</p></td><td><p>2300</p></td></tr>`,
+      );
+      expect(html).toContain("type: 'donut'");
+    });
+
+    it('defaults an unknown type to a vertical bar chart', () => {
+      const html = renderChart('SomethingWeird');
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain('horizontal: false');
+    });
+  });
+
+  describe('Legend option', () => {
+    it('hides the legend when legend=false', () => {
+      const html = renderChart('Column', '<ac:parameter ac:name="legend">false</ac:parameter>');
+      expect(html).toContain('legend: { show: false }');
+    });
+
+    it('positions the legend when a valid position is given', () => {
+      const html = renderChart('Column', '<ac:parameter ac:name="legend">top</ac:parameter>');
+      expect(html).toContain("position: 'top'");
+    });
+
+    it('falls back to a bottom legend for an unknown position value', () => {
+      const html = renderChart('Column', '<ac:parameter ac:name="legend">weird</ac:parameter>');
+      expect(html).toContain("position: 'bottom'");
+    });
+  });
+
+  describe('Title option', () => {
+    it('adds a chart title when the title parameter is set', () => {
+      const html = renderChart('Column', '<ac:parameter ac:name="title">My chart</ac:parameter>');
+      expect(html).toContain('title: { text: "My chart"');
+    });
+
+    it('omits the title block when no title parameter is set', () => {
+      expect(renderChart('Column')).not.toContain('title: { text:');
+    });
+  });
+
+  describe('Numeric parsing', () => {
+    it('strips thousands separators and spaces from numeric cells', () => {
+      const html = renderChart(
+        'Column',
+        '<ac:parameter ac:name="aggregation">Value</ac:parameter>',
+        `<tr><th><p>Month</p></th><th><p>Value</p></th></tr>
+         <tr><td><p>May</p></td><td><p>2,300</p></td></tr>
+         <tr><td><p>June</p></td><td><p>1 500</p></td></tr>`,
+      );
+      expect(html).toContain('"data":[2300,1500]');
+    });
+  });
 });


### PR DESCRIPTION
## WEB-2452 — Display tables and charts generated with the "Table Filters and Charts" macro

### Summary
Confluence pages that use the Stiltsoft **Table Filters and Charts for Confluence** macro family (`Chart from Table`, `Pivot Table`, `Table Filter`) rendered **blank** in Konviw — neither the chart nor the underlying data table were shown. This PR reconstructs and renders that output.

Example page from the ticket: *Test Table Filter and Charts for Confluence* (`pageId 60616441914`).

---

### Root Cause Analysis (RCA)
- The macro is stored under the extension key **`table-chart`** (`com.atlassian.confluence.macro.core`).
- It is an **Atlassian Connect *dynamic content* macro**. In `body.view`, Confluence returns only an **empty Connect iframe placeholder** (`[data-macro-name="table-chart"]`) — the app renders client-side inside that iframe, which never loads in a Konviw rendition. Confirmed against the real page: the view placeholder contains no table data.
- On top of that, Konviw's `addUnsupportedMacroIndicator` listed `table-chart` as **unsupported and actively removed it** from the DOM. Net effect: **nothing displayed**.

Key insight: the macro data (all parameters **and** the source data table) *is* present in the page's **`body.storage`** format, which Konviw already fetches (`context.getBodyStorage()`). This mirrors the API v2 fallback already used for draw.io in `fixDrawio`. Verified against the real storage body that both macros + tables parse correctly.

---

### Changes

**1. New step — `src/proxy-page/steps/fixTableChart.ts`**
- Parses the storage body, collecting every `<ac:structured-macro ac:name="table-chart">` in document order (parameters + `<ac:rich-text-body>` table).
- Correlates each storage macro to its `[data-macro-name="table-chart"]` view placeholder by document order and replaces the empty placeholder:
  - **Chart from Table** (has a `type` param) -> interactive **ApexCharts** chart.
    - Type mapping: `Pie`, `Donut`, `Line`, `Area`, `Column`->vertical bar, `Bar`->horizontal bar, `Stacked *`->stacked; unknown -> vertical bar.
    - Honors `column` (category axis), `aggregation` (series columns), `colors`, `legend`, `title`.
    - **Data labels** shown inside each bar/segment (dark `#172b4d` text on a translucent pill for readability; `0` blanked). Off for line charts.
    - Source table appended below the chart unless `hide=true`.
  - **Table Filter / Pivot Table** (no `type`) -> renders the **plain source table**.
  - Defensive numeric parsing (strips thousands separators/spaces).
  - **HTML entity decoding**: the aggregation/pieKeys separator is stored as `&sbquo;` (U+201A), which cheerio XML mode leaves undecoded; decoded so multi-column series split and keep their configured order.
  - ApexCharts library injected once per page.

**2. `src/proxy-page/proxy-page.service.ts`** — wired `fixTableChartMacro()` into both `renderPage` and `renderSlides`, after `fixChartMacro`.

**3. `src/proxy-page/steps/addUnsupportedMacroIndicator.ts`** — removed `table-chart` from the unsupported-macro list (now handled).

**4. Tests — `tests/unit/steps/fixTableChart.spec.ts`** — 28 unit tests incl. a regression test for the `&sbquo;` separator based on the real storage body.

---

### Test plan / Verification
- [x] `npm run test:unit` — **49 suites / 245 tests pass**.
- [x] `npm run build` — succeeds.
- [x] `npm run lint` — clean.
- [x] Verified end-to-end against the **real** page data (`pageId 60616441914`): 2 charts render, series decoded in the correct order (`MCE, Not Managed, Central Jira` stacked column; `[1500,2900,900]` pie), the `hide=false` source table is shown, and no placeholders leak.

### Notes / Follow-ups
- View-placeholder detection targets `[data-macro-name="table-chart"]`. If another Confluence instance emits a different wrapper, only that selector needs adjusting — storage parsing is unaffected.
- `Pivot Table` / `Table Filter` currently fall back to their source table; dedicated interactive rendering could be a future enhancement.