### PR TITLE
fix: fail open on Confluence emoji gateway errors instead of crashing render

### DIFF
--- a/src/confluence/confluence.service.ts
+++ b/src/confluence/confluence.service.ts
@@ -471,42 +471,57 @@ export class ConfluenceService {
   }
 
   async getSpecialAtlassianIcons(image?: string): Promise<any> {
-    const response: AxiosResponse = await firstValueFrom(
-      this.http.get<Content>(
-        '/gateway/api/emoji/atlassian?scale=XHDPI&altScale=XXXHDPI&preferredRepresentation=IMAGE',
-      ),
-    );
-    const results = response.data?.emojis ?? [];
-    if (image) {
-      const imageData = results.find(({ id }) => id === image);
-      const { imagePath } = imageData.representation;
-      return imagePath;
+    try {
+      const response: AxiosResponse = await firstValueFrom(
+        this.http.get<Content>(
+          '/gateway/api/emoji/atlassian?scale=XHDPI&altScale=XXXHDPI&preferredRepresentation=IMAGE',
+        ),
+      );
+      const results = response.data?.emojis ?? [];
+      if (image) {
+        const imageData = results.find(({ id }) => id === image);
+        const { imagePath } = imageData.representation;
+        return imagePath;
+      }
+      return results;
+    } catch (err) {
+      // The /gateway/api/emoji endpoint is an internal Confluence frontend
+      // gateway and can reject the API token auth used elsewhere in this
+      // service; fail open so a page without special icons still renders.
+      this.logger.error(`error:getSpecialAtlassianIcons - ${this.getSafeErrorMessage(err)}`);
+      return image ? undefined : [];
     }
-    return results;
   }
 
   async getSpecialUploadedIcons(image?: string): Promise<any> {
-    const response: AxiosResponse = await firstValueFrom(
-      // Special custom emojis are uploaded to a specific collection per site, so we set it up
-      // via env variable emojiCollection
-      //
-      this.http.get<Content>(
-        `/gateway/api/emoji/${this.config.get('confluence.emojiCollection')}/site`
-        + '?scale=XHDPI&altScale=XXXHDPI&preferredRepresentation=IMAGE',
-      ),
-    );
-    // retrieve the custom uploaded emojis and image path
-    const results = response.data?.emojis ?? [];
-    // retrieve the metadata for retrieving the images from the media library, specially JWT token and client
-    const meta = response.data?.meta ?? {};
-    if (image) {
-      const imageData = results.find(({ id }) => id === image);
-      if (!imageData) return '';
-      const baseImagePath = imageData.representation.imagePath;
-      const imagePath = `${baseImagePath}&token=${meta.mediaApiToken.jwt}&client=${meta.mediaApiToken.clientId}`;
-      return imagePath;
+    try {
+      const response: AxiosResponse = await firstValueFrom(
+        // Special custom emojis are uploaded to a specific collection per site, so we set it up
+        // via env variable emojiCollection
+        //
+        this.http.get<Content>(
+          `/gateway/api/emoji/${this.config.get('confluence.emojiCollection')}/site`
+          + '?scale=XHDPI&altScale=XXXHDPI&preferredRepresentation=IMAGE',
+        ),
+      );
+      // retrieve the custom uploaded emojis and image path
+      const results = response.data?.emojis ?? [];
+      // retrieve the metadata for retrieving the images from the media library, specially JWT token and client
+      const meta = response.data?.meta ?? {};
+      if (image) {
+        const imageData = results.find(({ id }) => id === image);
+        if (!imageData) return '';
+        const baseImagePath = imageData.representation.imagePath;
+        const imagePath = `${baseImagePath}&token=${meta.mediaApiToken.jwt}&client=${meta.mediaApiToken.clientId}`;
+        return imagePath;
+      }
+      return response.data;
+    } catch (err) {
+      // Same rationale as getSpecialAtlassianIcons: fail open on auth/network
+      // errors from this gateway endpoint rather than crashing page render.
+      this.logger.error(`error:getSpecialUploadedIcons - ${this.getSafeErrorMessage(err)}`);
+      return image ? '' : { emojis: [], meta: {} };
     }
-    return response.data;
   }
 
   private async getSpacesAccountByPermissions(data) {


### PR DESCRIPTION
# Ticket
N/A — surfaced while investigating access to https://sanofi.atlassian.net/wiki/spaces/PLAT/pages/67200483712/Claude+Code+and+Claude+Cowork+-+AD+Groups

# Problem
Requesting a Confluence page proxy URl (e.g. `/cpv/wiki/spaces/:spaceKey/pages/67200483712`) for a page containing custom/site-uploaded emojis (⚠️ 📝 🤖 📒 💰 🚀 🔐 etc.) returned a generic, unstyled `500 Internal Server Error` instead of rendering the page. The page itself is valid, accessible, and unrestricted in Confluence — the failure was entirely in konviw's rendering pipeline.

# Root Cause Analysis
`ProxyPageService.renderPage()` → `fixEmojis` step calls `ConfluenceService.getSpecialAtlassianIcons()` and `getSpecialUploadedIcons()`, which hit Confluence's internal frontend-gateway endpoint `/gateway/api/emoji/{collection}/site`. Unlike every other Confluence call in `confluence.service.ts`, these two methods had **no error handling**.

That gateway endpoint returned `401 Unauthorized` — it behaves differently from the public `/wiki/api/v2/...` REST API and does not appear to accept the same Basic `email:API-token` auth used successfully everywhere else in the service (page content, labels, space data all fetched fine via `/wiki/api/v2/...`). Because the 401 was unhandled, it propagated as a raw exception past the app's error handling (`HttpExceptionFilter` only catches `HttpException`), and NestJS's default handler returned a generic 500 instead of konviw's normal styled error page.

This is structural, not intermittent: **any page with custom/uploaded emojis** hits this path and fails; pages without them render fine, which is why this had gone unnoticed.

# Solution
Wrapped `getSpecialAtlassianIcons()` and `getSpecialUploadedIcons()` in try/catch, matching the fail-safe pattern already used by every other method in `confluence.service.ts`. On failure they now log the error and fail open — returning `[]` / `{ emojis: [], meta: {} }` instead of throwing — so the page renders normally with emoji icons falling back to their text/unicode form instead of the fetched image.

# Proof
Verified locally against the real failing page:

| Before | After |
|--------|-------|
| `GET /cpv/wiki/spaces/konviw/pages/67200483712` → `500 {"statusCode":500,"message":"Internal server error"}` | `GET /cpv/wiki/spaces/konviw/pages/67200483712` → `200`, full page HTML rendered |

# Tasks
- [x] Clean code principles are respected
- [x] Logging is added
- [x] Error handling is added, to the right place, without hiding errors (still logged via `getSafeErrorMessage`)
- [ ] Documentation is updated (N/A — internal error-handling fix, no user-facing behavior/docs to update)
- [ ] List breaking changes (N/A — no breaking changes)
- [ ] Detailed information about new dependencies (N/A — no new dependencies)
- [ ] Dependencies consistently updated (N/A — no dependency changes)
- [x] All newly developed functionality is tested (existing `confluence.service.spec.ts` suite passes; manually verified fix against the real failing page)
- [ ] Unit tests check for both positive and negative cases (existing tests pass; **no new unit test was added for the failure path itself** — worth adding a case that mocks a rejected emoji-gateway call and asserts fail-open behavior)
- [ ] Unit tests that became obsolete have been removed (N/A)
- [ ] Referencing Pull Requests that need to be merged before/after (N/A — independent of #700)

# Documentation
N/A

# Project specific tasks
_None_