### PR TITLE
fix(table-chart): render Jira-backed "Table Filter, Charts & Spreadsheets" macros

### DIFF
--- a/src/assets/scss/_macro-table-chart.scss
+++ b/src/assets/scss/_macro-table-chart.scss
@@ -1,0 +1,79 @@
+// Table Filter/Chart tab toggle ==============================
+// Lets the reader switch between a chart and its underlying table (or
+// between several charts) instead of always showing them stacked — see
+// fixTableChart.ts's `buildTabbedViews`.
+
+.konviw-tablechart-group {
+  margin: 8px 0;
+}
+
+.konviw-tablechart-tablist {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.65;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &.is-active {
+    opacity: 1;
+    border-bottom-color: var(--primary-color-link);
+    color: var(--primary-color-link);
+  }
+}
+
+.konviw-tablechart-panel {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
+// "Service Category ="-style filter dropdown above the chart/table tabs —
+// see fixTableChart.ts's `buildFilterBar`.
+.konviw-tablechart-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-filter-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: inherit;
+}
+
+.konviw-tablechart-filter {
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: var(--bg-color, #fff);
+  border: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  border-radius: 4px;
+  padding: 4px 8px;
+  max-width: 260px;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color-link);
+  }
+}

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -21,6 +21,7 @@
 @import 'macro-content-by-label';
 @import 'macro-roadmap';
 @import 'macro-jira';
+@import 'macro-table-chart';
 @import 'dark-theme';
 @import 'attachments';
 @import 'author-header';

--- a/src/assets/scss/iadc/_macro-table-chart.scss
+++ b/src/assets/scss/iadc/_macro-table-chart.scss
@@ -1,0 +1,79 @@
+// Table Filter/Chart tab toggle ==============================
+// Lets the reader switch between a chart and its underlying table (or
+// between several charts) instead of always showing them stacked — see
+// fixTableChart.ts's `buildTabbedViews`.
+
+.konviw-tablechart-group {
+  margin: 8px 0;
+}
+
+.konviw-tablechart-tablist {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.65;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &.is-active {
+    opacity: 1;
+    border-bottom-color: var(--primary-color-link);
+    color: var(--primary-color-link);
+  }
+}
+
+.konviw-tablechart-panel {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
+// "Service Category ="-style filter dropdown above the chart/table tabs —
+// see fixTableChart.ts's `buildFilterBar`.
+.konviw-tablechart-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-filter-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: inherit;
+}
+
+.konviw-tablechart-filter {
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: var(--bg-color, #fff);
+  border: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  border-radius: 4px;
+  padding: 4px 8px;
+  max-width: 260px;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color-link);
+  }
+}

--- a/src/assets/scss/iadc/custom.scss
+++ b/src/assets/scss/iadc/custom.scss
@@ -20,6 +20,7 @@
 @import 'macro-content-by-label';
 @import 'macro-roadmap';
 @import 'macro-jira';
+@import 'macro-table-chart';
 @import 'dark-theme';
 @import 'attachments';
 @import 'author-header';

--- a/src/assets/scss/opella/_macro-table-chart.scss
+++ b/src/assets/scss/opella/_macro-table-chart.scss
@@ -1,0 +1,79 @@
+// Table Filter/Chart tab toggle ==============================
+// Lets the reader switch between a chart and its underlying table (or
+// between several charts) instead of always showing them stacked — see
+// fixTableChart.ts's `buildTabbedViews`.
+
+.konviw-tablechart-group {
+  margin: 8px 0;
+}
+
+.konviw-tablechart-tablist {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.65;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &.is-active {
+    opacity: 1;
+    border-bottom-color: var(--primary-color-link);
+    color: var(--primary-color-link);
+  }
+}
+
+.konviw-tablechart-panel {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
+// "Service Category ="-style filter dropdown above the chart/table tabs —
+// see fixTableChart.ts's `buildFilterBar`.
+.konviw-tablechart-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.konviw-tablechart-filter-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: inherit;
+}
+
+.konviw-tablechart-filter {
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: var(--bg-color, #fff);
+  border: 1px solid var(--border-color, rgba(9, 30, 66, 0.13));
+  border-radius: 4px;
+  padding: 4px 8px;
+  max-width: 260px;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color-link);
+  }
+}

--- a/src/assets/scss/opella/custom.scss
+++ b/src/assets/scss/opella/custom.scss
@@ -22,6 +22,7 @@
 @import '../macro-content-by-label';
 @import '../macro-roadmap';
 @import 'macro-jira';
+@import 'macro-table-chart';
 @import 'dark-theme';
 @import 'attachments';
 @import 'author-header';

