### PR TITLE
fix(macros): guard table-chart rendering against unexpected errors (WEB-2452)

### DIFF
--- a/src/proxy-page/steps/fixTableChart.ts
+++ b/src/proxy-page/steps/fixTableChart.ts
@@ -1,7 +1,10 @@
+import { Logger } from '@nestjs/common';
 import * as cheerio from 'cheerio';
 import { Tabletojson } from 'tabletojson';
 import { Step } from '../proxy-page.step';
 import { ContextService } from '../../context/context.service';
+
+const logger = new Logger('fixTableChart');
 
 /**
  * ### Proxy page step to render the "Table Filters and Charts for Confluence"
@@ -228,50 +231,58 @@ export default (): Step => (context: ContextService): void => {
     return;
   }
 
-  const macros = collectStorageTableChartMacros(context.getBodyStorage());
-  let needsApexCharts = false;
+  try {
+    const macros = collectStorageTableChartMacros(context.getBodyStorage());
+    let needsApexCharts = false;
 
-  placeholders.each((index: number, element: cheerio.Element) => {
-    const macro = macros[index];
-    if (!macro) {
-      // No matching storage data: drop the empty placeholder to avoid leaking
-      // the unusable iframe stub into the rendition.
-      $(element).remove();
-      return;
-    }
+    placeholders.each((index: number, element: cheerio.Element) => {
+      const macro = macros[index];
+      if (!macro) {
+        // No matching storage data: drop the empty placeholder to avoid leaking
+        // the unusable iframe stub into the rendition.
+        $(element).remove();
+        return;
+      }
 
-    const isChart = Boolean(macro.params.type);
-    let output = '';
+      const isChart = Boolean(macro.params.type);
+      let output = '';
 
-    if (isChart) {
-      const chart = buildChart(macro, index);
-      if (chart) {
-        needsApexCharts = true;
-        output = chart;
-        // The source table is a data source hidden by default; only show it
-        // when the macro is explicitly configured to keep it visible.
-        if (macro.params.hide !== 'true') {
-          output += buildTable(macro);
+      if (isChart) {
+        const chart = buildChart(macro, index);
+        if (chart) {
+          needsApexCharts = true;
+          output = chart;
+          // The source table is a data source hidden by default; only show it
+          // when the macro is explicitly configured to keep it visible.
+          if (macro.params.hide !== 'true') {
+            output += buildTable(macro);
+          }
         }
       }
-    }
 
-    if (!output) {
-      // Table Filter / Pivot Table variants (or a chart without usable data):
-      // fall back to the plain source table.
-      output = buildTable(macro);
-    }
+      if (!output) {
+        // Table Filter / Pivot Table variants (or a chart without usable data):
+        // fall back to the plain source table.
+        output = buildTable(macro);
+      }
 
-    if (output) {
-      $(element).replaceWith(output);
-    } else {
-      $(element).remove();
-    }
-  });
+      if (output) {
+        $(element).replaceWith(output);
+      } else {
+        $(element).remove();
+      }
+    });
 
-  if (needsApexCharts && $('script[data-konviw-apexcharts]').length === 0) {
-    $('body').append(
-      '<script defer data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>',
+    if (needsApexCharts && $('script[data-konviw-apexcharts]').length === 0) {
+      $('body').append(
+        '<script defer data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>',
+      );
+    }
+  } catch (error) {
+    // Never let an unexpected parsing/rendering error break the whole page:
+    // log it and leave the original placeholders untouched.
+    logger.error(
+      `Failed to render table-chart macro(s): ${(error as Error).message}`,
     );
   }
 


### PR DESCRIPTION
## Why

PR #689 (the initial `table-chart` support for the *Table Filters and Charts* Stiltsoft macro) is already merged into `main` and shipped as `chore(release): 3.55.0`, but the **dev environment has not picked up the new release**. This PR merges a small semantic (`fix:`) change to re-trigger semantic-release and the dev deployment pipeline.

## What

Rather than a no-op, this is a genuine robustness improvement: the `fixTableChart` step is now wrapped in a `try/catch`. If macro parsing or chart building ever throws unexpectedly, the error is logged and the page is served intact (placeholders left untouched) instead of the whole rendition failing.

## Test plan

- [x] `npx eslint src/proxy-page/steps/fixTableChart.ts` — clean
- [x] `npx jest tests/unit/steps/fixTableChart.spec.ts` — 28/28 pass
- [ ] Confirm semantic-release cuts a new version on merge and the dev deployment redeploys with the `table-chart` rendering visible

Made with [Cursor](https://cursor.com)