### PR TITLE
fix(table-chart): fall back to Confluence's native table when table-processor has no iframe placeholder

### DIFF
--- a/src/proxy-page/steps/fixTableChart.ts
+++ b/src/proxy-page/steps/fixTableChart.ts
@@ -657,16 +657,39 @@ const findChartNodesSafe = (
   tree: tableProcessorJira.TableProcessorNode | null,
 ): tableProcessorJira.TableProcessorNode[] => tableProcessorJira.findChartNodes(tree);
 
+// The class Confluence's own renderer gives the plain `<table>` it produces
+// when it server-renders a table-processor macro's Jira search itself instead
+// of leaving the iframe placeholder this step was originally built around
+// (see the fallback in `renderTableProcessorMacros` below).
+const NATIVE_JIRA_TABLE_SELECTOR = 'table.jiraWorkItemMacroListViewTable';
+
 // Only called by the default export when it has already confirmed at least
-// one `table-processor` placeholder exists, so `placeholders` is never empty here.
+// one `table-processor` placeholder (iframe or native-rendered table) exists,
+// but `placeholders` can still end up empty here — see the native-table
+// fallback's count guard below.
 const renderTableProcessorMacros = async (
   $: cheerio.CheerioAPI,
   storageBody: string,
   config: ConfigService,
   jiraService: JiraService,
 ): Promise<{ needsApexCharts: boolean; needsGridjs: boolean; needsTabScript: boolean; needsFilterScript: boolean }> => {
-  const placeholders = $('[data-macro-name="table-processor"]');
   const macros = collectStorageTableProcessorMacros(storageBody);
+
+  // Confluence normally leaves an empty iframe placeholder for this macro
+  // (see the file-level doc comment), but on some renditions it instead
+  // server-renders the underlying Jira search straight into a plain table
+  // (no macro id or marker of any kind survives). Only trust that as a
+  // document-order match for our macros when the counts line up exactly —
+  // an unrelated macro producing the same table class elsewhere on the page
+  // could otherwise desync the correlation.
+  let placeholders = $('[data-macro-name="table-processor"]');
+  if (placeholders.length === 0) {
+    const nativeTables = $(NATIVE_JIRA_TABLE_SELECTOR);
+    if (macros.length > 0 && nativeTables.length === macros.length) {
+      placeholders = nativeTables;
+    }
+  }
+
   const baseUrl = config.get('confluence.baseURL');
 
   let jiraFields: any[] = [];
@@ -726,7 +749,8 @@ export default (config: ConfigService, jiraService: JiraService): Step => async 
   const $ = context.getCheerioBody();
 
   const hasLegacyPlaceholders = $('[data-macro-name="table-chart"]').length > 0;
-  const hasProcessorPlaceholders = $('[data-macro-name="table-processor"]').length > 0;
+  const hasProcessorPlaceholders = $('[data-macro-name="table-processor"]').length > 0
+    || $(NATIVE_JIRA_TABLE_SELECTOR).length > 0;
 
   if (!hasLegacyPlaceholders && !hasProcessorPlaceholders) {
     context.getPerfMeasure('fixTableChart');

--- a/tests/unit/steps/fixTableChart.spec.ts
+++ b/tests/unit/steps/fixTableChart.spec.ts
@@ -71,6 +71,22 @@ const processorViewHtml = (count = 1) => `
   </body>
 </html>`;
 
+// Some Confluence renditions server-render a table-processor macro's Jira
+// search directly into a plain table instead of leaving the empty iframe
+// placeholder `processorViewHtml` builds above — no macro id or marker
+// survives, just this Confluence-native table class.
+const NATIVE_JIRA_TABLE = '<table class="jiraWorkItemMacroListViewTable"><thead><tr><th>Key</th></tr>'
+  + '</thead><tbody><tr><td>FND-1</td></tr></tbody></table>';
+
+const processorNativeTableViewHtml = (count = 1) => `
+<html>
+  <body>
+    <div id="Content">
+      ${NATIVE_JIRA_TABLE.repeat(count)}
+    </div>
+  </body>
+</html>`;
+
 // The view body Confluence returns for a Connect "Table Filters and Charts"
 // macro: only an empty iframe placeholder, no table nor chart.
 const viewHtml = `
@@ -833,6 +849,77 @@ describe('ConfluenceProxy / fixTableChart', () => {
       const $ = context.getCheerioBody();
       expect($('.konviw-table-chart').length).toBe(0);
       expect(context.getHtmlBody()).toContain('id="gridjstp-0"');
+    });
+  });
+
+  describe('table-processor: Confluence-native table rendering (no iframe placeholder)', () => {
+    beforeEach(() => {
+      jiraService.getFields.mockResolvedValue([
+        { id: 'status', name: 'Status', schema: { type: 'status' } },
+      ]);
+      jiraService.findTickets.mockResolvedValue({
+        data: {
+          issues: [
+            { key: 'FND-1', fields: { status: statusField('Done') } },
+            { key: 'FND-2', fields: { status: statusField('Open') } },
+            { key: 'FND-3', fields: { status: statusField('Done') } },
+          ],
+        },
+      });
+    });
+
+    it('replaces the native list-view table with the chart/table toggle when its count matches the storage macro count', async () => {
+      context.setHtmlBody(processorNativeTableViewHtml());
+      context.setBodyStorage(buildProcessorStorage());
+      await runStep();
+
+      expect(jiraService.findTickets).toHaveBeenCalledWith(
+        'System JIRA',
+        'project = FND',
+        expect.stringContaining('status'),
+      );
+
+      const $ = context.getCheerioBody();
+      expect($('table.jiraWorkItemMacroListViewTable').length).toBe(0);
+      expect($('.konviw-tablechart-group').length).toBe(1);
+      expect($('.konviw-tablechart-tab').length).toBe(2);
+      expect($('script[data-konviw-apexcharts]').length).toBe(1);
+      expect($('script[src*="gridjs.production.min.js"]').length).toBe(1);
+    });
+
+    it('matches multiple native tables to their storage macros by document order', async () => {
+      context.setHtmlBody(processorNativeTableViewHtml(2));
+      context.setBodyStorage(buildProcessorStorage() + buildProcessorStorage());
+      await runStep();
+
+      expect(jiraService.findTickets).toHaveBeenCalledTimes(2);
+      const $ = context.getCheerioBody();
+      expect($('table.jiraWorkItemMacroListViewTable').length).toBe(0);
+      expect($('.konviw-tablechart-group').length).toBe(2);
+    });
+
+    it('leaves the native tables untouched when their count does not match the storage macro count (ambiguous correlation)', async () => {
+      // Three native tables (e.g. an unrelated Jira Issues macro sharing the
+      // same Confluence table class) but only one table-processor macro in
+      // storage: matching by document order would be a guess, so skip
+      // rendering entirely rather than risk misattributing a table.
+      context.setHtmlBody(processorNativeTableViewHtml(3));
+      context.setBodyStorage(buildProcessorStorage());
+      await expect(runStep()).resolves.toBeUndefined();
+
+      expect(jiraService.findTickets).not.toHaveBeenCalled();
+      const $ = context.getCheerioBody();
+      expect($('table.jiraWorkItemMacroListViewTable').length).toBe(3);
+      expect($('.konviw-tablechart-group').length).toBe(0);
+    });
+
+    it('does nothing when there are no native tables and no iframe placeholders', async () => {
+      context.setHtmlBody('<html><body><div id="Content"><p>no macros here</p></div></body></html>');
+      context.setBodyStorage('');
+      await runStep();
+
+      expect(jiraService.getFields).not.toHaveBeenCalled();
+      expect(jiraService.findTickets).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# Ticket
N/A — found while manually verifying #693 against a real Confluence page (konviw space, page 67121287386).

# Problem
After #693 merged, the "Table Filter, Charts & Spreadsheets" macro still showed only raw, unstyled tables stacked one after another — no chart option, no tab toggle, no filter dropdown, and raw `{"start":...,"end":...}` JSON leaking into date columns.

# Root Cause Analysis
`fixTableChart.ts` was built on the assumption that Confluence always leaves an empty iframe placeholder (`data-macro-name="table-processor"`) for this macro in `body.view`, and correlates it to the `body.storage` macro by document order.

Fetching the real page directly from the Confluence API confirmed that assumption doesn't hold here: `body.storage` has 7 `table-processor` macros, but `body.view` has **zero** `data-macro-name="table-processor"` placeholders. Confluence instead server-renders each macro's Jira search straight into a plain `<table class="jiraWorkItemMacroListViewTable">`, with no macro id or marker surviving. Since the placeholder selector never matched, the entire chart/table/tab/filter pipeline (`renderTableProcessorMacros`) silently never ran, and readers saw Confluence's bare native table markup for all 7 macros.

# Solution
`fixTableChart.ts` now falls back to matching `table.jiraWorkItemMacroListViewTable` elements by document order when no iframe placeholders exist — but only when their count exactly matches the number of `table-processor` macros found in storage, so an unrelated macro that happens to share the same table class can't desync the correlation. Verified by rebuilding and running against the real page: all 7 macros now render as Chart/Table toggle groups with working ApexCharts, Grid.js table, and the "Service Category" filter dropdown.

# Proof
| Before | After |
|--------|-------|
| 7 raw, unstyled `jiraWorkItemMacroListViewTable` tables stacked with no charts, no tabs, and raw JSON in date columns | 7 macros each rendering a Chart/Table tab toggle, working ApexCharts bar chart, sortable/searchable Grid.js table with formatted dates and status badges, and a working filter dropdown |

# Tasks
- [x] Clean code principles are respected
- [x] Logging is added (existing `logger.error` calls cover the new fallback path)
- [x] Error handling is added, to the right place, without hiding errors
- [ ] Documentation is updated — N/A, no user-facing docs for this internal rendering step
- [ ] List breaking changes (if applicable) — N/A, none
- [ ] Detailed information about new dependencies (if applicable) — N/A, no new dependencies
- [ ] Dependencies consistently updated (e.g. `package-lock.json`) — N/A, no dependency changes
- [x] All newly developed functionality is tested
- [x] Unit tests check for both positive and negative cases
- [ ] Unit tests that became obsolete have been removed — N/A, no tests removed
- [ ] Referencing Pull Requests that need to be merged before/after — builds on #693

# Documentation
N/A

# Project specific tasks
N/A — section not applicable, removed per template instructions.