### PR TITLE
chore: re-add the PR template, without enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+# Ticket
+_Link to the JIRA ticket and/or Confluence page_
+
+# Problem
+_What is broken/needed? Describe the current behavior._
+
+# Root Cause Analysis
+_Why is this happening? (if not applicable, e.g. new feature, write N/A and say why)_
+
+# Solution
+_What was changed to fix/implement it?_
+
+# Proof
+_Before / after screenshots, logs, or recordings demonstrating the fix/feature (write N/A and say why if truly not applicable)_
+
+| Before | After |
+|--------|-------|
+|        |       |
+
+# Tasks
+- [ ] Clean code principles are respected
+- [ ] Logging is added
+- [ ] Error handling is added, to the right place, without hiding errors
+- [ ] Documentation is updated
+- [ ] List breaking changes (if applicable)
+- [ ] Detailed information about new dependencies (if applicable)
+- [ ] Dependencies consistently updated (e.g. `package-lock.json`)
+- [ ] All newly developed functionality is tested
+- [ ] Unit tests check for both positive and negative cases
+- [ ] Unit tests that became obsolete have been removed
+- [ ] Referencing Pull Requests that need to be merged before/after
+
+# Documentation
+_Link to relevant documentation_
+
+# Project specific tasks
+_Create or remove this section in the template_


### PR DESCRIPTION
## Summary
- Re-adds `.github/pull_request_template.md`, byte-for-byte identical to what #694 added (Ticket/Problem/Root Cause Analysis/Solution/Proof/Tasks/Documentation/Project specific tasks sections).
- Does **not** re-add `pr-template-check.yml` or any branch protection — no CI check, no required review, no required status check. GitHub will simply pre-fill the PR description box with this template when someone opens a PR; filling it in is optional, matching how the repo worked before #694 but with the convenience of a starting template.

## Why
Per request: keep the template itself (useful as a checklist/reminder) but drop everything that made it mandatory, since that enforcement was what broke semantic-release's release automation (see #694 → #695/#696 failures → #698 revert).

## Test plan
- [x] Diffed the new file against `d41fece9:.github/pull_request_template.md` (the original #694 commit) — identical
- [x] Confirmed no workflow file and no branch protection accompany this change