### PR TITLE
Fix iadc table responsiveness and add image zoom modal

### DIFF
--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -111,3 +111,44 @@ hr {
   clear: both;
   border-width: 0.5px;
 }
+
+// Lightbox for embedded images: clicking a thumbnail opens the full image in a
+// centered modal (90% of the viewport) instead of viewing it at its inline
+// size. Added by the addImageModal step.
+img.konviw-image-modal-zoomable {
+  cursor: zoom-in;
+}
+
+.konviw-image-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+
+  &.is-open {
+    display: flex;
+  }
+
+  .konviw-image-modal-img {
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .konviw-image-modal-close {
+    position: absolute;
+    top: 20px;
+    right: 32px;
+    color: #fff;
+    font-size: 40px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+}

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -111,3 +111,44 @@ hr {
   clear: both;
   border-width: 0.5px;
 }
+
+// Lightbox for embedded images: clicking a thumbnail opens the full image in a
+// centered modal (90% of the viewport) instead of viewing it at its inline
+// size. Added by the addImageModal step.
+img.konviw-image-modal-zoomable {
+  cursor: zoom-in;
+}
+
+.konviw-image-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+
+  &.is-open {
+    display: flex;
+  }
+
+  .konviw-image-modal-img {
+    max-width: 90vw;
+    max-height: 90vh;
+    object-fit: contain;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .konviw-image-modal-close {
+    position: absolute;
+    top: 20px;
+    right: 32px;
+    color: #fff;
+    font-size: 40px;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+}

--- a/src/assets/scss/iadc/_tables.scss
+++ b/src/assets/scss/iadc/_tables.scss
@@ -8,6 +8,20 @@ table.confluenceTable {
   margin-right: auto;
   table-layout: fixed;
 
+  // 'Large' tables to 100% of the layout width
+  &[data-konviw-table-size='large'] {
+    width: 100%;
+  }
+
+  // 'Small' tables may be centered
+  &[data-konviw-table-size='small'] {
+    &[data-layout='center'] {
+      margin-left: auto;
+      margin-right: auto;
+      table-layout: fixed;
+    }
+  }
+
   // Fix 'default' tables to 60% of the layout width
   &[data-layout='default'] {
     max-width: 100%;
@@ -202,5 +216,45 @@ table.tasks-report {
     text-align: left;
     padding: 0.2em 0.5em 0.2em 0.5em;
     vertical-align: top;
+  }
+}
+
+
+// Responsive Tables for small width devices ==============
+@media (max-width: 700px) {
+  tbody {
+    margin: 0;
+    border-spacing: 0;
+    padding-bottom: 1rem;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  th {
+    display: none;
+  }
+
+  tbody tr td {
+    display: block;
+    width: 95vw;
+    box-sizing: border-box;
+  }
+  tr td:not(:first-of-type):not(:last-of-type):not(:only-of-type) {
+    border-bottom: none;
+    border-top: none;
+  }
+
+  tr td:first-of-type:not(:only-of-type) {
+    border-bottom: none;
+  }
+
+  tr td:last-of-type:not(:only-of-type) {
+    border-top: none;
+  }
+
+  tr td::before {
+    content: attr(data-column-id) " " attr(data-lign-id);
+    font-weight: bold;
+    text-transform: capitalize;
   }
 }

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -56,6 +56,7 @@ import fixProfilePicture from './steps/fixProfilePicture';
 import fixEmbeddedFile from './steps/fixEmbeddedFile';
 import fixRecentlyUpdated from './steps/fixRecentlyUpdated';
 import addJiraSnapshot from './steps/addJiraSnapshot';
+import addImageModal from './steps/addImageModal';
 
 @Injectable()
 export class ProxyPageService {
@@ -153,6 +154,7 @@ export class ProxyPageService {
     addCustomCss(this.config, style)(context);
     addLibrariesCSS()(context);
     addZoom()(context);
+    addImageModal()(context);
     addTheme()(context);
     if (view !== 'iframe-resizer') {
       addScrollToTop()(context);

--- a/src/proxy-page/steps/addImageModal.ts
+++ b/src/proxy-page/steps/addImageModal.ts
@@ -1,0 +1,67 @@
+import * as cheerio from 'cheerio';
+import { ContextService } from '../../context/context.service';
+import { Step } from '../proxy-page.step';
+
+// Images that already open their own zoom/lightbox experience (drawio diagrams,
+// images explicitly marked '(zoom)' via addZoom) are excluded so a click does not
+// trigger two competing handlers. Emoticons and inline icons are excluded because
+// they are part of the text flow, not thumbnails meant to be viewed full-size.
+const MODAL_ZOOMABLE_IMAGE_SELECTOR = 'img'
+  + ':not(.emoticon)'
+  + ':not(.confluence-content-image-inline)'
+  + ':not(.drawio-zoomable)'
+  + ':not(.konviw-image-zoom-effect)';
+
+export default (): Step => (context: ContextService): void => {
+  context.setPerfMark('addImageModal');
+  const $ = context.getCheerioBody();
+
+  const zoomableImages = $(MODAL_ZOOMABLE_IMAGE_SELECTOR);
+
+  if (zoomableImages.length > 0) {
+    zoomableImages.each((_index: number, image: cheerio.Element) => {
+      $(image).addClass('konviw-image-modal-zoomable');
+    });
+
+    // The modal image is created client-side (not in the server HTML) so that
+    // earlier link/image steps (e.g. fixLinks, which hides <img> tags that have
+    // an empty src) cannot tamper with it before we set its src on click.
+    $('body').append(
+      '<div id="konviw-image-modal" class="konviw-image-modal" role="dialog" aria-modal="true" aria-label="Image preview">'
+      + '<button type="button" class="konviw-image-modal-close" aria-label="Close">&times;</button>'
+      + '</div>',
+    );
+    $('body').append(`<script defer>
+      document.addEventListener('DOMContentLoaded', function () {
+        var modal = document.getElementById('konviw-image-modal');
+        if (!modal) { return; }
+        var modalImg = document.createElement('img');
+        modalImg.className = 'konviw-image-modal-img';
+        modal.appendChild(modalImg);
+        var open = function (src, alt) {
+          modalImg.setAttribute('src', src);
+          modalImg.setAttribute('alt', alt || '');
+          modal.classList.add('is-open');
+        };
+        var close = function () {
+          modal.classList.remove('is-open');
+          modalImg.setAttribute('src', '');
+        };
+        document.addEventListener('click', function (e) {
+          var target = e.target;
+          if (target && target.classList && target.classList.contains('konviw-image-modal-zoomable')) {
+            e.preventDefault();
+            open(target.currentSrc || target.src, target.getAttribute('alt'));
+          } else if (target === modal || (target.classList && target.classList.contains('konviw-image-modal-close'))) {
+            close();
+          }
+        });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') { close(); }
+        });
+      });
+    </script>`);
+  }
+
+  context.getPerfMeasure('addImageModal');
+};


### PR DESCRIPTION
## Summary
- Ports the WEB-2507 dynamic table-width rules and mobile card-stack breakpoint into the `iadc` theme, which had been missing them since the original fix only touched the default theme's stylesheet.
- Adds a click-to-zoom lightbox for embedded images: clicking any image opens it centered in a modal at 90% of the viewport, closable via Escape or an outside click. Images with their own existing zoom behavior (drawio diagrams, `(zoom)`-marked images) and non-thumbnail images (emoticons, inline icons) are excluded to avoid conflicting click handlers.

## Why
- Pages rendered with `?style=iadc` never got dynamic table width or mobile responsiveness for tables, unlike the default theme.
- Embedded images (in or outside tables) were only viewable at their inline/thumbnail size, making it hard to read image content in tables and elsewhere.

## Test plan
- [x] `npm run scss` compiles cleanly and the new/updated CSS rules appear in all three theme bundles (default, iadc, opella).
- [x] `npx tsc --noEmit` and `eslint` pass on the changed TypeScript files.
- [x] Verified locally in the browser against real Confluence pages:
  - iadc-themed table renders with dynamic width and collapses into the mobile card layout under 700px.
  - Clicking a table image and a non-table image both open the centered zoom modal; Escape and outside-click close it; clicking the image itself does not close it.