### PR TITLE
chore: add PR template and enforce mandatory sections via CI check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+# Ticket
+_Link to the JIRA ticket and/or Confluence page_
+
+# Problem
+_What is broken/needed? Describe the current behavior._
+
+# Root Cause Analysis
+_Why is this happening? (if not applicable, e.g. new feature, write N/A and say why)_
+
+# Solution
+_What was changed to fix/implement it?_
+
+# Proof
+_Before / after screenshots, logs, or recordings demonstrating the fix/feature (write N/A and say why if truly not applicable)_
+
+| Before | After |
+|--------|-------|
+|        |       |
+
+# Tasks
+- [ ] Clean code principles are respected
+- [ ] Logging is added
+- [ ] Error handling is added, to the right place, without hiding errors
+- [ ] Documentation is updated
+- [ ] List breaking changes (if applicable)
+- [ ] Detailed information about new dependencies (if applicable)
+- [ ] Dependencies consistently updated (e.g. `package-lock.json`)
+- [ ] All newly developed functionality is tested
+- [ ] Unit tests check for both positive and negative cases
+- [ ] Unit tests that became obsolete have been removed
+- [ ] Referencing Pull Requests that need to be merged before/after
+
+# Documentation
+_Link to relevant documentation_
+
+# Project specific tasks
+_Create or remove this section in the template_

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,86 @@
+name: PR Template Check
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches:
+      - 'main'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate-pr-template:
+    name: Validate PR template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required sections are filled
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const COMMENT_MARKER = '<!-- pr-template-check -->';
+
+            const requiredSections = [
+              { name: 'Ticket', placeholder: 'Link to the JIRA ticket and/or Confluence page' },
+              { name: 'Problem', placeholder: 'What is broken/needed? Describe the current behavior.' },
+              { name: 'Root Cause Analysis', placeholder: 'Why is this happening? (skip if not applicable, e.g. new feature)' },
+              { name: 'Solution', placeholder: 'What was changed to fix/implement it?' },
+              { name: 'Proof', placeholder: 'Before / after screenshots, logs, or recordings demonstrating the fix/feature' },
+            ];
+
+            function parseSections(text) {
+              const sections = {};
+              let current = null;
+              for (const line of text.split(/\r?\n/)) {
+                const m = line.match(/^#\s+(.+?)\s*$/);
+                if (m) {
+                  current = m[1].trim();
+                  sections[current] = [];
+                } else if (current) {
+                  sections[current].push(line);
+                }
+              }
+              return sections;
+            }
+
+            function isFilled(lines, placeholder) {
+              const meaningful = lines
+                .map((l) => l.trim())
+                .filter((l) => l.length > 0)
+                .filter((l) => l !== `_${placeholder}_`)
+                .filter((l) => !/^\|?\s*-{2,}\s*\|/.test(l))
+                .filter((l) => !/^\|\s*before\s*\|\s*after\s*\|$/i.test(l))
+                .filter((l) => !/^\|\s*\|\s*\|$/.test(l));
+              return meaningful.length > 0;
+            }
+
+            const sections = parseSections(body);
+            const missing = requiredSections
+              .filter(({ name, placeholder }) => !isFilled(sections[name] || [], placeholder))
+              .map(({ name }) => name);
+
+            const [{ data: comments }] = await Promise.all([
+              github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              }),
+            ]);
+            const existing = comments.find((c) => c.body.includes(COMMENT_MARKER));
+
+            if (missing.length > 0) {
+              const message = `${COMMENT_MARKER}\n### :x: PR template incomplete\n\nPlease fill in the following section(s) before this PR can be merged:\n\n${missing.map((s) => `- **${s}**`).join('\n')}\n\nReplace the placeholder text under each heading with real content (or \`N/A\` if a section genuinely doesn't apply).`;
+              if (existing) {
+                await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body: message });
+              } else {
+                await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: message });
+              }
+              core.setFailed(`PR template is missing required content in: ${missing.join(', ')}`);
+            } else if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${COMMENT_MARKER}\n### :white_check_mark: PR template complete`,
+              });
+            }


### PR DESCRIPTION
# Ticket
N/A — requested directly by the team; no dedicated JIRA ticket for this process/tooling change.

# Problem
konviw has no PR template today. Descriptions are inconsistent, and nothing stops a PR from merging with an empty or low-effort description (no ticket link, no explanation, no before/after proof). Separately, `main` currently has **no required approving reviewers and no required status checks at all** — any PR can be merged with zero review and a red CI run.

# Root Cause Analysis
N/A — this is a new process/tooling addition, not a bug fix.

# Solution
- Added `.github/pull_request_template.md` with required sections: Ticket, Problem, Root Cause Analysis, Solution, Proof, plus a Tasks checklist and optional Documentation / Project specific tasks sections. Mirrors the org-wide standard documented at https://sanofi.atlassian.net/wiki/spaces/SRE/pages/64102272621/Pull+Request+template, extended the same way as https://github.com/Sanofi-GitHub/factory4_digital-foundation_template-frontend/pull/446.
- Added `.github/workflows/pr-template-check.yml`, a GitHub Action that parses the PR description on open/edit/sync/reopen and fails if Ticket/Problem/Root Cause Analysis/Solution/Proof are still placeholder text or empty. It posts/updates a single PR comment listing exactly what's missing.
- Will enable branch protection on `main` once this PR's own checks are green (see Proof): 1 required approving review with stale reviews dismissed on new commits, plus required status checks `Validate PR template`, `Quality (20.x)` and `Quality (22.22.0)` — main currently has none of this.

# Proof
This PR itself is the proof — its "Validate PR template" check (Checks tab) should pass since every required section above is filled with real content rather than placeholder text, and the existing `Quality` checks run the same as on any other PR.

| Before | After |
|--------|-------|
| No `.github/pull_request_template.md`; empty-description PRs mergeable with 0 reviews and no required checks | Template + CI check enforce real descriptions; `main` will require 1 review + green Quality/template checks |

# Tasks
- [x] Clean code principles are respected
- [ ] Logging is added — N/A, no runtime application code
- [ ] Error handling is added, to the right place, without hiding errors — N/A
- [ ] Documentation is updated — N/A, template/workflow are self-documenting via the placeholder copy
- [ ] List breaking changes (if applicable) — none; net-new files only
- [ ] Detailed information about new dependencies (if applicable) — none added
- [ ] Dependencies consistently updated (e.g. `package-lock.json`) — N/A
- [ ] All newly developed functionality is tested — N/A, YAML/workflow config; validated by this PR's own check run
- [ ] Unit tests check for both positive and negative cases — N/A
- [ ] Unit tests that became obsolete have been removed — N/A
- [ ] Referencing Pull Requests that need to be merged before/after — none

# Documentation
Template format follows https://sanofi.atlassian.net/wiki/spaces/SRE/pages/64102272621/Pull+Request+template, extended per https://github.com/Sanofi-GitHub/factory4_digital-foundation_template-frontend/pull/446.

# Project specific tasks
None.