--- a/src/proxy-page/proxy-page.service.ts
+++ b/src/proxy-page/proxy-page.service.ts
@@ -128,7 +128,7 @@ export class ProxyPageService {
     await fixEmojis(this.config, this.confluence)(context);
     fixDrawioMacro(this.config)(context);
     fixChartMacro(this.config)(context);
-    fixTableChartMacro()(context);
+    await fixTableChartMacro(this.config, this.jira)(context);
     fixExpander()(context);
     fixVideo()(context);
     // fixEmptyLineIncludePage()(this.context);
@@ -211,7 +211,7 @@ export class ProxyPageService {
     await fixEmojis(this.config, this.confluence)(context);
     fixDrawioMacro(this.config)(context);
     fixChartMacro(this.config)(context);
-    fixTableChartMacro()(context);
+    await fixTableChartMacro(this.config, this.jira)(context);
     fixExpander()(context);
     fixVideo()(context);
     fixEmptyLineIncludePage()(context);

--- a/src/proxy-page/steps/fixTableChart.ts
+++ b/src/proxy-page/steps/fixTableChart.ts
@@ -1,31 +1,44 @@
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
 import { Tabletojson } from 'tabletojson';
 import { Step } from '../proxy-page.step';
 import { ContextService } from '../../context/context.service';
+import { JiraService } from '../../jira/jira.service';
+import * as tableProcessorJira from '../utils/tableProcessorJira';
 
 const logger = new Logger('fixTableChart');
 
 /**
  * ### Proxy page step to render the "Table Filters and Charts for Confluence"
- * (Stiltsoft) macro family, whose macros are stored under the `table-chart`
- * extension key (`com.atlassian.confluence.macro.core`).
+ * (Stiltsoft) macro family.
  *
  * These macros are Atlassian Connect *dynamic content macros*: Confluence only
- * returns an empty iframe placeholder (`[data-macro-name="table-chart"]`) in the
- * `body.view` format, so neither the source table nor the chart are visible in a
- * Konviw rendition. The macro data (parameters + the source table) does live in
- * the `body.storage` format though, so — exactly like the API v2 fallback in
- * {@link fixDrawio} — we parse the storage body, correlate the macros to the
- * view placeholders by document order and rebuild the output ourselves:
+ * returns an empty iframe placeholder in the `body.view` format, so neither the
+ * source table nor the chart are visible in a Konviw rendition. The macro data
+ * does live in the `body.storage` format though, so — exactly like the API v2
+ * fallback in {@link fixDrawio} — we parse the storage body, correlate the
+ * macros to the view placeholders by document order and rebuild the output
+ * ourselves. Two macro shapes are handled, under separate extension keys:
  *
- * - "Chart from Table" (a `type` parameter is present) is rendered as an
- *   interactive ApexCharts chart. The source table is appended below the chart
- *   unless the macro is configured to hide it (`hide=true`).
- * - Any other variant (Table Filter, Pivot Table, ...) is rendered as its plain
- *   source table so at least the tabular data is displayed.
+ * - `table-chart` (legacy): a flat `<ac:parameter>` list plus an inline
+ *   `<ac:rich-text-body><table>`. "Chart from Table" (a `type` parameter is
+ *   present) is rendered as an interactive ApexCharts chart with the source
+ *   table appended below unless configured to hide it (`hide=true`); any other
+ *   variant (Table Filter, Pivot Table, ...) is rendered as its plain source
+ *   table.
+ * - `table-processor` (current): config lives in a single JSON tree (the
+ *   `serialized` parameter) and the "table" is a live Jira search — the
+ *   `<ac:rich-text-body>` holds a Jira smart-link datasource card (JQL +
+ *   columns) instead of an inline `<table>`. We fetch the issues via
+ *   `JiraService`, aggregate them (count per category — see
+ *   {@link tableProcessorJira.aggregateByCategory}) for every `chart` node
+ *   found in the tree, and always render the underlying issues as a Grid.js
+ *   table below (reusing the same building blocks as `addJira.ts`'s
+ *   `data-datasource` handling, which can't see this card itself since it only
+ *   exists in the storage fallback body, never in the resolved view DOM).
  *
- * @returns void
+ * @returns Promise<void>
  */
 
 // Stiltsoft joins the selected aggregation columns / pie keys with a
@@ -35,6 +48,11 @@ const AGGREGATION_SEPARATOR = '\u201A';
 type TableChartMacro = {
   params: Record<string, string>;
   tableHtml: string;
+};
+
+type TableProcessorMacro = {
+  tree: tableProcessorJira.TableProcessorNode | null;
+  datasource: tableProcessorJira.JiraDatasource | null;
 };
 
 /**
@@ -73,6 +91,35 @@ const collectStorageTableChartMacros = (storageBody: string): TableChartMacro[] 
     const tableHtml = $xml.html($el.find(String.raw`ac\:rich-text-body table`).first());
 
     macros.push({ params, tableHtml });
+  });
+
+  return macros;
+};
+
+/**
+ * Walk the storage XML and collect every `table-processor` macro in document
+ * order (the current Stiltsoft extension key — see the file-level doc comment
+ * for how its shape differs from the legacy `table-chart` macros above).
+ */
+const collectStorageTableProcessorMacros = (storageBody: string): TableProcessorMacro[] => {
+  if (!storageBody) return [];
+  const $xml = cheerio.load(storageBody, { xmlMode: true });
+  const macros: TableProcessorMacro[] = [];
+
+  $xml(String.raw`ac\:structured-macro[ac\:name="table-processor"]`).each((_i, el) => {
+    const $el = $xml(el);
+
+    const serializedRaw = decodeEntities(
+      $el.children(String.raw`ac\:parameter[ac\:name="serialized"]`).text(),
+    );
+    const tree = tableProcessorJira.parseSerializedTree(serializedRaw);
+
+    const richTextBody = $el.find(String.raw`ac\:rich-text-body`).get(0);
+    const datasource = richTextBody
+      ? tableProcessorJira.extractJiraDatasource($xml, richTextBody)
+      : null;
+
+    macros.push({ tree, datasource });
   });
 
   return macros;
@@ -124,9 +171,69 @@ const legendOption = (legend: string): string => {
 };
 
 /**
- * Build the ApexCharts `<div>` + `<script>` for a chart macro from its already
- * parsed data table. Returns an empty string when there is no usable data so the
- * caller can fall back to rendering the plain table.
+ * Render the ApexCharts `<div>` + `<script>` shell shared by both the legacy
+ * table-driven chart and the Jira-count-driven chart: everything but the
+ * series/categories data (already computed by the caller) is identical.
+ */
+const renderChartMarkup = (
+  chartId: string,
+  params: Record<string, string>,
+  seriesOption: string,
+  labelsOrXaxisOption: string,
+): string => {
+  const { apexType, horizontal, stacked } = resolveChartType(params.type);
+  // Stiltsoft prints the value inside each bar segment / pie slice. Keep labels
+  // off for line charts only, where they would clutter the plot.
+  const showDataLabels = apexType !== 'line';
+
+  const colors = splitList(params.colors);
+  const colorsOption = colors.length > 0 ? `colors: ${JSON.stringify(colors)},` : '';
+  const titleOption = params.title
+    ? `title: { text: ${JSON.stringify(params.title)}, align: 'center' },`
+    : '';
+
+  const options = `{
+    chart: { type: '${apexType}', height: 400, stacked: ${stacked}, toolbar: { show: false } },
+    plotOptions: { bar: { horizontal: ${horizontal}, borderRadius: 4, dataLabels: { position: 'center' } } },
+    ${colorsOption}
+    ${titleOption}
+    ${legendOption(params.legend)}
+    dataLabels: {
+      enabled: ${showDataLabels},
+      formatter: function (val) { return val === 0 ? '' : String(val); },
+      style: { fontSize: '12px', fontWeight: 600, colors: ['#172b4d'] },
+      background: { enabled: true, foreColor: '#ffffff', opacity: 0.7, borderWidth: 0, borderRadius: 2 },
+      dropShadow: { enabled: false },
+    },
+    ${seriesOption}
+    ${labelsOrXaxisOption}
+  }`;
+
+  // The chart id may contain characters that aren't valid in a JS identifier
+  // (e.g. the `jira-0-0` ids used for table-processor charts), so the variable
+  // name is derived separately from the (HTML-id-safe) chartId.
+  const varName = `chart_${chartId.replace(/\W/g, '_')}`;
+
+  return `<div class="konviw-table-chart" id="konviw-table-chart-${chartId}"></div>
+    <script type="module">
+      document.addEventListener('DOMContentLoaded', function () {
+        var ${varName} = new ApexCharts(
+          document.querySelector('#konviw-table-chart-${chartId}'),
+          ${options}
+        );
+        ${varName}.render();
+        // Registered so a filter control elsewhere on the page (see the
+        // table-processor filter dropdown) can update this chart client-side.
+        window.konviwCharts = window.konviwCharts || {};
+        window.konviwCharts[${JSON.stringify(chartId)}] = ${varName};
+      });
+    </script>`;
+};
+
+/**
+ * Build the ApexCharts chart for a legacy `table-chart` macro from its already
+ * parsed data table. Returns an empty string when there is no usable data so
+ * the caller can fall back to rendering the plain table.
  */
 const buildChart = (macro: TableChartMacro, index: number): string => {
   const tables = Tabletojson.convert(macro.tableHtml);
@@ -137,11 +244,8 @@ const buildChart = (macro: TableChartMacro, index: number): string => {
   if (headers.length < 2) return '';
 
   const { params } = macro;
-  const { apexType, horizontal, stacked } = resolveChartType(params.type);
+  const { apexType } = resolveChartType(params.type);
   const isCircular = apexType === 'pie' || apexType === 'donut';
-  // Stiltsoft prints the value inside each bar segment / pie slice. Keep labels
-  // off for line charts only, where they would clutter the plot.
-  const showDataLabels = apexType !== 'line';
 
   // The category column (X axis). Default to the first column.
   const categoryColumn = headers.includes(params.column) ? params.column : headers[0];
@@ -155,12 +259,6 @@ const buildChart = (macro: TableChartMacro, index: number): string => {
   if (seriesColumns.length === 0) return '';
 
   const categories = rows.map((row) => row[categoryColumn]);
-
-  const colors = splitList(params.colors);
-  const colorsOption = colors.length > 0 ? `colors: ${JSON.stringify(colors)},` : '';
-  const titleOption = params.title
-    ? `title: { text: ${JSON.stringify(params.title)}, align: 'center' },`
-    : '';
 
   let seriesOption: string;
   let labelsOrXaxis: string;
@@ -178,33 +276,37 @@ const buildChart = (macro: TableChartMacro, index: number): string => {
     labelsOrXaxis = `xaxis: { categories: ${JSON.stringify(categories)} },`;
   }
 
-  const options = `{
-    chart: { type: '${apexType}', height: 400, stacked: ${stacked}, toolbar: { show: false } },
-    plotOptions: { bar: { horizontal: ${horizontal}, borderRadius: 4, dataLabels: { position: 'center' } } },
-    ${colorsOption}
-    ${titleOption}
-    ${legendOption(params.legend)}
-    dataLabels: {
-      enabled: ${showDataLabels},
-      formatter: function (val) { return val === 0 ? '' : String(val); },
-      style: { fontSize: '12px', fontWeight: 600, colors: ['#172b4d'] },
-      background: { enabled: true, foreColor: '#ffffff', opacity: 0.7, borderWidth: 0, borderRadius: 2 },
-      dropShadow: { enabled: false },
-    },
-    ${seriesOption}
-    ${labelsOrXaxis}
-  }`;
+  return renderChartMarkup(String(index), params, seriesOption, labelsOrXaxis);
+};
 
-  return `<div class="konviw-table-chart" id="konviw-table-chart-${index}"></div>
-    <script type="module">
-      document.addEventListener('DOMContentLoaded', function () {
-        var chart${index} = new ApexCharts(
-          document.querySelector('#konviw-table-chart-${index}'),
-          ${options}
-        );
-        chart${index}.render();
-      });
-    </script>`;
+/**
+ * Build the ApexCharts chart for a `table-processor` chart node from
+ * pre-aggregated categories/counts (see
+ * {@link tableProcessorJira.aggregateByCategory}). Returns an empty string
+ * when there are no categories so the caller can skip this chart.
+ */
+const buildJiraChart = (
+  params: Record<string, string>,
+  categories: string[],
+  counts: number[],
+  chartId: string,
+): string => {
+  if (categories.length === 0) return '';
+  const { apexType } = resolveChartType(params.type);
+  const isCircular = apexType === 'pie' || apexType === 'donut';
+  // The caller only reaches this point once `params.column` has already
+  // resolved to a real Jira field (see `resolveFieldId` at the call site), so
+  // it's always defined here.
+  const seriesName = params.aggregation || params.column;
+
+  const seriesOption = isCircular
+    ? `series: ${JSON.stringify(counts)},`
+    : `series: ${JSON.stringify([{ name: seriesName, data: counts }])},`;
+  const labelsOrXaxisOption = isCircular
+    ? `labels: ${JSON.stringify(categories)},`
+    : `xaxis: { categories: ${JSON.stringify(categories)} },`;
+
+  return renderChartMarkup(chartId, params, seriesOption, labelsOrXaxisOption);
 };
 
 /**
@@ -221,69 +323,471 @@ const buildTable = (macro: TableChartMacro): string => {
   return `<div class="table-wrap">${$table.html()}</div>`;
 };
 
-export default (): Step => (context: ContextService): void => {
-  context.setPerfMark('fixTableChart');
-  const $ = context.getCheerioBody();
+type TabView = { label: string; html: string };
 
-  const placeholders = $('[data-macro-name="table-chart"]');
-  if (placeholders.length === 0) {
-    context.getPerfMeasure('fixTableChart');
-    return;
+/**
+ * Readers only want to see one view at a time (a chart, or the table), not
+ * both stacked. When there's more than one usable view, wraps them in a tab
+ * toggle so the reader picks; falls straight through to the single view (no
+ * tab UI at all) when there's nothing to choose between.
+ */
+const buildTabbedViews = (views: TabView[]): { html: string; usedTabs: boolean } => {
+  const usableViews = views.filter((view) => view.html);
+  if (usableViews.length <= 1) {
+    return { html: usableViews[0]?.html ?? '', usedTabs: false };
   }
 
-  try {
-    const macros = collectStorageTableChartMacros(context.getBodyStorage());
-    let needsApexCharts = false;
+  const tabs = usableViews
+    .map((view, i) => `<button type="button" class="konviw-tablechart-tab${i === 0 ? ' is-active' : ''}">${view.label}</button>`)
+    .join('');
+  const panels = usableViews
+    .map((view, i) => `<div class="konviw-tablechart-panel${i === 0 ? ' is-active' : ''}">${view.html}</div>`)
+    .join('');
 
-    placeholders.each((index: number, element: cheerio.Element) => {
-      const macro = macros[index];
-      if (!macro) {
-        // No matching storage data: drop the empty placeholder to avoid leaking
-        // the unusable iframe stub into the rendition.
+  return {
+    html: `<div class="konviw-tablechart-group">
+      <div class="konviw-tablechart-tablist" role="tablist">${tabs}</div>
+      ${panels}
+    </div>`,
+    usedTabs: true,
+  };
+};
+
+// Injected once per page (guarded like the ApexCharts/Grid.js asset tags
+// below) when at least one macro rendered a tab toggle. Matches tabs to
+// panels by position within their `.konviw-tablechart-group`, so no ids are
+// needed. Re-dispatches `resize` after switching so ApexCharts (which sizes
+// itself off its container's width at render time) recomputes correctly when
+// its panel was hidden — and therefore zero-width — at initial page load.
+const TAB_TOGGLE_SCRIPT = `<script data-konviw-tablechart-toggle>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('click', function (event) {
+      var tab = event.target.closest && event.target.closest('.konviw-tablechart-tab');
+      if (!tab) return;
+      var group = tab.closest('.konviw-tablechart-group');
+      if (!group) return;
+      var tabs = Array.prototype.slice.call(group.querySelectorAll('.konviw-tablechart-tab'));
+      var panels = Array.prototype.slice.call(group.querySelectorAll('.konviw-tablechart-panel'));
+      var index = tabs.indexOf(tab);
+      tabs.forEach(function (t) { t.classList.remove('is-active'); });
+      panels.forEach(function (p) { p.classList.remove('is-active'); });
+      tab.classList.add('is-active');
+      if (panels[index]) panels[index].classList.add('is-active');
+      window.dispatchEvent(new Event('resize'));
+    });
+  });
+</script>`;
+
+/**
+ * Builds the `<select>` filter bar for a `table-processor` macro's `filter`
+ * root node (e.g. the "Service Category =" control on the real macro). The
+ * per-issue values/labels used to react to it are emitted separately by
+ * {@link buildFilterDataScript}.
+ */
+const escapeHtml = (value: string): string => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+const buildFilterBar = (label: string, options: string[], groupId: string): string => {
+  const optionTags = options
+    .map((option) => `<option value="${escapeHtml(option)}">${escapeHtml(option)}</option>`)
+    .join('');
+  return `<div class="konviw-tablechart-filter-bar">
+    <label class="konviw-tablechart-filter-label">${escapeHtml(label)}</label>
+    <select class="konviw-tablechart-filter" data-konviw-filter-group="${groupId}">
+      <option value="">All</option>
+      ${optionTags}
+    </select>
+  </div>`;
+};
+
+/**
+ * Embeds the per-issue raw data a filter change needs to re-aggregate the
+ * chart(s) and re-filter the table client-side, without re-fetching from
+ * Jira: the filter value per issue, each chart's own category value per
+ * issue (index-aligned with `values`), the already-formatted Grid.js rows
+ * (also index-aligned), and the Grid.js instance's id.
+ */
+const buildFilterDataScript = (
+  groupId: string,
+  values: string[],
+  charts: { id: string; categories: string[] }[],
+  tableRows: any[][],
+  gridId: string,
+): string => `<script data-konviw-tablechart-data="${groupId}">
+  window.konviwTableProcessorData = window.konviwTableProcessorData || {};
+  window.konviwTableProcessorData[${JSON.stringify(groupId)}] = ${JSON.stringify({
+  values, charts, tableRows, gridId,
+})};
+</script>`;
+
+// Injected once per page (guarded like the other shared assets) when at least
+// one macro rendered a filter dropdown. Re-aggregates every chart (preserving
+// first-seen category order, mirroring `aggregateByCategory` server-side) and
+// re-filters the Grid.js table from the payload `buildFilterDataScript` embeds,
+// entirely client-side — no re-fetch from Jira on filter change.
+/**
+ * The filter's core algorithm — which issues match the selected value, and
+ * the resulting category/count grouping — as ordinary functions with no
+ * closures over anything outside their own parameters. That makes them:
+ * (a) directly unit-testable here in Node, no DOM/browser needed, and
+ * (b) safe to inline into `FILTER_APPLY_SCRIPT` via `.toString()` below, so
+ * the code under test is exactly the code shipped to the browser (see
+ * `mirrors aggregateByCategory`'s first-seen-order grouping server-side).
+ */
+export function computeFilterMask(values: string[], selected: string): boolean[] {
+  return values.map((value) => selected === '' || value === selected);
+}
+
+export function recomputeCategoryCounts(
+  categories: string[],
+  mask: boolean[],
+): { order: string[]; counts: Record<string, number> } {
+  const order: string[] = [];
+  const counts: Record<string, number> = {};
+  categories.forEach((label, i) => {
+    if (!mask[i]) return;
+    if (!(label in counts)) {
+      order.push(label);
+      counts[label] = 0;
+    }
+    counts[label] += 1;
+  });
+  return { order, counts };
+}
+
+const FILTER_APPLY_SCRIPT = `<script data-konviw-tablechart-filter>
+  ${computeFilterMask};
+  ${recomputeCategoryCounts};
+  document.addEventListener('DOMContentLoaded', function () {
+    document.body.addEventListener('change', function (event) {
+      var select = event.target;
+      if (!select.classList || !select.classList.contains('konviw-tablechart-filter')) return;
+      var groupId = select.getAttribute('data-konviw-filter-group');
+      var payload = window.konviwTableProcessorData && window.konviwTableProcessorData[groupId];
+      if (!payload) return;
+
+      var mask = computeFilterMask(payload.values, select.value);
+
+      payload.charts.forEach(function (chart) {
+        var result = recomputeCategoryCounts(chart.categories, mask);
+        var order = result.order;
+        var counts = result.counts;
+        var apex = window.konviwCharts && window.konviwCharts[chart.id];
+        if (!apex) return;
+        var chartType = apex.w && apex.w.config && apex.w.config.chart && apex.w.config.chart.type;
+        var isCircular = chartType === 'pie' || chartType === 'donut';
+        // Categories and series are merged into a SINGLE updateOptions() call
+        // (rather than a separate updateOptions() + updateSeries()) with
+        // redrawPaths=true: when the number of categories changes, splitting
+        // the update into two calls (or skipping the axis path redraw) left
+        // the previous render's rotated axis labels on screen, overlapping
+        // the new ones instead of being replaced by them.
+        if (isCircular) {
+          apex.updateOptions({
+            labels: order,
+            series: order.map(function (label) { return counts[label]; }),
+          }, true, true);
+        } else {
+          var seriesName = (apex.w.config.series[0] && apex.w.config.series[0].name) || 'Count';
+          apex.updateOptions({
+            xaxis: { categories: order },
+            series: [{ name: seriesName, data: order.map(function (label) { return counts[label]; }) }],
+          }, true, true);
+        }
+      });
+
+      var grid = window.konviwGrids && window.konviwGrids[payload.gridId];
+      if (grid) {
+        var filteredRows = payload.tableRows.filter(function (_row, i) { return mask[i]; });
+        grid.updateConfig({ data: filteredRows }).forceRender();
+      }
+    });
+  });
+</script>`;
+
+// Only called by the default export when it has already confirmed at least
+// one `table-chart` placeholder exists, so `placeholders` is never empty here.
+const renderLegacyTableChartMacros = (
+  $: cheerio.CheerioAPI,
+  storageBody: string,
+): { needsApexCharts: boolean; needsTabScript: boolean } => {
+  const placeholders = $('[data-macro-name="table-chart"]');
+  let needsApexCharts = false;
+  let needsTabScript = false;
+  const macros = collectStorageTableChartMacros(storageBody);
+
+  placeholders.each((index: number, element: cheerio.Element) => {
+    const macro = macros[index];
+    if (!macro) {
+      // No matching storage data: drop the empty placeholder to avoid leaking
+      // the unusable iframe stub into the rendition.
+      $(element).remove();
+      return;
+    }
+
+    const isChart = Boolean(macro.params.type);
+    let output = '';
+
+    if (isChart) {
+      const chart = buildChart(macro, index);
+      if (chart) {
+        needsApexCharts = true;
+        // The source table is a data source hidden by default; only show it
+        // when the macro is explicitly configured to keep it visible — and
+        // when both are shown, let the reader pick one via a tab toggle
+        // instead of always stacking them.
+        const table = macro.params.hide !== 'true' ? buildTable(macro) : '';
+        const tabbed = buildTabbedViews([{ label: 'Chart', html: chart }, { label: 'Table', html: table }]);
+        output = tabbed.html;
+        if (tabbed.usedTabs) needsTabScript = true;
+      }
+    }
+
+    if (!output) {
+      // Table Filter / Pivot Table variants (or a chart without usable data):
+      // fall back to the plain source table.
+      output = buildTable(macro);
+    }
+
+    if (output) {
+      $(element).replaceWith(output);
+    } else {
+      $(element).remove();
+    }
+  });
+
+  return { needsApexCharts, needsTabScript };
+};
+
+/**
+ * Fetch and render a single `table-processor` macro's Jira-backed content:
+ * every `chart` node in its tree as an ApexCharts chart, plus the underlying
+ * issues as a Grid.js table underneath. Returns null when there's nothing
+ * fetchable (no datasource) so the caller falls back to a plain message.
+ */
+const renderJiraTableProcessorMacro = async (
+  macro: TableProcessorMacro,
+  placeholderIndex: number,
+  jiraService: JiraService,
+  jiraFields: any[],
+  baseUrl: string,
+): Promise<{ html: string; hasChart: boolean; usedTabs: boolean; usedFilter: boolean } | null> => {
+  const { datasource, tree } = macro;
+  if (!datasource) return null;
+
+  const chartNodes = findChartNodesSafe(tree);
+  const chartFieldIds = new Set<string>();
+  chartNodes.forEach((node) => {
+    const columnId = tableProcessorJira.resolveFieldId(node.params?.column, jiraFields);
+    if (columnId) chartFieldIds.add(columnId);
+  });
+
+  // The root `filter` node's own column (e.g. "Service Category" in the real
+  // macro's filter chip) isn't necessarily one of the table/chart columns
+  // already being fetched, so it needs to be requested explicitly too.
+  const filterLabel: string | undefined = tree?.type === 'filter'
+    ? (tree.params?.labels || tree.params?.column)
+    : undefined;
+  const filterColumnId = tableProcessorJira.resolveFieldId(tree?.params?.column, jiraFields);
+  if (filterColumnId) chartFieldIds.add(filterColumnId);
+
+  const fields = Array.from(new Set([...datasource.columnKeys, ...chartFieldIds]));
+  const response = await jiraService.findTickets('System JIRA', datasource.jql, fields.join(','));
+  const issues = response?.data?.issues ?? [];
+
+  const chartHtmls: string[] = [];
+  const chartPayloads: { id: string; categories: string[] }[] = [];
+
+  chartNodes.forEach((node, chartIndex) => {
+    const columnId = tableProcessorJira.resolveFieldId(node.params?.column, jiraFields);
+    if (!columnId) return;
+    const perIssueLabels = tableProcessorJira.extractPerIssueLabels(issues, columnId);
+    const { categories, counts } = tableProcessorJira.aggregateByCategory(issues, columnId);
+    const chartId = `jira-${placeholderIndex}-${chartIndex}`;
+    // `columnId` only resolved above because `node.params.column` was truthy,
+    // so `node.params` is guaranteed to exist here.
+    const chart = buildJiraChart(node.params as Record<string, string>, categories, counts, chartId);
+    if (chart) {
+      chartHtmls.push(chart);
+      chartPayloads.push({ id: chartId, categories: perIssueLabels });
+    }
+  });
+
+  const gridId = `tp-${placeholderIndex}`;
+  const table = tableProcessorJira.buildJiraGridTable(
+    issues,
+    datasource.columnKeys,
+    jiraFields,
+    baseUrl,
+    gridId,
+  );
+
+  // Only number the chart tabs ("Chart 1", "Chart 2", ...) when there's more
+  // than one, so the common single-chart case just reads "Chart".
+  const views: TabView[] = [
+    ...chartHtmls.map((html, i) => ({ label: chartHtmls.length > 1 ? `Chart ${i + 1}` : 'Chart', html })),
+    { label: 'Table', html: table.html },
+  ];
+  const tabbed = buildTabbedViews(views);
+
+  // Only offer the filter dropdown when it actually narrows anything: it
+  // needs to resolve to a real field with 2+ distinct values across the
+  // fetched issues (a single-value filter is a no-op, not worth a control).
+  const filterValues = filterColumnId ? tableProcessorJira.extractPerIssueLabels(issues, filterColumnId) : [];
+  const filterOptions = tableProcessorJira.distinctSortedLabels(filterValues);
+  const usedFilter = Boolean(filterLabel) && filterOptions.length > 1;
+
+  const groupId = `konviw-tp-filter-${placeholderIndex}`;
+  const html = usedFilter
+    ? buildFilterBar(filterLabel as string, filterOptions, groupId)
+      + tabbed.html
+      + buildFilterDataScript(groupId, filterValues, chartPayloads, table.rows, gridId)
+    : tabbed.html;
+
+  return {
+    html, hasChart: chartHtmls.length > 0, usedTabs: tabbed.usedTabs, usedFilter,
+  };
+};
+
+// `findChartNodes` narrowed to tolerate a null tree (malformed `serialized` param).
+const findChartNodesSafe = (
+  tree: tableProcessorJira.TableProcessorNode | null,
+): tableProcessorJira.TableProcessorNode[] => tableProcessorJira.findChartNodes(tree);
+
+// Only called by the default export when it has already confirmed at least
+// one `table-processor` placeholder exists, so `placeholders` is never empty here.
+const renderTableProcessorMacros = async (
+  $: cheerio.CheerioAPI,
+  storageBody: string,
+  config: ConfigService,
+  jiraService: JiraService,
+): Promise<{ needsApexCharts: boolean; needsGridjs: boolean; needsTabScript: boolean; needsFilterScript: boolean }> => {
+  const placeholders = $('[data-macro-name="table-processor"]');
+  const macros = collectStorageTableProcessorMacros(storageBody);
+  const baseUrl = config.get('confluence.baseURL');
+
+  let jiraFields: any[] = [];
+  if (macros.some((macro) => macro.datasource)) {
+    jiraFields = (await jiraService.getFields()) ?? [];
+  }
+
+  let needsApexCharts = false;
+  let needsGridjs = false;
+  let needsTabScript = false;
+  let needsFilterScript = false;
+
+  const elements = placeholders.toArray();
+  await Promise.all(elements.map(async (element, index) => {
+    const macro = macros[index];
+    if (!macro) {
+      $(element).remove();
+      return;
+    }
+
+    try {
+      const rendered = await renderJiraTableProcessorMacro(
+        macro,
+        index,
+        jiraService,
+        jiraFields,
+        baseUrl,
+      );
+
+      if (!rendered?.html) {
+        // No parseable Jira datasource, or the search returned nothing usable:
+        // drop the empty placeholder rather than leaking the iframe stub.
         $(element).remove();
         return;
       }
 
-      const isChart = Boolean(macro.params.type);
-      let output = '';
+      needsGridjs = true;
+      if (rendered.hasChart) needsApexCharts = true;
+      if (rendered.usedTabs) needsTabScript = true;
+      if (rendered.usedFilter) needsFilterScript = true;
+      $(element).replaceWith(rendered.html);
+    } catch (error) {
+      logger.error(`Failed to render table-processor macro at index ${index}: ${(error as Error).message}`);
+      $(element).remove();
+    }
+  }));
 
-      if (isChart) {
-        const chart = buildChart(macro, index);
-        if (chart) {
-          needsApexCharts = true;
-          output = chart;
-          // The source table is a data source hidden by default; only show it
-          // when the macro is explicitly configured to keep it visible.
-          if (macro.params.hide !== 'true') {
-            output += buildTable(macro);
-          }
-        }
-      }
+  return {
+    needsApexCharts, needsGridjs, needsTabScript, needsFilterScript,
+  };
+};
 
-      if (!output) {
-        // Table Filter / Pivot Table variants (or a chart without usable data):
-        // fall back to the plain source table.
-        output = buildTable(macro);
-      }
+export default (config: ConfigService, jiraService: JiraService): Step => async (
+  context: ContextService,
+): Promise<void> => {
+  context.setPerfMark('fixTableChart');
+  const $ = context.getCheerioBody();
 
-      if (output) {
-        $(element).replaceWith(output);
-      } else {
-        $(element).remove();
-      }
-    });
+  const hasLegacyPlaceholders = $('[data-macro-name="table-chart"]').length > 0;
+  const hasProcessorPlaceholders = $('[data-macro-name="table-processor"]').length > 0;
 
-    if (needsApexCharts && $('script[data-konviw-apexcharts]').length === 0) {
-      $('body').append(
-        '<script defer data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>',
-      );
+  if (!hasLegacyPlaceholders && !hasProcessorPlaceholders) {
+    context.getPerfMeasure('fixTableChart');
+    return;
+  }
+
+  const storageBody = context.getBodyStorage();
+  let needsApexCharts = false;
+  let needsGridjs = false;
+  let needsTabScript = false;
+  let needsFilterScript = false;
+
+  try {
+    if (hasLegacyPlaceholders) {
+      const result = renderLegacyTableChartMacros($, storageBody);
+      needsApexCharts = result.needsApexCharts;
+      needsTabScript = result.needsTabScript;
     }
   } catch (error) {
     // Never let an unexpected parsing/rendering error break the whole page:
     // log it and leave the original placeholders untouched.
-    logger.error(
-      `Failed to render table-chart macro(s): ${(error as Error).message}`,
+    logger.error(`Failed to render table-chart macro(s): ${(error as Error).message}`);
+  }
+
+  if (hasProcessorPlaceholders) {
+    try {
+      const result = await renderTableProcessorMacros($, storageBody, config, jiraService);
+      needsApexCharts = needsApexCharts || result.needsApexCharts;
+      needsGridjs = result.needsGridjs;
+      needsTabScript = needsTabScript || result.needsTabScript;
+      needsFilterScript = result.needsFilterScript;
+    } catch (error) {
+      logger.error(`Failed to render table-processor macro(s): ${(error as Error).message}`);
+    }
+  }
+
+  if (needsApexCharts && $('script[data-konviw-apexcharts]').length === 0) {
+    $('body').append(
+      '<script defer data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>',
     );
+  }
+
+  // addJira.ts injects the same Grid.js assets unconditionally when it handles
+  // its own `[data-datasource]` elements; guard against double-injecting them.
+  if (needsGridjs && $('script[src*="gridjs.production.min.js"]').length === 0) {
+    const basePath = config.get('web.basePath');
+    const version = config.get('version');
+    $('head').append(
+      `<link href="${basePath}/gridjs/mermaid.min.css?cache=${version}" rel="stylesheet" />`,
+    );
+    $('body').append(
+      `<script defer src="${basePath}/gridjs/gridjs.production.min.js?cache=${version}"></script>`,
+    );
+  }
+
+  if (needsTabScript && $('script[data-konviw-tablechart-toggle]').length === 0) {
+    $('body').append(TAB_TOGGLE_SCRIPT);
+  }
+
+  if (needsFilterScript && $('script[data-konviw-tablechart-filter]').length === 0) {
+    $('body').append(FILTER_APPLY_SCRIPT);
   }
 
   context.getPerfMeasure('fixTableChart');

--- a/src/proxy-page/utils/jiraGrid.ts
+++ b/src/proxy-page/utils/jiraGrid.ts
@@ -71,14 +71,14 @@ export const createTable = (index, gridjsColumns, preparedData) => `
   <div id="gridjs${index}"></div>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-      new gridjs.Grid({
+      var konviwGrid = new gridjs.Grid({
         columns: ${gridjsColumns},
         data: ${JSON.stringify(preparedData)},
         resizable: true,
         sort: true,
         search: {
           enabled: true,
-          selector: (cell, rowIndex, cellIndex) => 
+          selector: (cell, rowIndex, cellIndex) =>
             cell?.data?.map(item => item?.name).filter(name => name).join(', ') || cell?.data
         },
         width: '100%',
@@ -93,7 +93,13 @@ export const createTable = (index, gridjsColumns, preparedData) => `
             padding: '5px 5px'
           }
         }
-      }).render(document.getElementById("gridjs${index}"));
+      });
+      konviwGrid.render(document.getElementById("gridjs${index}"));
+      // Registered so a filter control elsewhere on the page (see
+      // fixTableChart.ts's table-processor filter dropdown) can re-filter
+      // this grid's rows client-side via updateConfig()/forceRender().
+      window.konviwGrids = window.konviwGrids || {};
+      window.konviwGrids["gridjs${index}"] = konviwGrid;
     });
   </script>
 `;

--- a/src/proxy-page/utils/tableProcessorJira.ts
+++ b/src/proxy-page/utils/tableProcessorJira.ts
@@ -1,0 +1,282 @@
+import * as cheerio from 'cheerio';
+import * as FieldInterfaces from '../dto/FieldInterface';
+import * as jiraGrid from './jiraGrid';
+
+/**
+ * Newer releases of the Stiltsoft "Table Filter, Charts & Spreadsheets" macro
+ * (`ac:name="table-processor"`) store their configuration as a tree of these
+ * nodes in a single `serialized` JSON parameter, instead of the classic flat
+ * `<ac:parameter>` list. A `filter` root commonly wraps `chart`/`pivot`
+ * children — see {@link findChartNodes}.
+ */
+export type TableProcessorNode = {
+  type?: string;
+  isActive?: boolean;
+  params?: Record<string, any>;
+  child?: TableProcessorNode[];
+};
+
+export type JiraDatasource = {
+  jql: string;
+  columnKeys: string[];
+};
+
+/**
+ * Parse the macro's `serialized` parameter (already HTML-entity-decoded by the
+ * caller). Returns null on any malformed/unexpected shape so callers can fall
+ * back gracefully instead of throwing.
+ */
+export const parseSerializedTree = (raw: string): TableProcessorNode | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const root = Array.isArray(parsed) ? parsed[0] : parsed;
+    return root ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/** Depth-first search for every `chart`-type node anywhere in the tree. */
+export const findChartNodes = (root: TableProcessorNode | null): TableProcessorNode[] => {
+  if (!root) return [];
+  const nodes: TableProcessorNode[] = [];
+  const stack: TableProcessorNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node) {
+      if (node.type === 'chart') nodes.push(node);
+      (node.child ?? []).forEach((child) => stack.push(child));
+    }
+  }
+  return nodes;
+};
+
+/**
+ * These macro instances source their "table" from a live Jira search instead
+ * of an inline `<table>`: the `<ac:rich-text-body>` holds a Jira smart-link
+ * "datasource" card (`<a data-datasource="{...}">`) carrying the JQL and the
+ * columns the user picked for the underlying table view.
+ */
+export const extractJiraDatasource = (
+  $xml: cheerio.CheerioAPI,
+  richTextBodyEl: cheerio.Element,
+): JiraDatasource | null => {
+  const raw = $xml(richTextBodyEl).find('a[data-datasource]').first().attr('data-datasource');
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const jql = parsed?.parameters?.jql;
+    const columns = parsed?.views?.[0]?.properties?.columns;
+    if (!jql || !Array.isArray(columns)) return null;
+    const columnKeys: string[] = columns
+      .map((column: { key?: string }) => column?.key)
+      .filter(Boolean);
+    if (columnKeys.length === 0) return null;
+    return { jql, columnKeys };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The chart/pivot params reference Jira fields by their display label (e.g.
+ * `"Submitted month"`), not their id, so a lookup against `JiraService.getFields()`
+ * is needed before the value can be pulled off a fetched issue.
+ */
+export const resolveFieldId = (label: string, jiraFields: any[]): string | undefined => {
+  if (!label) return undefined;
+  const normalized = label.trim().toLowerCase();
+  const field = (jiraFields ?? []).find(
+    (candidate) => (candidate?.name ?? '').trim().toLowerCase() === normalized,
+  );
+  return field?.id;
+};
+
+/**
+ * Turn a raw Jira issue field value into a single display label suitable for
+ * grouping. Unlike `FieldInterface.ts`'s `fieldFunctions` (grid-display
+ * oriented: they array-wrap every value and locale-format dates), this reads
+ * the field's raw shape directly so category buckets compare on plain values.
+ */
+/**
+ * Some marketplace "date bucket" custom fields (e.g. a "Month" grouping
+ * field) store their value as a JSON-encoded string instead of a plain
+ * label — e.g. `{"start":"2026-07-01","end":"2026-07-31"}` for a "Submitted
+ * month" field. Detect that shape and render the month/year the range
+ * starts in, instead of dumping the raw JSON text onto the chart/table.
+ * Returns null for anything that doesn't match so the caller can fall back.
+ */
+const extractDateRangeLabel = (raw: string): string | null => {
+  if (!raw.startsWith('{') || !raw.includes('"start"')) return null;
+  try {
+    // `raw` starts with '{' (checked above), so a successful JSON.parse of it
+    // always yields a non-null object — `parsed.start` is safe without `?.`.
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.start !== 'string') return null;
+    const date = new Date(parsed.start);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+  } catch {
+    return null;
+  }
+};
+
+export const extractGroupLabel = (value: any): string => {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) {
+    return value.map((item) => extractGroupLabel(item)).filter(Boolean).join(', ');
+  }
+  if (typeof value === 'object') {
+    if (typeof value.value === 'string') return value.value;
+    if (typeof value.name === 'string') return value.name;
+    return '';
+  }
+  if (typeof value === 'string') {
+    return extractDateRangeLabel(value) ?? value;
+  }
+  return String(value);
+};
+
+/**
+ * The per-issue label for a field, in fetch order. Used both for the initial
+ * server-side aggregation below and as the raw payload sent to the browser so
+ * a chart/table can be re-aggregated client-side when the reader changes the
+ * "Service Category"-style filter dropdown (see `fixTableChart.ts`).
+ */
+export const extractPerIssueLabels = (issues: any[], fieldId: string): string[] =>
+  (issues ?? []).map((issue) => extractGroupLabel(issue?.fields?.[fieldId]) || 'Unspecified');
+
+/**
+ * The distinct values of a per-issue label list, alphabetically sorted —
+ * used to populate a filter dropdown's options.
+ */
+export const distinctSortedLabels = (labels: string[]): string[] =>
+  Array.from(new Set(labels)).sort((a, b) => a.localeCompare(b));
+
+/**
+ * V1 aggregation is count-of-issues-per-category only (see plan/context for
+ * why): groups issues by the category field's label, in first-seen order.
+ */
+export const aggregateByCategory = (
+  issues: any[],
+  categoryFieldId: string,
+): { categories: string[]; counts: number[] } => {
+  const order: string[] = [];
+  const countByCategory = new Map<string, number>();
+  extractPerIssueLabels(issues, categoryFieldId).forEach((label) => {
+    if (!countByCategory.has(label)) {
+      order.push(label);
+      countByCategory.set(label, 0);
+    }
+    // The label was just guaranteed to be a key above, so `get` always returns
+    // a number here.
+    countByCategory.set(label, (countByCategory.get(label) as number) + 1);
+  });
+  return {
+    categories: order,
+    counts: order.map((label) => countByCategory.get(label) as number),
+  };
+};
+
+const checkFieldExistence = (
+  fields: any[],
+  idToCheck: string,
+): { name: string; type: string | undefined } | undefined => {
+  const targetedField = (fields ?? []).find((field) => field.id === idToCheck);
+  if (!targetedField) return undefined;
+  let { type } = targetedField.schema ?? {};
+  // `type` can only be 'array' here if `targetedField.schema` was defined (it's
+  // where `type` came from), so `.schema.items` is safe without another `?.`.
+  if (type === 'array' && targetedField.schema.items) {
+    type = targetedField.schema.items;
+  }
+  return { name: targetedField.name, type };
+};
+
+const reorderDataObjectKeys = (
+  item: Record<string, any>,
+  requestedFields: string[],
+): Record<string, any> => {
+  const reordered: Record<string, any> = {};
+  requestedFields.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(item, field)) {
+      reordered[field] = item[field];
+    }
+  });
+  return reordered;
+};
+
+const buildGridColumnsConfig = (
+  data: Record<string, any>[],
+  columnConfig: Record<string, (name: string) => string>,
+): string => {
+  // `gridtype` is always one of the fixed keys `columnConfig` declares (set
+  // either by a `FieldInterface.fieldFunctions` formatter or the hardcoded
+  // 'link'/'normal' fallbacks below), so the lookup is never nullish.
+  const columns = data.slice(0, 1).flatMap((obj) => Object.keys(obj)
+    .map((key) => columnConfig[obj[key].gridtype](obj[key].name))
+    .filter(Boolean));
+  return `[${columns.join(',')}]`;
+};
+
+/**
+ * Reproduces the Jira-issues-to-Grid.js-table pipeline already used by
+ * `addJira.ts` (field resolution via `FieldInterface.fieldFunctions` + a
+ * `jiraGrid.createTable` render) for a single flat set of issues/columns, so
+ * table-processor macros get the same rendering without duplicating that
+ * logic wholesale. Also returns the prepared row data (index-aligned with
+ * `issues`) so the caller can re-filter the table client-side without
+ * re-fetching or re-deriving it.
+ */
+export const buildJiraGridTable = (
+  issues: any[],
+  columnKeys: string[],
+  jiraFields: any[],
+  baseUrl: string,
+  gridIndex: string,
+): { html: string; rows: any[][] } => {
+  const requestedFields = columnKeys.filter((field) => {
+    if (!/^customfield_\d+$/i.test(field)) return true;
+    return Boolean(checkFieldExistence(jiraFields, field));
+  });
+
+  const { fieldFunctions } = FieldInterfaces;
+  const dataObjects = (issues ?? []).map((issue) => {
+    const rowData: Record<string, any> = {};
+    if (requestedFields.includes('key')) {
+      rowData.key = {
+        data: [FieldInterfaces.createLinkObject(issue.key, baseUrl)],
+        name: 'Key',
+        type: 'issuelinks',
+        gridtype: 'link',
+      };
+    }
+    Object.keys(issue.fields ?? {}).forEach((fieldName) => {
+      let fieldValue = issue.fields[fieldName];
+      const fieldTypeData = checkFieldExistence(jiraFields, fieldName) ?? { name: fieldName, type: 'string' };
+      let gridtype = '';
+      if (fieldTypeData.type && fieldTypeData.type in fieldFunctions) {
+        [fieldValue, gridtype] = fieldFunctions[fieldTypeData.type](fieldValue, baseUrl);
+      } else {
+        fieldValue = ['Type not treated'];
+        gridtype = 'normal';
+      }
+      rowData[fieldName] = {
+        data: fieldValue,
+        name: fieldTypeData.name,
+        type: fieldTypeData.type,
+        gridtype,
+      };
+    });
+    return rowData;
+  });
+
+  const reordered = dataObjects.map((item) => reorderDataObjectKeys(item, requestedFields));
+  const preparedData = reordered.map((obj) => Object.values(obj));
+  const gridjsColumns = buildGridColumnsConfig(reordered, jiraGrid.columnConfig);
+  return {
+    html: jiraGrid.createTable(gridIndex, gridjsColumns, preparedData),
+    rows: preparedData,
+  };
+};

--- a/tests/unit/steps/fixTableChart.spec.ts
+++ b/tests/unit/steps/fixTableChart.spec.ts
@@ -1,9 +1,75 @@
+import { ConfigService } from '@nestjs/config';
+import { Tabletojson } from 'tabletojson';
 import { ContextService } from '../../../src/context/context.service';
-import fixTableChart from '../../../src/proxy-page/steps/fixTableChart';
+import fixTableChart, { computeFilterMask, recomputeCategoryCounts } from '../../../src/proxy-page/steps/fixTableChart';
 import { createModuleRefForStep } from './utils';
 
 // Stiltsoft joins the selected aggregation columns with U+201A (‚), not a comma.
 const SEP = '\u201A';
+
+// jest.fn()-backed so table-processor specs can control/assert Jira calls;
+// legacy table-chart specs never exercise these and keep the harmless defaults.
+class JiraServiceMock {
+  getFields = jest.fn().mockResolvedValue([]);
+
+  findTickets = jest.fn().mockResolvedValue({ data: { issues: [] } });
+}
+
+const statusField = (name: string) => ({
+  self: '',
+  description: '',
+  iconUrl: '',
+  name,
+  id: name,
+  statusCategory: {
+    self: '', id: 1, key: name.toLowerCase(), colorName: 'green', name,
+  },
+});
+
+// Builds the storage body for a `table-processor` macro: a `serialized` JSON
+// tree (filter root + chart children) plus a Jira smart-link datasource card
+// in place of an inline `<table>` (see tableProcessorJira.ts for the shape).
+const buildProcessorStorage = ({
+  chartParams = [{
+    column: 'Status', aggregation: 'Status', type: 'Column', legend: 'right',
+  }] as Record<string, string>[],
+  filterParams = {} as Record<string, string>,
+  datasourceColumns = ['key', 'status'],
+  jql = 'project = FND',
+  includeDatasource = true,
+  includeRichTextBody = true,
+  serialized = undefined as string | undefined,
+} = {}) => {
+  const tree = {
+    type: 'filter',
+    params: filterParams,
+    child: chartParams.map((params) => ({ type: 'chart', params })),
+  };
+  const serializedJson = serialized ?? JSON.stringify([tree]);
+  const datasourceJson = JSON.stringify({
+    parameters: { jql },
+    views: [{ type: 'table', properties: { columns: datasourceColumns.map((key) => ({ key })) } }],
+  });
+  let richTextBody = '';
+  if (includeRichTextBody) {
+    richTextBody = includeDatasource
+      ? `<ac:rich-text-body><a data-datasource='${datasourceJson}'>Jira issues</a></ac:rich-text-body>`
+      : '<ac:rich-text-body><p>no datasource here</p></ac:rich-text-body>';
+  }
+  return `<ac:structured-macro ac:name="table-processor" ac:schema-version="1">
+    <ac:parameter ac:name="serialized">${serializedJson}</ac:parameter>
+    ${richTextBody}
+  </ac:structured-macro>`;
+};
+
+const processorViewHtml = (count = 1) => `
+<html>
+  <body>
+    <div id="Content">
+      ${'<div class="ap-container output-block" data-macro-name="table-processor"><iframe></iframe></div>'.repeat(count)}
+    </div>
+  </body>
+</html>`;
 
 // The view body Confluence returns for a Connect "Table Filters and Charts"
 // macro: only an empty iframe placeholder, no table nor chart.
@@ -39,20 +105,78 @@ const storageXml = `
   </ac:rich-text-body>
 </ac:structured-macro>`;
 
+// These two are exported specifically so this exact code — the algorithm
+// embedded (via `.toString()`) into the browser-side FILTER_APPLY_SCRIPT —
+// can be exercised directly in Node, without a DOM/browser. This is the
+// core of the filter-dropdown feature: which issues match the selected
+// value, and how the chart re-aggregates them.
+describe('ConfluenceProxy / fixTableChart — client-side filter algorithm', () => {
+  describe('computeFilterMask', () => {
+    it('matches everything when nothing is selected ("All")', () => {
+      expect(computeFilterMask(['A', 'B', 'A'], '')).toEqual([true, true, true]);
+    });
+
+    it('matches only entries equal to the selected value', () => {
+      expect(computeFilterMask(['A', 'B', 'A', 'C'], 'A')).toEqual([true, false, true, false]);
+    });
+
+    it('matches nothing when the selected value is not present', () => {
+      expect(computeFilterMask(['A', 'B'], 'Z')).toEqual([false, false]);
+    });
+
+    it('returns an empty mask for an empty values list', () => {
+      expect(computeFilterMask([], 'A')).toEqual([]);
+    });
+  });
+
+  describe('recomputeCategoryCounts', () => {
+    it('counts only the masked-in entries, preserving first-seen order', () => {
+      const categories = ['Open', 'Done', 'Open', 'Done', 'Open'];
+      const mask = [true, true, false, true, true];
+      expect(recomputeCategoryCounts(categories, mask)).toEqual({
+        order: ['Open', 'Done'],
+        counts: { Open: 2, Done: 2 },
+      });
+    });
+
+    it('returns an empty result when the mask excludes every entry', () => {
+      expect(recomputeCategoryCounts(['Open', 'Done'], [false, false])).toEqual({
+        order: [],
+        counts: {},
+      });
+    });
+
+    it('matches aggregateByCategory\'s server-side grouping for the unfiltered (all-true) mask', () => {
+      const categories = ['Done', 'Open', 'Done', 'Done', 'Open'];
+      const mask = categories.map(() => true);
+      expect(recomputeCategoryCounts(categories, mask)).toEqual({
+        order: ['Done', 'Open'],
+        counts: { Done: 3, Open: 2 },
+      });
+    });
+  });
+});
+
 describe('ConfluenceProxy / fixTableChart', () => {
   let context: ContextService;
+  let config: ConfigService;
+  let jiraService: JiraServiceMock;
 
   beforeEach(async () => {
     const moduleRef = await createModuleRefForStep();
     context = moduleRef.get<ContextService>(ContextService);
+    config = moduleRef.get<ConfigService>(ConfigService);
+    jiraService = new JiraServiceMock();
     context.initPageContext('v2', 'XXX', '60616441914', 'dark');
   });
 
+  const runStep = async () => fixTableChart(config, jiraService as any)(context);
+
   describe('Chart from Table (hidden source table)', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       context.setHtmlBody(viewHtml);
       context.setBodyStorage(storageXml);
-      fixTableChart()(context);
+      await runStep();
     });
 
     it('replaces the placeholder iframe with an ApexCharts container', () => {
@@ -90,24 +214,43 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('Chart from Table (visible source table)', () => {
-    it('renders both the chart and the source table when hide!=true', () => {
+    it('wraps the chart and the source table in a Chart/Table tab toggle instead of stacking them when hide!=true', async () => {
       const storageVisible = storageXml.replace(
         '<ac:parameter ac:name="hide">true</ac:parameter>',
         '<ac:parameter ac:name="hide">false</ac:parameter>',
       );
       context.setHtmlBody(viewHtml);
       context.setBodyStorage(storageVisible);
-      fixTableChart()(context);
+      await runStep();
 
       const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-group').length).toBe(1);
+      expect($('.konviw-tablechart-tab').length).toBe(2);
+      expect($('.konviw-tablechart-tab').eq(0).text()).toBe('Chart');
+      expect($('.konviw-tablechart-tab').eq(1).text()).toBe('Table');
+      expect($('.konviw-tablechart-tab.is-active').length).toBe(1);
+      expect($('.konviw-tablechart-tab.is-active').text()).toBe('Chart');
       expect($('.konviw-table-chart').length).toBe(1);
       expect($('table.confluenceTable').length).toBe(1);
       expect($('table.confluenceTable').text()).toContain('May');
+      expect($('script[data-konviw-tablechart-toggle]').length).toBe(1);
+    });
+
+    it('does not wrap in tabs when the chart has no table to switch to (hide=true)', async () => {
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(storageXml);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-group').length).toBe(0);
+      expect($('.konviw-table-chart').length).toBe(1);
+      expect($('table.confluenceTable').length).toBe(0);
+      expect($('script[data-konviw-tablechart-toggle]').length).toBe(0);
     });
   });
 
   describe('Pie chart', () => {
-    it('emits labels and a flat series array for a pie chart', () => {
+    it('emits labels and a flat series array for a pie chart', async () => {
       const pieStorage = `
         <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
           <ac:parameter ac:name="type">Pie</ac:parameter>
@@ -127,7 +270,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
         </ac:structured-macro>`;
       context.setHtmlBody(viewHtml);
       context.setBodyStorage(pieStorage);
-      fixTableChart()(context);
+      await runStep();
 
       const html = context.getHtmlBody();
       expect(html).toContain("type: 'pie'");
@@ -137,7 +280,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('Table Filter / Pivot Table variants (no chart type)', () => {
-    it('renders the plain source table when the macro has no type', () => {
+    it('renders the plain source table when the macro has no type', async () => {
       const filterStorage = `
         <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
           <ac:parameter ac:name="column">Month</ac:parameter>
@@ -152,7 +295,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
         </ac:structured-macro>`;
       context.setHtmlBody(viewHtml);
       context.setBodyStorage(filterStorage);
-      fixTableChart()(context);
+      await runStep();
 
       const $ = context.getCheerioBody();
       expect($('.konviw-table-chart').length).toBe(0);
@@ -163,7 +306,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('Multiple macros correlated by document order', () => {
-    it('matches each placeholder with the storage macro at the same index', () => {
+    it('matches each placeholder with the storage macro at the same index', async () => {
       const twoPlaceholders = `
         <html><body><div id="Content">
           <div data-macro-name="table-chart"><iframe></iframe></div>
@@ -193,7 +336,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
         </ac:structured-macro>`;
       context.setHtmlBody(twoPlaceholders);
       context.setBodyStorage(twoMacros);
-      fixTableChart()(context);
+      await runStep();
 
       const $ = context.getCheerioBody();
       expect($('.konviw-table-chart').length).toBe(2);
@@ -204,11 +347,11 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('No placeholders present', () => {
-    it('does nothing when the page has no table-chart macros', () => {
+    it('does nothing when the page has no table-chart macros', async () => {
       const plain = '<html><body><div id="Content"><p>hello</p></div></body></html>';
       context.setHtmlBody(plain);
       context.setBodyStorage('');
-      fixTableChart()(context);
+      await runStep();
       expect(context.getHtmlBody()).toContain('hello');
       expect(context.getCheerioBody()('script[data-konviw-apexcharts]').length).toBe(0);
     });
@@ -216,7 +359,7 @@ describe('ConfluenceProxy / fixTableChart', () => {
 
   // Helper to render a single chart macro of a given type and return the
   // generated HTML (including the ApexCharts options script).
-  const renderChart = (type: string, extraParams = '', tableRows = ''): string => {
+  const renderChart = async (type: string, extraParams = '', tableRows = ''): Promise<string> => {
     const rows = tableRows
       || `<tr><th><p>Month</p></th><th><p>Not Managed</p></th><th><p>MCE</p></th></tr>
           <tr><td><p>May</p></td><td><p>2300</p></td><td><p>2900</p></td></tr>
@@ -231,32 +374,32 @@ describe('ConfluenceProxy / fixTableChart', () => {
       </ac:structured-macro>`;
     context.setHtmlBody(viewHtml);
     context.setBodyStorage(storage);
-    fixTableChart()(context);
+    await runStep();
     return context.getHtmlBody();
   };
 
   describe('Data labels (WEB-2452 values on bars)', () => {
-    it('enables data labels for bar/column charts', () => {
-      expect(renderChart('Column')).toContain('enabled: true');
+    it('enables data labels for bar/column charts', async () => {
+      expect(await renderChart('Column')).toContain('enabled: true');
     });
 
-    it('uses a readable dark label color with a background pill', () => {
-      const html = renderChart('Column');
+    it('uses a readable dark label color with a background pill', async () => {
+      const html = await renderChart('Column');
       expect(html).toContain("colors: ['#172b4d']");
       expect(html).toContain('background: { enabled: true');
     });
 
-    it('blanks out zero values so empty categories show no label', () => {
-      const html = renderChart('Column');
+    it('blanks out zero values so empty categories show no label', async () => {
+      const html = await renderChart('Column');
       expect(html).toContain("return val === 0 ? '' : String(val);");
     });
 
-    it('disables data labels for line charts to avoid clutter', () => {
-      expect(renderChart('Line')).toContain('enabled: false');
+    it('disables data labels for line charts to avoid clutter', async () => {
+      expect(await renderChart('Line')).toContain('enabled: false');
     });
 
-    it('enables data labels for pie charts', () => {
-      const html = renderChart(
+    it('enables data labels for pie charts', async () => {
+      const html = await renderChart(
         'Pie',
         '',
         `<tr><th><p>Month</p></th><th><p>Not Managed</p></th></tr>
@@ -268,31 +411,31 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('Chart type mapping', () => {
-    it('renders "Bar" as a horizontal bar chart', () => {
-      const html = renderChart('Bar');
+    it('renders "Bar" as a horizontal bar chart', async () => {
+      const html = await renderChart('Bar');
       expect(html).toContain("type: 'bar'");
       expect(html).toContain('horizontal: true');
     });
 
-    it('renders "Column" as a vertical (non-horizontal) bar chart', () => {
-      const html = renderChart('Column');
+    it('renders "Column" as a vertical (non-horizontal) bar chart', async () => {
+      const html = await renderChart('Column');
       expect(html).toContain("type: 'bar'");
       expect(html).toContain('horizontal: false');
       expect(html).toContain('stacked: false');
     });
 
-    it('renders "Stacked Bar" as a horizontal stacked bar chart', () => {
-      const html = renderChart('Stacked Bar');
+    it('renders "Stacked Bar" as a horizontal stacked bar chart', async () => {
+      const html = await renderChart('Stacked Bar');
       expect(html).toContain('horizontal: true');
       expect(html).toContain('stacked: true');
     });
 
-    it('renders "Area" as an area chart', () => {
-      expect(renderChart('Area')).toContain("type: 'area'");
+    it('renders "Area" as an area chart', async () => {
+      expect(await renderChart('Area')).toContain("type: 'area'");
     });
 
-    it('renders "Donut" as a donut chart', () => {
-      const html = renderChart(
+    it('renders "Donut" as a donut chart', async () => {
+      const html = await renderChart(
         'Donut',
         '',
         `<tr><th><p>Month</p></th><th><p>Value</p></th></tr>
@@ -301,38 +444,38 @@ describe('ConfluenceProxy / fixTableChart', () => {
       expect(html).toContain("type: 'donut'");
     });
 
-    it('defaults an unknown type to a vertical bar chart', () => {
-      const html = renderChart('SomethingWeird');
+    it('defaults an unknown type to a vertical bar chart', async () => {
+      const html = await renderChart('SomethingWeird');
       expect(html).toContain("type: 'bar'");
       expect(html).toContain('horizontal: false');
     });
   });
 
   describe('Legend option', () => {
-    it('hides the legend when legend=false', () => {
-      const html = renderChart('Column', '<ac:parameter ac:name="legend">false</ac:parameter>');
+    it('hides the legend when legend=false', async () => {
+      const html = await renderChart('Column', '<ac:parameter ac:name="legend">false</ac:parameter>');
       expect(html).toContain('legend: { show: false }');
     });
 
-    it('positions the legend when a valid position is given', () => {
-      const html = renderChart('Column', '<ac:parameter ac:name="legend">top</ac:parameter>');
+    it('positions the legend when a valid position is given', async () => {
+      const html = await renderChart('Column', '<ac:parameter ac:name="legend">top</ac:parameter>');
       expect(html).toContain("position: 'top'");
     });
 
-    it('falls back to a bottom legend for an unknown position value', () => {
-      const html = renderChart('Column', '<ac:parameter ac:name="legend">weird</ac:parameter>');
+    it('falls back to a bottom legend for an unknown position value', async () => {
+      const html = await renderChart('Column', '<ac:parameter ac:name="legend">weird</ac:parameter>');
       expect(html).toContain("position: 'bottom'");
     });
   });
 
   describe('Title option', () => {
-    it('adds a chart title when the title parameter is set', () => {
-      const html = renderChart('Column', '<ac:parameter ac:name="title">My chart</ac:parameter>');
+    it('adds a chart title when the title parameter is set', async () => {
+      const html = await renderChart('Column', '<ac:parameter ac:name="title">My chart</ac:parameter>');
       expect(html).toContain('title: { text: "My chart"');
     });
 
-    it('omits the title block when no title parameter is set', () => {
-      expect(renderChart('Column')).not.toContain('title: { text:');
+    it('omits the title block when no title parameter is set', async () => {
+      expect(await renderChart('Column')).not.toContain('title: { text:');
     });
   });
 
@@ -357,10 +500,10 @@ describe('ConfluenceProxy / fixTableChart', () => {
         </ac:rich-text-body>
       </ac:structured-macro>`;
 
-    it('splits the &sbquo; aggregation into the configured series order', () => {
+    it('splits the &sbquo; aggregation into the configured series order', async () => {
       context.setHtmlBody(viewHtml);
       context.setBodyStorage(stackedStorage);
-      fixTableChart()(context);
+      await runStep();
 
       const html = context.getHtmlBody();
       expect(html).toContain(
@@ -370,8 +513,8 @@ describe('ConfluenceProxy / fixTableChart', () => {
   });
 
   describe('Numeric parsing', () => {
-    it('strips thousands separators and spaces from numeric cells', () => {
-      const html = renderChart(
+    it('strips thousands separators and spaces from numeric cells', async () => {
+      const html = await renderChart(
         'Column',
         '<ac:parameter ac:name="aggregation">Value</ac:parameter>',
         `<tr><th><p>Month</p></th><th><p>Value</p></th></tr>
@@ -379,6 +522,460 @@ describe('ConfluenceProxy / fixTableChart', () => {
          <tr><td><p>June</p></td><td><p>1 500</p></td></tr>`,
       );
       expect(html).toContain('"data":[2300,1500]');
+    });
+
+    it('treats a non-numeric cell as 0', async () => {
+      const html = await renderChart(
+        'Column',
+        '<ac:parameter ac:name="aggregation">Value</ac:parameter>',
+        `<tr><th><p>Month</p></th><th><p>Value</p></th></tr>
+         <tr><td><p>May</p></td><td><p>N/A</p></td></tr>`,
+      );
+      expect(html).toContain('"data":[0]');
+    });
+  });
+
+  describe('buildChart edge cases (no usable data)', () => {
+    it('falls back to the (empty) source table when the macro has a type but no rows', async () => {
+      const noRowsStorage = `
+        <ac:structured-macro ac:name="table-chart">
+          <ac:parameter ac:name="type">Column</ac:parameter>
+          <ac:parameter ac:name="column">Month</ac:parameter>
+          <ac:rich-text-body><table><tbody></tbody></table></ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(noRowsStorage);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect($('script[data-konviw-apexcharts]').length).toBe(0);
+    });
+
+    it('falls back to the plain table when the source table has fewer than 2 columns', async () => {
+      const singleColumnStorage = `
+        <ac:structured-macro ac:name="table-chart">
+          <ac:parameter ac:name="type">Column</ac:parameter>
+          <ac:parameter ac:name="column">Month</ac:parameter>
+          <ac:rich-text-body><table><tbody>
+            <tr><th><p>Month</p></th></tr>
+            <tr><td><p>May</p></td></tr>
+          </tbody></table></ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(singleColumnStorage);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect($('table.confluenceTable').text()).toContain('May');
+    });
+
+    it('defaults to the first column when the configured category column is not one of the table headers', async () => {
+      const html = await renderChart(
+        'Column',
+        '<ac:parameter ac:name="column">NotAColumn</ac:parameter><ac:parameter ac:name="aggregation">MCE</ac:parameter>',
+      );
+      // "Month" (the first/actual header) is used as the category axis instead
+      // of the non-existent configured "NotAColumn".
+      expect(html).toContain('categories: ["May","June"]');
+    });
+  });
+
+  describe('table-processor (Jira-backed) macros', () => {
+    beforeEach(() => {
+      jiraService.getFields.mockResolvedValue([
+        { id: 'status', name: 'Status', schema: { type: 'status' } },
+      ]);
+      jiraService.findTickets.mockResolvedValue({
+        data: {
+          issues: [
+            { key: 'FND-1', fields: { status: statusField('Done') } },
+            { key: 'FND-2', fields: { status: statusField('Open') } },
+            { key: 'FND-3', fields: { status: statusField('Done') } },
+          ],
+        },
+      });
+    });
+
+    it('renders an ApexCharts chart aggregated by category and a Grid.js table from live Jira data', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await runStep();
+
+      expect(jiraService.getFields).toHaveBeenCalledTimes(1);
+      expect(jiraService.findTickets).toHaveBeenCalledWith(
+        'System JIRA',
+        'project = FND',
+        expect.stringContaining('status'),
+      );
+
+      const html = context.getHtmlBody();
+      expect(html).toContain('konviw-table-chart-jira-0-0');
+      expect(html).toContain('series: [{"name":"Status","data":[2,1]}]');
+      expect(html).toContain('xaxis: { categories: ["Done","Open"] },');
+      expect(html).toContain('id="gridjstp-0"');
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(0);
+      expect($('script[data-konviw-apexcharts]').length).toBe(1);
+      expect($('script[src*="gridjs.production.min.js"]').length).toBe(1);
+
+      // The chart and its table are offered as a Chart/Table toggle, not
+      // stacked, so the reader picks one.
+      expect($('.konviw-tablechart-group').length).toBe(1);
+      expect($('.konviw-tablechart-tab').length).toBe(2);
+      expect($('.konviw-tablechart-tab').eq(0).text()).toBe('Chart');
+      expect($('.konviw-tablechart-tab').eq(1).text()).toBe('Table');
+      expect($('.konviw-tablechart-panel.is-active').length).toBe(1);
+      expect($('script[data-konviw-tablechart-toggle]').length).toBe(1);
+    });
+
+    it('does not re-inject the ApexCharts/Grid.js assets when they are already present', async () => {
+      context.setHtmlBody(`
+        <html><head>
+          <link href="/gridjs/mermaid.min.css" rel="stylesheet" />
+        </head><body>
+          <script data-konviw-apexcharts src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+          <script src="/gridjs/gridjs.production.min.js"></script>
+          <div id="Content">${processorViewHtml().replace(/<\/?html>|<\/?body>/g, '')}</div>
+        </body></html>`);
+      context.setBodyStorage(buildProcessorStorage());
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('script[data-konviw-apexcharts]').length).toBe(1);
+      expect($('script[src*="gridjs.production.min.js"]').length).toBe(1);
+    });
+
+    it('renders every chart node found in the serialized tree, each with a unique id', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({
+        chartParams: [
+          { column: 'Status', aggregation: 'Status', type: 'Column' },
+          { column: 'Status', aggregation: 'Status', type: 'Pie' },
+        ],
+      }));
+      await runStep();
+
+      const html = context.getHtmlBody();
+      expect(html).toContain('konviw-table-chart-jira-0-0');
+      expect(html).toContain('konviw-table-chart-jira-0-1');
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain("type: 'pie'");
+
+      // Three views to choose from (two numbered charts + the table).
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-tab').length).toBe(3);
+      expect($('.konviw-tablechart-tab').eq(0).text()).toBe('Chart 1');
+      expect($('.konviw-tablechart-tab').eq(1).text()).toBe('Chart 2');
+      expect($('.konviw-tablechart-tab').eq(2).text()).toBe('Table');
+    });
+
+    it('falls back to a table-only rendering (no tabs) when the tree has no chart node', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ chartParams: [] }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect($('script[data-konviw-apexcharts]').length).toBe(0);
+      expect($('script[src*="gridjs.production.min.js"]').length).toBe(1);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+      expect($('.konviw-tablechart-group').length).toBe(0);
+      expect($('script[data-konviw-tablechart-toggle]').length).toBe(0);
+    });
+
+    it('falls back to a table-only rendering when the serialized JSON is malformed', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ serialized: '{not valid json' }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('skips a chart whose column label does not resolve to a known Jira field, but still renders the table', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({
+        chartParams: [{ column: 'Not A Real Field', aggregation: 'Not A Real Field', type: 'Column' }],
+      }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('removes a placeholder outright when its macro has no parseable Jira datasource', async () => {
+      context.setHtmlBody(processorViewHtml(2));
+      const withDatasource = buildProcessorStorage();
+      const withoutDatasource = buildProcessorStorage({ includeDatasource: false });
+      context.setBodyStorage(withDatasource + withoutDatasource);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(0);
+      expect($('.konviw-table-chart').length).toBe(1);
+      expect($('div[id^="gridjstp-"]').length).toBe(1);
+    });
+
+    it('removes a placeholder with no matching storage macro (index mismatch) without calling Jira', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage('');
+      await runStep();
+
+      expect(jiraService.getFields).not.toHaveBeenCalled();
+      expect(jiraService.findTickets).not.toHaveBeenCalled();
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(0);
+    });
+
+    it('drops only the placeholder whose Jira search failed, leaving the others rendered', async () => {
+      jiraService.findTickets
+        .mockRejectedValueOnce(new Error('Jira is down'))
+        .mockResolvedValueOnce({ data: { issues: [{ key: 'FND-9', fields: { status: statusField('Open') } }] } });
+
+      context.setHtmlBody(processorViewHtml(2));
+      context.setBodyStorage(buildProcessorStorage() + buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(0);
+      expect($('.konviw-table-chart').length).toBe(1);
+    });
+
+    it('leaves table-processor placeholders untouched (but still renders a sibling legacy chart) when getFields fails', async () => {
+      jiraService.getFields.mockRejectedValue(new Error('Jira fields unavailable'));
+
+      const combinedView = `
+        <html><body><div id="Content">
+          <div data-macro-name="table-chart"><iframe></iframe></div>
+          ${processorViewHtml().replace(/<\/?html>|<\/?body>|<div id="Content">|<\/div>\s*<\/div>\s*$/g, '')}
+        </div></body></html>`;
+      context.setHtmlBody(combinedView);
+      context.setBodyStorage(storageXml + buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(1);
+      expect($('.konviw-table-chart').length).toBe(1);
+      expect($('script[data-konviw-apexcharts]').length).toBe(1);
+      expect($('script[src*="gridjs.production.min.js"]').length).toBe(0);
+    });
+
+    it('removes a placeholder whose macro has no <ac:rich-text-body> at all', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ includeRichTextBody: false }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-processor"]').length).toBe(0);
+      expect($('.konviw-table-chart').length).toBe(0);
+    });
+
+    it('defaults a chart node with no type/aggregation params to a vertical bar named after its column', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ chartParams: [{ column: 'Status' }] }));
+      await runStep();
+
+      const html = context.getHtmlBody();
+      expect(html).toContain("type: 'bar'");
+      expect(html).toContain('"name":"Status"');
+    });
+
+    it('tolerates a chart node with no params object at all', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ chartParams: [undefined as unknown as Record<string, string>] }));
+      await expect(runStep()).resolves.toBeUndefined();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('skips the chart (but still renders the table) when the Jira search returns no issues', async () => {
+      jiraService.findTickets.mockResolvedValue({ data: { issues: [] } });
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('tolerates a findTickets response with no data/issues shape', async () => {
+      jiraService.findTickets.mockResolvedValue({});
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('tolerates findTickets resolving to undefined outright', async () => {
+      jiraService.findTickets.mockResolvedValue(undefined);
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('tolerates getFields resolving to null (falls back to no known fields)', async () => {
+      jiraService.getFields.mockResolvedValue(null);
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-table-chart').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+  });
+
+  describe('table-processor filter dropdown ("Service Category ="-style control)', () => {
+    beforeEach(() => {
+      jiraService.getFields.mockResolvedValue([
+        { id: 'status', name: 'Status', schema: { type: 'status' } },
+        { id: 'customfield_svccat', name: 'Service Category', schema: { type: 'string' } },
+      ]);
+      jiraService.findTickets.mockResolvedValue({
+        data: {
+          issues: [
+            { key: 'FND-1', fields: { status: statusField('Done'), customfield_svccat: 'Payroll' } },
+            { key: 'FND-2', fields: { status: statusField('Open'), customfield_svccat: 'IT' } },
+            { key: 'FND-3', fields: { status: statusField('Done'), customfield_svccat: 'Payroll' } },
+          ],
+        },
+      });
+    });
+
+    it('renders a filter dropdown for the filter root\'s column with its distinct values, and requests the field from Jira', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ filterParams: { column: 'Service Category', labels: 'Service Category' } }));
+      await runStep();
+
+      expect(jiraService.findTickets).toHaveBeenCalledWith(
+        'System JIRA',
+        'project = FND',
+        expect.stringContaining('customfield_svccat'),
+      );
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(1);
+      expect($('.konviw-tablechart-filter-label').text()).toBe('Service Category');
+      const optionValues = $('.konviw-tablechart-filter option').map((_i, el) => $(el).text()).get();
+      expect(optionValues).toEqual(['All', 'IT', 'Payroll']);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(1);
+
+      const html = context.getHtmlBody();
+      expect(html).toContain('data-konviw-tablechart-data="konviw-tp-filter-0"');
+      expect(html).toContain('"gridId":"tp-0"');
+      expect(html).toContain('window.konviwCharts["jira-0-0"]');
+    });
+
+    it('does not render a filter when the configured column has only one distinct value', async () => {
+      jiraService.findTickets.mockResolvedValue({
+        data: {
+          issues: [
+            { key: 'FND-1', fields: { status: statusField('Done'), customfield_svccat: 'Payroll' } },
+            { key: 'FND-2', fields: { status: statusField('Open'), customfield_svccat: 'Payroll' } },
+          ],
+        },
+      });
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ filterParams: { column: 'Service Category' } }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(0);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(0);
+    });
+
+    it('does not render a filter when the filter column does not resolve to a known Jira field', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ filterParams: { column: 'Not A Real Field' } }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(0);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(0);
+    });
+
+    it('does not render a filter when the tree root is not a filter node', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({
+        serialized: JSON.stringify([{ type: 'chart', params: { column: 'Status', aggregation: 'Status', type: 'Column' } }]),
+      }));
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(0);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(0);
+    });
+
+    it('tolerates a filter root with no params object at all', async () => {
+      context.setHtmlBody(processorViewHtml());
+      context.setBodyStorage(buildProcessorStorage({ serialized: JSON.stringify([{ type: 'filter' }]) }));
+      await expect(runStep()).resolves.toBeUndefined();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(0);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(0);
+      expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+
+    it('injects the filter-apply script only once across multiple filterable macros', async () => {
+      context.setHtmlBody(processorViewHtml(2));
+      const macro = buildProcessorStorage({ filterParams: { column: 'Service Category' } });
+      context.setBodyStorage(macro + macro);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('.konviw-tablechart-filter-bar').length).toBe(2);
+      expect($('script[data-konviw-tablechart-filter]').length).toBe(1);
+    });
+  });
+
+  describe('Legacy table-chart error handling', () => {
+    it('never breaks the page when parsing the source table throws', async () => {
+      const convertSpy = jest.spyOn(Tabletojson, 'convert').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      try {
+        context.setHtmlBody(viewHtml);
+        context.setBodyStorage(storageXml);
+        await expect(runStep()).resolves.toBeUndefined();
+        expect(context.getCheerioBody()('.konviw-table-chart').length).toBe(0);
+      } finally {
+        convertSpy.mockRestore();
+      }
+    });
+
+    it('removes a table-chart placeholder that has neither a chart nor any source table', async () => {
+      const emptyStorage = `
+        <ac:structured-macro ac:name="table-chart" ac:schema-version="1">
+          <ac:parameter ac:name="column">Month</ac:parameter>
+          <ac:rich-text-body><p>no table here</p></ac:rich-text-body>
+        </ac:structured-macro>`;
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage(emptyStorage);
+      await runStep();
+
+      const $ = context.getCheerioBody();
+      expect($('[data-macro-name="table-chart"]').length).toBe(0);
+      expect($('table.confluenceTable').length).toBe(0);
+    });
+
+    it('removes a table-chart placeholder with no matching storage macro (index mismatch)', async () => {
+      context.setHtmlBody(viewHtml);
+      context.setBodyStorage('');
+      await runStep();
+
+      expect(context.getCheerioBody()('[data-macro-name="table-chart"]').length).toBe(0);
     });
   });
 });

--- a/tests/unit/utils/tableProcessorJira.spec.ts
+++ b/tests/unit/utils/tableProcessorJira.spec.ts
@@ -1,0 +1,391 @@
+import * as cheerio from 'cheerio';
+import {
+  parseSerializedTree,
+  findChartNodes,
+  extractJiraDatasource,
+  resolveFieldId,
+  extractGroupLabel,
+  extractPerIssueLabels,
+  distinctSortedLabels,
+  aggregateByCategory,
+  buildJiraGridTable,
+  TableProcessorNode,
+} from '../../../src/proxy-page/utils/tableProcessorJira';
+
+describe('tableProcessorJira / parseSerializedTree', () => {
+  it('returns null for empty/falsy input', () => {
+    expect(parseSerializedTree('')).toBeNull();
+    expect(parseSerializedTree(undefined as unknown as string)).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseSerializedTree('{not json')).toBeNull();
+  });
+
+  it('parses a plain object tree', () => {
+    const tree = parseSerializedTree('{"type":"filter","params":{}}');
+    expect(tree).toEqual({ type: 'filter', params: {} });
+  });
+
+  it('takes the first element when the root is an array', () => {
+    const tree = parseSerializedTree('[{"type":"filter"},{"type":"chart"}]');
+    expect(tree).toEqual({ type: 'filter' });
+  });
+
+  it('returns null when the parsed JSON is itself null', () => {
+    expect(parseSerializedTree('null')).toBeNull();
+  });
+});
+
+describe('tableProcessorJira / findChartNodes', () => {
+  it('returns an empty array for a null root', () => {
+    expect(findChartNodes(null)).toEqual([]);
+  });
+
+  it('returns the root itself when it is a chart node', () => {
+    const root: TableProcessorNode = { type: 'chart', params: { column: 'X' } };
+    expect(findChartNodes(root)).toEqual([root]);
+  });
+
+  it('returns an empty array when no node in the tree is a chart', () => {
+    const root: TableProcessorNode = { type: 'filter', child: [{ type: 'pivot' }] };
+    expect(findChartNodes(root)).toEqual([]);
+  });
+
+  it('collects every chart node found anywhere in a nested tree', () => {
+    const chartA: TableProcessorNode = { type: 'chart', params: { column: 'A' } };
+    const chartB: TableProcessorNode = { type: 'chart', params: { column: 'B' } };
+    const root: TableProcessorNode = {
+      type: 'filter',
+      child: [
+        { type: 'pivot', child: [chartA] },
+        chartB,
+      ],
+    };
+    expect(findChartNodes(root)).toEqual(expect.arrayContaining([chartA, chartB]));
+    expect(findChartNodes(root)).toHaveLength(2);
+  });
+
+  it('tolerates nodes with no child property', () => {
+    const root: TableProcessorNode = { type: 'chart' };
+    expect(findChartNodes(root)).toEqual([root]);
+  });
+
+  it('skips falsy entries in a child array', () => {
+    const root: TableProcessorNode = { type: 'filter', child: [null as unknown as TableProcessorNode] };
+    expect(findChartNodes(root)).toEqual([]);
+  });
+});
+
+const loadRichTextBody = (innerHtml: string) => {
+  const $xml = cheerio.load(
+    `<ac:rich-text-body>${innerHtml}</ac:rich-text-body>`,
+    { xmlMode: true },
+  );
+  const richTextBody = $xml('ac\\:rich-text-body').get(0);
+  return { $xml, richTextBody };
+};
+
+describe('tableProcessorJira / extractJiraDatasource', () => {
+  it('returns null when there is no data-datasource anchor', () => {
+    const { $xml, richTextBody } = loadRichTextBody('<p>no card here</p>');
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when the data-datasource attribute is not valid JSON', () => {
+    const { $xml, richTextBody } = loadRichTextBody('<a data-datasource="{not json">link</a>');
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when the JSON has no jql', () => {
+    const datasource = JSON.stringify({ parameters: {}, views: [{ properties: { columns: [{ key: 'key' }] } }] });
+    const { $xml, richTextBody } = loadRichTextBody(`<a data-datasource='${datasource}'>link</a>`);
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when views/columns are missing', () => {
+    const datasource = JSON.stringify({ parameters: { jql: 'project = X' } });
+    const { $xml, richTextBody } = loadRichTextBody(`<a data-datasource='${datasource}'>link</a>`);
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when the "parameters" object is entirely absent', () => {
+    const datasource = JSON.stringify({ views: [{ properties: { columns: [{ key: 'key' }] } }] });
+    const { $xml, richTextBody } = loadRichTextBody(`<a data-datasource='${datasource}'>link</a>`);
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when every column key is falsy or the column itself is null', () => {
+    const datasource = JSON.stringify({
+      parameters: { jql: 'project = X' },
+      views: [{ properties: { columns: [{}, { key: '' }, null] } }],
+    });
+    const { $xml, richTextBody } = loadRichTextBody(`<a data-datasource='${datasource}'>link</a>`);
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('returns null when the data-datasource JSON parses to null', () => {
+    const { $xml, richTextBody } = loadRichTextBody('<a data-datasource="null">link</a>');
+    expect(extractJiraDatasource($xml, richTextBody)).toBeNull();
+  });
+
+  it('extracts the jql and column keys from a well-formed datasource card', () => {
+    const datasource = JSON.stringify({
+      parameters: { jql: 'project in (BOIP) ORDER BY created DESC' },
+      views: [{ type: 'table', properties: { columns: [{ key: 'issuetype' }, { key: 'key' }, { key: 'customfield_123' }] } }],
+    });
+    const { $xml, richTextBody } = loadRichTextBody(`<a data-datasource='${datasource}'>link</a>`);
+    expect(extractJiraDatasource($xml, richTextBody)).toEqual({
+      jql: 'project in (BOIP) ORDER BY created DESC',
+      columnKeys: ['issuetype', 'key', 'customfield_123'],
+    });
+  });
+});
+
+describe('tableProcessorJira / resolveFieldId', () => {
+  const jiraFields = [
+    { id: 'customfield_111', name: 'Submitted month' },
+    { id: 'status', name: 'Status' },
+  ];
+
+  it('returns undefined for a falsy label', () => {
+    expect(resolveFieldId('', jiraFields)).toBeUndefined();
+    expect(resolveFieldId(undefined as unknown as string, jiraFields)).toBeUndefined();
+  });
+
+  it('returns undefined when no field matches', () => {
+    expect(resolveFieldId('Not A Field', jiraFields)).toBeUndefined();
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    expect(resolveFieldId('  submitted MONTH  ', jiraFields)).toBe('customfield_111');
+  });
+
+  it('tolerates a missing/undefined fields list', () => {
+    expect(resolveFieldId('Status', undefined as unknown as any[])).toBeUndefined();
+  });
+
+  it('tolerates a null/nameless entry in the fields list', () => {
+    const fieldsWithGaps = [null, { id: 'status' }, ...jiraFields] as unknown as any[];
+    expect(resolveFieldId('Status', fieldsWithGaps)).toBe('status');
+  });
+});
+
+describe('tableProcessorJira / extractGroupLabel', () => {
+  it('returns an empty string for null/undefined', () => {
+    expect(extractGroupLabel(null)).toBe('');
+    expect(extractGroupLabel(undefined)).toBe('');
+  });
+
+  it('stringifies plain scalars', () => {
+    expect(extractGroupLabel('Backlog')).toBe('Backlog');
+    expect(extractGroupLabel(42)).toBe('42');
+  });
+
+  it('formats a JSON-encoded {start,end} date-range string as its start month/year (a "Submitted month"-style field)', () => {
+    expect(extractGroupLabel('{"start":"2026-07-01","end":"2026-07-31"}')).toBe('Jul 2026');
+  });
+
+  it('falls back to the raw string for {start,...}-shaped JSON with an unparseable date', () => {
+    expect(extractGroupLabel('{"start":"not-a-date","end":"2026-07-31"}')).toBe('{"start":"not-a-date","end":"2026-07-31"}');
+  });
+
+  it('falls back to the raw string when "start" is present but not a string', () => {
+    const raw = '{"start":123,"end":"2026-07-31"}';
+    expect(extractGroupLabel(raw)).toBe(raw);
+  });
+
+  it('falls back to the raw string for malformed JSON that merely starts with "{" and mentions "start"', () => {
+    expect(extractGroupLabel('{"start": not valid json')).toBe('{"start": not valid json');
+  });
+
+  it('falls back to the raw string for a "{"-prefixed string with no "start" key', () => {
+    expect(extractGroupLabel('{"foo":"bar"}')).toBe('{"foo":"bar"}');
+  });
+
+  it('does not attempt date-range parsing for strings that do not start with "{"', () => {
+    expect(extractGroupLabel('"start":"2026-07-01"')).toBe('"start":"2026-07-01"');
+  });
+
+  it('reads .value off an option-shaped object', () => {
+    expect(extractGroupLabel({ value: 'Service Category' })).toBe('Service Category');
+  });
+
+  it('reads .name off a user/status/component-shaped object when there is no .value', () => {
+    expect(extractGroupLabel({ name: 'Done' })).toBe('Done');
+  });
+
+  it('returns an empty string for an object with neither .value nor .name', () => {
+    expect(extractGroupLabel({ start: '2026-01-01', end: '2026-02-01' })).toBe('');
+  });
+
+  it('joins array values, dropping empty entries', () => {
+    expect(extractGroupLabel([{ name: 'A' }, {}, { value: 'B' }])).toBe('A, B');
+  });
+});
+
+describe('tableProcessorJira / aggregateByCategory', () => {
+  it('returns empty categories/counts for no issues', () => {
+    expect(aggregateByCategory([], 'status')).toEqual({ categories: [], counts: [] });
+  });
+
+  it('groups issues by category label, preserving first-seen order', () => {
+    const issues = [
+      { fields: { status: { name: 'Open' } } },
+      { fields: { status: { name: 'Done' } } },
+      { fields: { status: { name: 'Open' } } },
+    ];
+    expect(aggregateByCategory(issues, 'status')).toEqual({
+      categories: ['Open', 'Done'],
+      counts: [2, 1],
+    });
+  });
+
+  it('buckets issues with a missing/unlabelable field value under "Unspecified"', () => {
+    const issues = [{ fields: { status: null } }, { fields: {} }];
+    expect(aggregateByCategory(issues, 'status')).toEqual({
+      categories: ['Unspecified'],
+      counts: [2],
+    });
+  });
+
+  it('tolerates a null/undefined issues list', () => {
+    expect(aggregateByCategory(null as unknown as any[], 'status')).toEqual({ categories: [], counts: [] });
+    expect(aggregateByCategory(undefined as unknown as any[], 'status')).toEqual({ categories: [], counts: [] });
+  });
+
+  it('tolerates a null issue entry and an issue with no fields object at all', () => {
+    const issues = [null as unknown as { fields: any }, {} as { fields: any }];
+    expect(aggregateByCategory(issues, 'status')).toEqual({
+      categories: ['Unspecified'],
+      counts: [2],
+    });
+  });
+});
+
+describe('tableProcessorJira / extractPerIssueLabels', () => {
+  it('returns one label per issue, in fetch order, defaulting unlabelable values to "Unspecified"', () => {
+    const issues = [
+      { fields: { status: { name: 'Open' } } },
+      { fields: { status: null } },
+      { fields: { status: { name: 'Done' } } },
+    ];
+    expect(extractPerIssueLabels(issues, 'status')).toEqual(['Open', 'Unspecified', 'Done']);
+  });
+
+  it('tolerates a null/undefined issues list', () => {
+    expect(extractPerIssueLabels(null as unknown as any[], 'status')).toEqual([]);
+  });
+});
+
+describe('tableProcessorJira / distinctSortedLabels', () => {
+  it('deduplicates and alphabetically sorts the given labels', () => {
+    expect(distinctSortedLabels(['Open', 'Done', 'Open', 'Backlog'])).toEqual(['Backlog', 'Done', 'Open']);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(distinctSortedLabels([])).toEqual([]);
+  });
+});
+
+describe('tableProcessorJira / buildJiraGridTable', () => {
+  const jiraFields = [
+    { id: 'status', name: 'Status', schema: { type: 'status' } },
+    { id: 'customfield_999', name: 'Known Field', schema: { type: 'string' } },
+    { id: 'labels', name: 'Labels', schema: { type: 'array', items: 'string' } },
+  ];
+
+  const issues = [
+    {
+      key: 'FND-1',
+      fields: {
+        status: {
+          self: '',
+          description: '',
+          iconUrl: '',
+          name: 'Done',
+          id: '3',
+          statusCategory: {
+            self: '', id: 3, key: 'done', colorName: 'green', name: 'Done',
+          },
+        },
+        customfield_999: 'hello',
+        labels: ['a', 'b'],
+        unknownField: 'raw',
+      },
+    },
+  ];
+
+  it('drops unresolved internal customfield_ columns but keeps regular columns like key', () => {
+    const { html } = buildJiraGridTable(issues, ['key', 'status', 'customfield_404'], jiraFields, 'https://x.atlassian.net', 'tp-0');
+    expect(html).toContain('id="gridjstp-0"');
+    // customfield_404 has no matching jiraFields entry, so it must not appear as a rendered column.
+    expect(html).not.toContain('customfield_404');
+  });
+
+  it('builds a Key column using createLinkObject when "key" is requested', () => {
+    const { html, rows } = buildJiraGridTable(issues, ['key'], jiraFields, 'https://x.atlassian.net', 'tp-1');
+    expect(html).toContain('https://x.atlassian.net/browse/FND-1?src=confmacro');
+    // `rows` is index-aligned with `issues` and reused by the caller to
+    // re-filter the table client-side without re-deriving it.
+    expect(rows).toHaveLength(1);
+  });
+
+  it('resolves a known field type through fieldFunctions (status)', () => {
+    const { html } = buildJiraGridTable(issues, ['status'], jiraFields, 'https://x.atlassian.net', 'tp-2');
+    expect(html).toContain('Done');
+  });
+
+  it('resolves an array-schema field via its item type (labels: array of string)', () => {
+    const { html } = buildJiraGridTable(issues, ['labels'], jiraFields, 'https://x.atlassian.net', 'tp-3');
+    expect(html).toContain('"a"');
+    expect(html).toContain('"b"');
+  });
+
+  it('falls back to "Type not treated" for a field with no resolvable formatter', () => {
+    const unresolvedFields = [{ id: 'weird', name: 'Weird', schema: { type: 'not-a-real-type' } }];
+    const weirdIssues = [{ key: 'FND-2', fields: { weird: 'value' } }];
+    const { html } = buildJiraGridTable(weirdIssues, ['weird'], unresolvedFields, 'https://x.atlassian.net', 'tp-4');
+    expect(html).toContain('Type not treated');
+  });
+
+  it('treats an unresolved field id as a plain string column', () => {
+    const { html } = buildJiraGridTable(issues, ['unknownField'], [], 'https://x.atlassian.net', 'tp-5');
+    expect(html).toContain('raw');
+  });
+
+  it('renders an empty grid without throwing when there are no issues', () => {
+    const { html } = buildJiraGridTable([], ['key'], jiraFields, 'https://x.atlassian.net', 'tp-6');
+    expect(html).toContain('id="gridjstp-6"');
+    expect(html).toContain('data: []');
+  });
+
+  it('tolerates a null/undefined jiraFields list', () => {
+    const { html } = buildJiraGridTable(
+      [{ key: 'FND-4', fields: { unknownField: 'raw' } }],
+      ['unknownField'],
+      null as unknown as any[],
+      'https://x.atlassian.net',
+      'tp-10',
+    );
+    expect(html).toContain('raw');
+  });
+
+  it('tolerates a null/undefined issues list and issues with no fields object', () => {
+    expect(() => buildJiraGridTable(null as unknown as any[], ['key'], jiraFields, 'https://x.atlassian.net', 'tp-7')).not.toThrow();
+    const { html } = buildJiraGridTable([{ key: 'FND-9' }], ['key'], jiraFields, 'https://x.atlassian.net', 'tp-8');
+    expect(html).toContain('FND-9');
+  });
+
+  it('tolerates a field with no schema and an array-typed field with no declared item type', () => {
+    const noSchemaFields = [
+      { id: 'noschema', name: 'No Schema' },
+      { id: 'arraynoitems', name: 'Array No Items', schema: { type: 'array' } },
+    ];
+    const rows = [{ key: 'FND-3', fields: { noschema: 'plain', arraynoitems: ['x'] } }];
+    const { html } = buildJiraGridTable(rows, ['noschema', 'arraynoitems'], noSchemaFields, 'https://x.atlassian.net', 'tp-9');
+    // Neither 'undefined' (no schema) nor 'array' (unresolved item type) are in
+    // fieldFunctions, so both columns fall back to the "Type not treated" formatter.
+    expect(html).toContain('Type not treated');
+  });
+});


### PR DESCRIPTION
## Summary
- Renders the current Stiltsoft "Table Filter, Charts & Spreadsheets" macro shape (`ac:name="table-processor"`), which stores config as a JSON tree and sources its data from a live Jira search instead of an inline `<table>` — previously this left Confluence's empty iframe placeholder on the page with nothing rendered.
- Adds a Chart/Table tab toggle (also applied to the legacy `table-chart` macro) instead of always stacking both, plus a "Service Category ="-style filter dropdown that re-aggregates the chart(s) and re-filters the table entirely client-side from data already fetched (no re-fetch from Jira on filter change).
- Fixes garbled axis labels for date-bucket custom fields that store a JSON-encoded `{start,end}` range instead of a plain value, and fixes overlapping axis labels after a filter change (ApexCharts categories/series now update in a single atomic call instead of two separate calls).
- `fixTableChart` is now async with `(config, jiraService)` DI, matching `addJira.ts`/`addJiraSnapshot.ts`'s existing pattern; both `proxy-page.service.ts` call sites updated accordingly.
- New `src/proxy-page/utils/tableProcessorJira.ts` reuses the same field-resolution/Grid.js building blocks `addJira.ts` already established, rather than duplicating that logic.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `eslint` on all changed/new files — clean
- [x] Full unit suite: 50/50 suites, 338/338 tests passing (no regressions in `addJira.spec.ts`/`addJiraSnapshot.spec.ts`, which share `jiraGrid.ts`)
- [x] Coverage on new/changed files: `tableProcessorJira.ts` 100% lines/branches/funcs; `fixTableChart.ts` 100% lines/funcs (3 remaining branch gaps are pre-existing/documented dead defensive code, not reachable via the public API)
- [x] Production build succeeds (`npm run build`), including all 3 scss theme bundles (base, iadc, opella)
- [x] Manually verified live against a real Confluence page with this macro: charts + table render from live Jira data, tab toggle works, filter dropdown correctly re-aggregates the chart and re-filters the table, no leftover placeholders, no duplicate asset injection

