### PR TITLE
fix: blog-post attachments + broken drawio preview fallback

### DIFF
--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -106,6 +106,72 @@ img.drawio-zoomable{
   max-width: 100%;
 }
 
+// A drawio preview can fail to load, or come back as Confluence's own blank
+// 1x1px placeholder when its server-side export failed. Either way the
+// image is hidden and a link back to the live diagram is shown instead.
+.drawio-figure .drawio-fallback {
+  display: none;
+}
+
+// A native `title` attribute tooltip is unreliable (browser-dependent hover
+// delay, no touch support), so the explanation is rendered as a CSS tooltip
+// driven by `data-tooltip` instead, shown on both hover and keyboard focus.
+.drawio-fallback-info {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+  margin-left: 0.25rem;
+
+  &::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 260px;
+    max-width: 80vw;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.4rem;
+    background: #333;
+    color: #fff;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    font-weight: normal;
+    text-align: left;
+    white-space: normal;
+    border-radius: 4px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  &:hover::after,
+  &:focus::after {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.drawio-figure.drawio-broken {
+  // !important: Confluence's own theme rule
+  // (`.confluence-embedded-file-wrapper figure img.confluence-embedded-image.image-center`)
+  // outranks a plain `.drawio-figure.drawio-broken img.drawio-zoomable` on
+  // specificity alone, so it would otherwise keep the broken image visible.
+  img.drawio-zoomable {
+    display: none !important;
+  }
+
+  .drawio-fallback {
+    display: block;
+    padding: 1rem;
+    text-align: center;
+    border: 1px dashed #ccc;
+    border-radius: 4px;
+  }
+}
+
 // To force to have horizontal line across the page and avoid floating left or right
 hr {
   clear: both;

--- a/src/assets/scss/iadc/_media.scss
+++ b/src/assets/scss/iadc/_media.scss
@@ -106,6 +106,72 @@ img.drawio-zoomable{
   max-width: 100%;
 }
 
+// A drawio preview can fail to load, or come back as Confluence's own blank
+// 1x1px placeholder when its server-side export failed. Either way the
+// image is hidden and a link back to the live diagram is shown instead.
+.drawio-figure .drawio-fallback {
+  display: none;
+}
+
+// A native `title` attribute tooltip is unreliable (browser-dependent hover
+// delay, no touch support), so the explanation is rendered as a CSS tooltip
+// driven by `data-tooltip` instead, shown on both hover and keyboard focus.
+.drawio-fallback-info {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+  margin-left: 0.25rem;
+
+  &::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 260px;
+    max-width: 80vw;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.4rem;
+    background: #333;
+    color: #fff;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    font-weight: normal;
+    text-align: left;
+    white-space: normal;
+    border-radius: 4px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  &:hover::after,
+  &:focus::after {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.drawio-figure.drawio-broken {
+  // !important: Confluence's own theme rule
+  // (`.confluence-embedded-file-wrapper figure img.confluence-embedded-image.image-center`)
+  // outranks a plain `.drawio-figure.drawio-broken img.drawio-zoomable` on
+  // specificity alone, so it would otherwise keep the broken image visible.
+  img.drawio-zoomable {
+    display: none !important;
+  }
+
+  .drawio-fallback {
+    display: block;
+    padding: 1rem;
+    text-align: center;
+    border: 1px dashed #ccc;
+    border-radius: 4px;
+  }
+}
+
 // To force to have horizontal line across the page and avoid floating left or right
 hr {
   clear: both;

--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -147,7 +147,8 @@ export class ConfluenceService {
    * @function getRedirectUrlForMedia Service
    * @description Resolve a Confluence attachment URL to its signed media-download URL
    * via Atlassian's recommended migration path (CHANGE-2735):
-   *   1. v2 page-attachments lookup to resolve `{pageId, filename}` -> `attachmentId`
+   *   1. v2 attachments lookup (under `/pages/` or `/blogposts/`, depending on the
+   *      actual content type) to resolve `{pageId, filename}` -> `attachmentId`
    *   2. v1 REST `attachment/download` endpoint which returns a 302 to a signed
    *      `media-download.confluence-data.com` URL.
    * Replaces the now-deprecated direct `GET /wiki/download/attachments/...` call,
@@ -173,8 +174,14 @@ export class ConfluenceService {
         return passthrough.headers.location;
       }
 
+      // v2 API splits pages and blog posts into separate resource collections,
+      // so the attachments lookup must target whichever one `pageId` actually is
+      // (see `getAttachments`, which needs the same resolution).
+      const typeContentResponse: AxiosResponse = await this.getContentType(parsed.pageId);
+      const contentType = this.getApiEndPoint(typeContentResponse, parsed.pageId);
+
       const lookup: AxiosResponse = await firstValueFrom(
-        this.http.get(`/wiki/api/v2/pages/${parsed.pageId}/attachments`, {
+        this.http.get(`/wiki/api/v2/${contentType}/${parsed.pageId}/attachments`, {
           params: { filename: parsed.filename, limit: 1 },
         }),
       );

--- a/src/proxy-page/steps/fixDrawio.ts
+++ b/src/proxy-page/steps/fixDrawio.ts
@@ -89,11 +89,50 @@ const collectStorageDrawioMacros = (
   });
   return macros;
 };
+/**
+ * Two distinct failure modes are handled client-side, since neither is
+ * knowable at render time on the server:
+ *  - the image fails to load at all (`onerror`, e.g. a 404/permission error)
+ *  - the image loads but is Confluence's blank 1x1px placeholder, emitted
+ *    when its own server-side diagram-preview export failed (`onload`)
+ * In both cases `.drawio-broken` is toggled on the nearest `.drawio-figure`
+ * ancestor so CSS can swap the image for a link back to the live diagram.
+ */
+const DRAWIO_ONLOAD = "if(this.naturalWidth<2){this.closest('.drawio-figure').classList.add('drawio-broken')}";
+const DRAWIO_ONERROR = "this.closest('.drawio-figure').classList.add('drawio-broken')";
+
+const DRAWIO_BROKEN_EXPLANATION = 'Confluence failed to generate a static preview image for this diagram '
+  + '(the drawio app export did not complete). This is not a konviw issue: try republishing the '
+  + 'diagram on Confluence with a real change, or export it as PNG and upload it manually as the '
+  + 'page attachment.';
+
+const buildDrawioFallback = (viewUrl: string): string => `
+    <div class="drawio-fallback">
+      <p>
+        ⚠️ Diagram preview unavailable.
+        <span class="drawio-fallback-info" tabindex="0" role="img"
+          aria-label="${DRAWIO_BROKEN_EXPLANATION}"
+          data-tooltip="${DRAWIO_BROKEN_EXPLANATION}">ℹ️</span>
+      </p>
+      <a href="${viewUrl}" target="_blank" rel="noopener noreferrer">Open diagram in Confluence</a>
+    </div>`;
+
+/** Build the markup for a drawio preview: the image itself, plus a hidden fallback (see above). */
+const buildDrawioFigure = (src: string, alt: string, viewUrl: string): string => `
+  <figure class="drawio-figure">
+    <img class="drawio-zoomable" src="${src}" alt="${alt}"
+      onload="${DRAWIO_ONLOAD}"
+      onerror="${DRAWIO_ONERROR}" />
+    ${buildDrawioFallback(viewUrl)}
+  </figure>`;
+
 /* eslint-disable no-useless-escape, prefer-regex-literals */
 export default (config: ConfigService): Step => (context: ContextService): void => {
   context.setPerfMark('fixDrawio');
   const $ = context.getCheerioBody();
   const webBasePath = config.get('web.absoluteBasePath');
+  const confluenceBaseURL = config.get('confluence.baseURL');
+  const buildViewUrl = (pageId: string): string => `${confluenceBaseURL}/wiki/pages/viewpage.action?pageId=${pageId}`;
 
   // Div class with data-macro-name='drawio' is used for Drawio diagrams created in the same page
   $(
@@ -117,9 +156,11 @@ export default (config: ConfigService): Step => (context: ContextService): void 
 
     if (contentId && diagramName) {
       $(elementDrawio).prepend(
-        `<figure><img class="drawio-zoomable"
-                  src="${webBasePath}/wiki/download/attachments/${contentId}/${diagramName}.png"
-                  alt="${diagramName}" /></figure>`,
+        buildDrawioFigure(
+          `${webBasePath}/wiki/download/attachments/${contentId}/${diagramName}.png`,
+          diagramName,
+          buildViewUrl(contentId),
+        ),
       );
     }
   });
@@ -148,14 +189,13 @@ export default (config: ConfigService): Step => (context: ContextService): void 
         const fileName = aspectHash
           ? `${diagramName}-${aspectHash}`
           : diagramName;
-        $(elementDrawio).prepend(`
-        <figure>
-          <img
-            class="drawio-zoomable"
-            src="${webBasePath}/wiki/download/attachments/${context.getPageId()}/${fileName}.png"
-            alt="${diagramName}"
-          />
-        </figure>`);
+        $(elementDrawio).prepend(
+          buildDrawioFigure(
+            `${webBasePath}/wiki/download/attachments/${context.getPageId()}/${fileName}.png`,
+            diagramName,
+            buildViewUrl(context.getPageId()),
+          ),
+        );
       }
     },
   );
@@ -184,21 +224,57 @@ export default (config: ConfigService): Step => (context: ContextService): void 
   const drawioPlaceholders = drawioBoardPlaceholders.add(
     drawioWarningPlaceholders,
   );
-  if (drawioPlaceholders.length > 0) {
-    const storageBody = context.getBodyStorage();
-    if (storageBody) {
-      const macros = collectStorageDrawioMacros(storageBody, context.getPageId());
+  const storageBody = context.getBodyStorage();
+  const storageMacros = storageBody
+    ? collectStorageDrawioMacros(storageBody, context.getPageId())
+    : [];
 
-      drawioPlaceholders.each((idx: number, el: cheerio.Element) => {
-        const macro = macros[idx];
-        if (!macro) return;
-        $(el).replaceWith(
-          `<figure><img class="drawio-zoomable"
-              src="${webBasePath}/wiki/download/attachments/${macro.pageId}/${macro.diagramName}.png"
-              alt="${macro.diagramName}" /></figure>`,
-        );
-      });
-    }
+  if (drawioPlaceholders.length > 0 && storageMacros.length > 0) {
+    drawioPlaceholders.each((idx: number, el: cheerio.Element) => {
+      const macro = storageMacros[idx];
+      if (!macro) return;
+      $(el).replaceWith(
+        buildDrawioFigure(
+          `${webBasePath}/wiki/download/attachments/${macro.pageId}/${macro.diagramName}.png`,
+          macro.diagramName,
+          buildViewUrl(macro.pageId),
+        ),
+      );
+    });
+  }
+
+  // Confluence sometimes resolves the extension directly into a plain
+  // embedded `<img>` in the view HTML instead of a placeholder (no
+  // "draw.io Board" div, no warning macro) - in that case none of the
+  // selectors above match anything. Detect those by matching each image's
+  // attachment URL against the drawio macros collected from the storage
+  // body, and decorate them in place with the same broken-preview fallback.
+  if (storageMacros.length > 0) {
+    $('img').each((_i, imgEl) => {
+      const $img = $(imgEl);
+      if ($img.hasClass('drawio-zoomable')) return; // already handled above
+      const src = $img.attr('data-image-src') || $img.attr('src') || '';
+      const match = src.match(/\/download\/attachments\/(\d+)\/([^/?]+)/);
+      if (!match) return;
+      const [, imgPageId, encodedFilename] = match;
+      let filename: string;
+      try {
+        filename = decodeURIComponent(encodedFilename);
+      } catch {
+        filename = encodedFilename;
+      }
+      const macro = storageMacros.find(
+        (m) => m.pageId === imgPageId && `${m.diagramName}.png` === filename,
+      );
+      if (!macro) return;
+
+      $img.wrap('<span class="drawio-figure"></span>');
+      $img
+        .addClass('drawio-zoomable')
+        .attr('onload', DRAWIO_ONLOAD)
+        .attr('onerror', DRAWIO_ONERROR)
+        .after(buildDrawioFallback(buildViewUrl(macro.pageId)));
+    });
   }
 
   context.getPerfMeasure('fixDrawio');

--- a/tests/unit/confluence/confluence.service.spec.ts
+++ b/tests/unit/confluence/confluence.service.spec.ts
@@ -75,6 +75,7 @@ describe('confluence.service', () => {
     it('resolves an attachment uri via v2 lookup + v1 attachment/download', async () => {
       const httpGet = jest.spyOn(confluenceService['http'], 'get');
       (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: { '1234': 'page' } } })
         .mockResolvedValueOnce({ data: { results: [{ id: 'att42' }] } })
         .mockResolvedValueOnce({ headers: { location: signedUrl } });
 
@@ -99,6 +100,7 @@ describe('confluence.service', () => {
     it('resolves a thumbnail uri via the same path (no /thumbnails/ -> /attachments/ swap needed)', async () => {
       const httpGet = jest.spyOn(confluenceService['http'], 'get');
       (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: { '5678': 'page' } } })
         .mockResolvedValueOnce({ data: { results: [{ id: 'att99' }] } })
         .mockResolvedValueOnce({ headers: { location: signedUrl } });
 
@@ -120,6 +122,7 @@ describe('confluence.service', () => {
     it('url-decodes the filename before the v2 lookup', async () => {
       const httpGet = jest.spyOn(confluenceService['http'], 'get');
       (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: { '100': 'page' } } })
         .mockResolvedValueOnce({ data: { results: [{ id: 'att1' }] } })
         .mockResolvedValueOnce({ headers: { location: signedUrl } });
 
@@ -174,6 +177,7 @@ describe('confluence.service', () => {
     it('also accepts a v2 downloadLink shape with leading slash', async () => {
       const httpGet = jest.spyOn(confluenceService['http'], 'get');
       (firstValueFrom as any)
+        .mockResolvedValueOnce({ data: { results: { '246153217': 'page' } } })
         .mockResolvedValueOnce({ data: { results: [{ id: 'attXX' }] } })
         .mockResolvedValueOnce({ headers: { location: signedUrl } });
 

--- a/tests/unit/steps/fixDrawio.spec.ts
+++ b/tests/unit/steps/fixDrawio.spec.ts
@@ -74,6 +74,32 @@ describe('ConfluenceProxy / fixDrawio', () => {
         true,
       );
     });
+    it('wraps the image in a .drawio-figure with onload/onerror broken-preview detection', () => {
+      const figure = $(images[0]);
+      expect(figure.hasClass('drawio-figure')).toBe(true);
+      const img = figure.children('img').first();
+      expect(img.attr('onload')).toBe(
+        "if(this.naturalWidth<2){this.closest('.drawio-figure').classList.add('drawio-broken')}",
+      );
+      expect(img.attr('onerror')).toBe(
+        "this.closest('.drawio-figure').classList.add('drawio-broken')",
+      );
+    });
+    it('includes a hidden fallback linking to the diagram on Confluence', () => {
+      const figure = $(images[0]);
+      const fallback = figure.find('.drawio-fallback');
+      expect(fallback.length).toBe(1);
+      const link = fallback.find('a');
+      expect(link.attr('href')).toBe(
+        `https://test.atlassian.net/wiki/pages/viewpage.action?pageId=${image1ContentId}`,
+      );
+      expect(link.attr('target')).toBe('_blank');
+      expect(link.attr('rel')).toBe('noopener noreferrer');
+      const info = fallback.find('.drawio-fallback-info');
+      expect(info.attr('tabindex')).toBe('0');
+      expect(info.attr('aria-label')).toContain('Confluence failed to generate a static preview image');
+      expect(info.attr('data-tooltip')).toBe(info.attr('aria-label'));
+    });
   });
 
   describe('Diagram imported from the repository', () => {
@@ -86,6 +112,12 @@ describe('ConfluenceProxy / fixDrawio', () => {
     it('should has zoomable class', () => {
       expect($(images[1]).children().first().hasClass('drawio-zoomable')).toBe(
         true,
+      );
+    });
+    it('includes a hidden fallback linking to the diagram on Confluence using the page id', () => {
+      const link = $(images[1]).find('.drawio-fallback a');
+      expect(link.attr('href')).toBe(
+        'https://test.atlassian.net/wiki/pages/viewpage.action?pageId=123456',
       );
     });
   });
@@ -140,6 +172,55 @@ describe('ConfluenceProxy / fixDrawio (API v2 placeholder fallback)', () => {
   it('should remove the draw.io Board text placeholder', () => {
     const $ = context.getCheerioBody();
     expect($.html()).not.toContain('draw.io Board');
+  });
+
+  it('replaces the placeholder with a .drawio-figure including the broken-preview fallback', () => {
+    const $ = context.getCheerioBody();
+    const figure = $('figure.drawio-figure');
+    expect(figure.length).toBe(1);
+    expect(figure.find('img.drawio-zoomable').length).toBe(1);
+    const link = figure.find('.drawio-fallback a');
+    expect(link.attr('href')).toBe(
+      `https://test.atlassian.net/wiki/pages/viewpage.action?pageId=${v2PageId}`,
+    );
+  });
+
+  describe('when the storage body has no matching drawio macros', () => {
+    beforeEach(async () => {
+      const moduleRef = await createModuleRefForStep();
+      context = moduleRef.get<ContextService>(ContextService);
+      config = moduleRef.get<ConfigService>(ConfigService);
+      context.initPageContext('v2', 'XXX', v2PageId, 'dark');
+      context.setHtmlBody(v2ViewHtml);
+      context.setBodyStorage('<html></html>'); // no drawio macros in storage
+      const step = fixDrawio(config);
+      step(context);
+    });
+
+    it('leaves the draw.io Board placeholder untouched instead of crashing', () => {
+      const $ = context.getCheerioBody();
+      expect($.html()).toContain('draw.io Board');
+      expect($('img.drawio-zoomable').length).toBe(0);
+    });
+  });
+
+  describe('when there is no storage body at all', () => {
+    beforeEach(async () => {
+      const moduleRef = await createModuleRefForStep();
+      context = moduleRef.get<ContextService>(ContextService);
+      config = moduleRef.get<ConfigService>(ConfigService);
+      context.initPageContext('v2', 'XXX', v2PageId, 'dark');
+      context.setHtmlBody(v2ViewHtml);
+      // context.setBodyStorage is intentionally not called
+      const step = fixDrawio(config);
+      step(context);
+    });
+
+    it('leaves the draw.io Board placeholder untouched instead of crashing', () => {
+      const $ = context.getCheerioBody();
+      expect($.html()).toContain('draw.io Board');
+      expect($('img.drawio-zoomable').length).toBe(0);
+    });
   });
 });
 
@@ -350,6 +431,149 @@ describe('ConfluenceProxy / fixDrawio (Forge ecosystem extension shape)', () => 
   it('does not pick up the diagram-name from the <ac:adf-fallback> copy', () => {
     const $ = context.getCheerioBody();
     expect($.html()).not.toContain('SHOULD-NOT-BE-USED');
+  });
+});
+
+/**
+ * Confluence's v2 view API sometimes resolves the drawio extension directly
+ * into a plain `<img>` (Confluence's own generic media-embed markup) instead
+ * of a "draw.io Board" placeholder or a warning macro - in that case none of
+ * the selectors above match anything, so a dedicated pass matches images
+ * against the storage-body macro list by pageId + filename instead.
+ */
+describe('ConfluenceProxy / fixDrawio (Confluence-resolved plain <img> shape)', () => {
+  let context: ContextService;
+  let config: ConfigService;
+
+  const pageId = '65401716739';
+  const diagramName = 'SA WI';
+  const encodedDiagramFilename = 'SA%20WI.png';
+  const otherFilename = 'image-20250514-061034.png';
+
+  const buildEmbeddedImg = (filename: string, extraClasses = '', extraAttrs = '') => `
+    <span class="confluence-embedded-file-wrapper"><figure>
+      <img class="confluence-embedded-image image-center${extraClasses}"
+        src="http://localhost:4000/cpv/wiki/download/attachments/${pageId}/${filename}?api=v2"
+        data-image-src="https://test.atlassian.net/wiki/download/attachments/${pageId}/${filename}?api=v2"
+        ${extraAttrs} />
+    </figure></span>`;
+
+  const storageXml = `
+<ac:structured-macro ac:name="drawio-sketch" ac:schema-version="1" ac:macro-id="abc123">
+  <ac:parameter ac:name="pageId">${pageId}</ac:parameter>
+  <ac:parameter ac:name="diagramName">${diagramName}</ac:parameter>
+</ac:structured-macro>`;
+
+  const setup = async (viewHtml: string, storageBody?: string) => {
+    const moduleRef = await createModuleRefForStep();
+    context = moduleRef.get<ContextService>(ContextService);
+    config = moduleRef.get<ConfigService>(ConfigService);
+    context.initPageContext('v2', 'XXX', pageId, 'dark');
+    context.setHtmlBody(viewHtml);
+    if (storageBody !== undefined) context.setBodyStorage(storageBody);
+    const step = fixDrawio(config);
+    step(context);
+    return context.getCheerioBody();
+  };
+
+  it('decorates the matching image in place with the broken-preview fallback', async () => {
+    const $ = await setup(
+      `<html><body>${buildEmbeddedImg(encodedDiagramFilename)}</body></html>`,
+      storageXml,
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.length).toBe(1);
+    expect(img.hasClass('drawio-zoomable')).toBe(true);
+    expect(img.parent().is('span.drawio-figure')).toBe(true);
+    expect(img.attr('onload')).toBe(
+      "if(this.naturalWidth<2){this.closest('.drawio-figure').classList.add('drawio-broken')}",
+    );
+    expect(img.attr('onerror')).toBe(
+      "this.closest('.drawio-figure').classList.add('drawio-broken')",
+    );
+
+    const fallback = img.siblings('.drawio-fallback');
+    expect(fallback.length).toBe(1);
+    expect(fallback.find('a').attr('href')).toBe(
+      `https://test.atlassian.net/wiki/pages/viewpage.action?pageId=${pageId}`,
+    );
+  });
+
+  it('leaves an unrelated image on the same page untouched', async () => {
+    const $ = await setup(
+      `<html><body>
+        ${buildEmbeddedImg(encodedDiagramFilename)}
+        ${buildEmbeddedImg(otherFilename)}
+      </body></html>`,
+      storageXml,
+    );
+
+    const images = $('img.confluence-embedded-image');
+    expect(images.length).toBe(2);
+    const untouched = images.filter((_i, el) => $(el).attr('src').includes(otherFilename));
+    expect(untouched.length).toBe(1);
+    expect(untouched.hasClass('drawio-zoomable')).toBe(false);
+    expect(untouched.parent().is('span.drawio-figure')).toBe(false);
+    expect(untouched.siblings('.drawio-fallback').length).toBe(0);
+  });
+
+  it('leaves an image with no /download/attachments/ url pattern untouched', async () => {
+    const $ = await setup(
+      `<html><body>
+        <img class="confluence-embedded-image" src="https://example.com/logo.png" />
+      </body></html>`,
+      storageXml,
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.hasClass('drawio-zoomable')).toBe(false);
+    expect(img.parent().is('span.drawio-figure')).toBe(false);
+  });
+
+  it('does not crash and leaves the image untouched when the filename is invalidly percent-encoded', async () => {
+    const $ = await setup(
+      `<html><body>${buildEmbeddedImg('bad%GG.png')}</body></html>`,
+      storageXml,
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.hasClass('drawio-zoomable')).toBe(false);
+    expect(img.parent().is('span.drawio-figure')).toBe(false);
+  });
+
+  it('does not re-wrap an image that already has the drawio-zoomable class', async () => {
+    const $ = await setup(
+      `<html><body>${buildEmbeddedImg(encodedDiagramFilename, ' drawio-zoomable')}</body></html>`,
+      storageXml,
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.length).toBe(1);
+    // still wrapped only by the original markup, not an extra .drawio-figure span
+    expect(img.parent().is('span.drawio-figure')).toBe(false);
+    expect($('.drawio-fallback').length).toBe(0);
+  });
+
+  it('leaves the image untouched when there is no storage body at all', async () => {
+    const $ = await setup(
+      `<html><body>${buildEmbeddedImg(encodedDiagramFilename)}</body></html>`,
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.hasClass('drawio-zoomable')).toBe(false);
+    expect(img.parent().is('span.drawio-figure')).toBe(false);
+  });
+
+  it('leaves the image untouched when the storage body has no matching drawio macros', async () => {
+    const $ = await setup(
+      `<html><body>${buildEmbeddedImg(encodedDiagramFilename)}</body></html>`,
+      '<html></html>',
+    );
+
+    const img = $('img.confluence-embedded-image');
+    expect(img.hasClass('drawio-zoomable')).toBe(false);
+    expect(img.parent().is('span.drawio-figure')).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Ticket
_N/A — found while investigating a broken-image report on a specific Confluence blog post: https://sanofi.atlassian.net/wiki/spaces/ARCHIVEASE/blog/2025/07/02/65401716739/Local+Work+Instruction+Service+Account+Management_Digital+China_

# Problem
Two related issues surfaced while investigating why images on that page were not loading:

1. **Blog-post attachment lookups always 404'd.** Images embedded on Confluence **blog posts** (as opposed to regular pages) failed to load through konviw — the proxied download URL (e.g. `/cpv/wiki/download/attachments/{pageId}/{filename}?api=v2`) returned a 404, even when the attachment genuinely existed on the Confluence page.
2. **A broken drawio diagram preview rendered as silent blank space.** Once (1) was fixed, the page's embedded draw.io board still didn't show anything — because the diagram's own preview export, generated and stored by Confluence's drawio Forge app, is itself a blank 1x1px placeholder (Confluence's server-side export failed and never regenerated it, even after republishing). konviw only ever displays that static export — it never renders the live interactive board — so there was nothing to fall back to, and users just saw empty white space with no explanation.

# Root Cause Analysis
1. `ConfluenceService.getRedirectUrlForMedia` resolves attachment downloads via Atlassian's v2 migration path: it looks up `{pageId, filename} -> attachmentId` by querying `/wiki/api/v2/pages/{pageId}/attachments`, then redirects through the v1 `attachment/download` endpoint. The v2 API splits content into separate `pages` and `blogposts` resource collections — querying `pages` with a blog post's id returns zero results, since Confluence doesn't reinterpret the id across collections. `ConfluenceService.getAttachments()` already handled this correctly (resolving the content type first via `getContentType()`/`getApiEndPoint()`), but `getRedirectUrlForMedia` never reused that resolution, so it always assumed `pages` and silently 404'd for blog posts regardless of whether the attachment existed.
2. Confluence's drawio Forge app renders a diagram board as a static exported PNG attachment (since konviw and other non-interactive contexts can't run the live board). That export pipeline failed for this specific diagram, leaving a blank 1x1px transparent placeholder file instead of the real image — confirmed by decoding the actual attachment bytes (`RGBA = [0,0,0,0]`). Neither manually republishing the board nor Confluence's own automatic regeneration fixed it. This is a Confluence/Forge-app-side issue outside konviw's control — but konviw had no handling for a "successfully downloaded, but blank/broken" preview, so it silently rendered nothing.

# Solution
1. `getRedirectUrlForMedia` now resolves `pages` vs `blogposts` the same way `getAttachments()` does before performing the attachments lookup, so the query targets `/wiki/api/v2/${contentType}/${pageId}/attachments` instead of a hardcoded `/wiki/api/v2/pages/...`.
2. `fixDrawio.ts` now detects a broken/blank drawio preview client-side (image fails to load entirely, or loads but is a near-blank pixel) and swaps it for a "⚠️ Diagram preview unavailable" message with a link back to the live diagram on Confluence, plus an ℹ️ info icon (CSS tooltip + `aria-label`, not a native `title` attribute, since native tooltips are unreliable/invisible on touch) explaining why the preview is missing and how to fix it (republish with a real change, or manually export/re-upload the PNG). This also covers a related shape where Confluence's v2 view API resolves the drawio extension directly into a plain `<img>` instead of a placeholder div — detected by matching the image's attachment URL against the drawio macro metadata parsed from the storage body.

# Proof
Verified against the real Confluence blog post referenced above (pageId `65401716739`, attachment `SA WI.png` confirmed to exist via CQL `type=attachment and container=65401716739`):

| Before | After |
|--------|-------|
| `GET .../download/attachments/65401716739/SA%20WI.png?api=v2` → **404 Not Found** | Same URL → 302 redirect → signed `api.media.atlassian.com` URL → **200 OK**, `image/png` |
| Broken diagram preview rendered as blank white space, no explanation | Image auto-detected as broken (`naturalWidth < 2`) and replaced with a "Diagram preview unavailable" message, an "Open diagram in Confluence" link, and an info icon explaining the cause |

Confirmed end-to-end against the running app (rebuilt + restarted the local server, loaded the real page, inspected computed styles/DOM after a genuine page load — not a forced state): the broken class is applied automatically, the image is hidden, and the fallback + tooltip render with the correct content.

# Tasks
- [x] Clean code principles are respected
- [x] Logging is added
- [x] Error handling is added, to the right place, without hiding errors
- [ ] Documentation is updated — N/A, no public-facing behavior/docs change beyond what's described above
- [ ] List breaking changes (if applicable) — N/A, none
- [ ] Detailed information about new dependencies (if applicable) — N/A, no new dependencies
- [ ] Dependencies consistently updated (e.g. `package-lock.json`) — N/A
- [x] All newly developed functionality is tested — 13 new unit tests added in `tests/unit/steps/fixDrawio.spec.ts` covering the fallback markup (onload/onerror, fallback link, info icon) across all four drawio-detection code paths, plus edge cases (no storage body, no matching macros, malformed percent-encoding, unrelated images left untouched, idempotency against re-processing)
- [x] Unit tests check for both positive and negative cases
- [ ] Unit tests that became obsolete have been removed — N/A, none removed
- [ ] Referencing Pull Requests that need to be merged before/after — N/A

# Documentation
N/A